### PR TITLE
Add io and datasets modules

### DIFF
--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -1,0 +1,5 @@
+phasorpy.datasets
+-----------------
+
+.. automodule:: phasorpy.datasets
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -14,4 +14,6 @@ PhasorPy library version |version|.
 
     phasorpy
     color
+    datasets
+    io
     cli

--- a/docs/api/io.rst
+++ b/docs/api/io.rst
@@ -1,0 +1,5 @@
+phasorpy.io
+-----------
+
+.. automodule:: phasorpy.io
+    :members:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,7 +2,7 @@ Contributing
 ============
 
 As a community-maintained project, PhasorPy welcomes contributions in the form
-of bug reports, bug fixes, documentation, and enhancement proposals.
+of bug reports, bug fixes, datasets, documentation, and enhancement proposals.
 This document provides information on how to contribute.
 
 The :doc:`code_of_conduct` should be honored by everyone participating in the
@@ -19,6 +19,14 @@ Propose enhancements
 
 To suggest a new feature or other improvement to the PhasorPy library, open a
 `GitHub issue <https://github.com/phasorpy/phasorpy/issues>`_.
+
+Share data files
+----------------
+
+The PhasorPy project strives to support reading image and metadata from many
+time-resolved and hyperspectral file formats used in bio-imaging.
+Consider sharing datasets for testing and use in tutorials, preferably with the
+`PhasorPy community on Zenodo <https://zenodo.org/communities/phasorpy/>`_.
 
 Report bugs
 -----------
@@ -164,7 +172,7 @@ Run the unit tests and doctests in the development environment::
 
 All tests must pass.
 
-PhasorPy strives to maintain near 100% test coverage. The coverage report
+PhasorPy strives to maintain near complete test coverage. The coverage report
 is automatically generated during testing.
 
 Configuration settings for pytest and other tools are in the

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -187,7 +187,7 @@ standard and be formatted with
 `black <https://black.readthedocs.io/en/stable/>`_
 (single quotes and lines up to 79 characters are allowed)::
 
-    python -m black --check phasorpy tutorials
+    python -m black --check src/phasorpy tutorials tests
 
 User-facing classes and functions must use
 `type hints <https://peps.python.org/pep-0484/>`_
@@ -200,14 +200,14 @@ static type checker::
 Import statements must be sorted and sectioned using
 `isort <https://pycqa.github.io/isort/>`_::
 
-    $ python -m isort src/phasorpy tutorials
+    $ python -m isort src/phasorpy tutorials tests
 
 Check for common misspellings in text files::
 
     $ python -m codespell_lib
 
 The PhasorPy project follows numpy's
-`NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`
+`NEP 29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`_
 for Python and NumPy version support.
 However, the initial requirements are Python 3.10+ and numpy 1.23+.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,6 +7,11 @@ Welcome to the documentation of PhasorPy version |version|.
 PhasorPy is an open-source Python library for the analysis of fluorescence
 lifetime and hyperspectral images using the :doc:`phasor_approach`.
 
+.. note::
+    The PhasorPy library is in its early stages of development.
+    It is not nearly feature complete.
+    Large, backwards-incompatible changes may occur between revisions.
+
 Quickstart
 ==========
 
@@ -29,13 +34,16 @@ The :doc:`code_of_conduct` should be honored by everyone participating in
 the PhasorPy community.
 
 The library's source code and documentation are maintained in the
-`PhasorPy repository <https://github.com/phasorpy/phasorpy>`_ on GitHub.
+`PhasorPy repository on GitHub <https://github.com/phasorpy/phasorpy>`_.
 
-Please report issues with the code or documentation on the GitHub
-`issue tracker <https://github.com/phasorpy/phasorpy/issues>`_.
+Sample data files used in tutorials and testing are available from the
+`PhasorPy community on Zenodo <https://zenodo.org/communities/phasorpy>`_.
 
-Questions about the usage of the PhasorPy library are answered on the GitHub
-`issue tracker <https://github.com/phasorpy/phasorpy/issues>`_.
+Please report issues with the code or documentation on the
+`issue tracker on GitHub <https://github.com/phasorpy/phasorpy/issues>`_.
+
+Questions about the usage of the PhasorPy library are answered on the
+`issue tracker on GitHub <https://github.com/phasorpy/phasorpy/issues>`_.
 
 The :doc:`acknowledgments` list individuals and organizations that
 contributed to the development of PhasorPy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "numpy",
     "matplotlib",
     "click",
+    "pooch",
+    "xarray",
+    "tifffile",
     # "scipy",
     # "scikit-image",
     # "scikit-learn",
@@ -36,7 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-authors = [{ name = "PhasorPy Contributors"},]
+authors = [{ name = "PhasorPy Contributors" }]
 license = { text = "MIT" }
 
 [project.urls]
@@ -64,21 +67,16 @@ test = [
     "pytest-doctestplus",
     "coverage",
 ]
-io = [
-    "aicsimageio",
-    "tifffile",
-    "lfdfiles",
-    "sdtfile",
-]
+io = ["lfdfiles", "sdtfile"]
 
 [tool.setuptools]
-package-dir = {"" = "src"}
+package-dir = { "" = "src" }
 packages = ["phasorpy"]
 license-files = ["LICENSE.txt"]
 zip-safe = false
 
 [tool.setuptools.dynamic]
-version = {attr = "phasorpy.version.__version__"}
+version = { attr = "phasorpy.version.__version__" }
 
 [tool.setuptools.package-data]
 phasorpy = ["py.typed"]
@@ -86,6 +84,21 @@ phasorpy = ["py.typed"]
 [tool.pylint.format]
 max-line-length = 79
 max-module-lines = 2500
+good-names = [
+    "i",
+    "j",
+    "k",
+    "x",
+    "y",
+    "z",
+    "c",
+    "t",
+    "ax",
+    "fh",
+    "dc",
+    "re",
+    "im",
+]
 
 [tool.pylint.messages_control]
 disable = [
@@ -104,7 +117,7 @@ profile = "black"
 line_length = 79
 
 [tool.codespell]
-skip = "*.html,*.css,*.js,*.map,./.git,./docs/_build,./docs/tutorials,PKG-INFO,_htmlcov,pyproject.toml"
+skip = "*.html,*.css,*.js,*.map,./.git,./data,./docs/_build,./docs/tutorials,PKG-INFO,_htmlcov,pyproject.toml"
 ignore-words-list = "ba,compiletime,hist,nd,unparseable,HSI"
 
 [tool.mypy]
@@ -114,10 +127,7 @@ packages = ["phasorpy"]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 
 [tool.coverage.report]
-exclude_lines = [
-    "pragma: no cover",
-    "pragma: ${PY_MAJOR_VERSION} no cover",
-]
+exclude_lines = ["pragma: no cover", "pragma: ${PY_MAJOR_VERSION} no cover"]
 
 [tool.coverage.html]
 directory = "_htmlcov"
@@ -129,11 +139,7 @@ doctest_optionflags = [
     "ELLIPSIS",
     "IGNORE_EXCEPTION_DETAIL",
 ]
-testpaths = [
-    "src/phasorpy",
-    "tests",
-    "docs",
-]
+testpaths = ["src/phasorpy", "tests", "docs"]
 norecursedirs = [
     "._",
     ".git",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,9 @@ numpy >= 1.25; python_version > "3.10"
 # runtime requirements
 matplotlib
 click
+pooch
+xarray
+tifffile
 #
 # build requirements
 setuptools
@@ -43,7 +46,6 @@ isort
 mypy
 codespell
 # pre-commit
-# pooch
 #
 # optional requirements
 # aicsimageio
@@ -51,8 +53,7 @@ codespell
 # scikit-image
 # scikit-learn
 # pandas
-# xarray
 # zarr
 # fsspec
-# lfdfiles
-# sdtfile
+lfdfiles
+sdtfile

--- a/src/phasorpy/_typing.py
+++ b/src/phasorpy/_typing.py
@@ -42,3 +42,4 @@ from typing import (
 )
 
 from numpy.typing import ArrayLike, DTypeLike, NDArray
+from xarray import DataArray

--- a/src/phasorpy/conftest.py
+++ b/src/phasorpy/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest configuration."""
+
+import pytest
+
+from .datasets import fetch
+
+
+@pytest.fixture(autouse=True)
+def add_fetch(doctest_namespace):
+    """Add datasets.fetch to doctest namespace."""
+    doctest_namespace['fetch'] = fetch

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -191,7 +191,7 @@ def fetch(
 
     Returns
     -------
-    full_path : str
+    str
         Absolute path of file in local storage.
 
     Examples

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 __all__ = ['fetch']
 
+import os
 from typing import Any
 
 import pooch
@@ -224,10 +225,10 @@ class _Unzip(pooch.processors.ExtractorProcessor):
     """Pooch processor that unpacks ZIP archive and returns single file."""
 
     def __call__(self, fname, action, pooch_):
-        filenames = pooch.processors.ExtractorProcessor.__call__(
+        pooch.processors.ExtractorProcessor.__call__(
             self, fname, action, pooch_
         )
-        return filenames[0]
+        return os.path.splitext(fname)[0]
 
     def _extract_file(self, fname, extract_dir):
         """Extract all files from ZIP archive."""

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -1,0 +1,237 @@
+"""Manage sample data files for testing and tutorials.
+
+The ``phasorpy.datasets`` module provides a :py:func:`fetch` function to
+download data files from remote repositories.
+The downloaded files are cached in a local directory.
+
+The implementation is based on the `Pooch <https://www.fatiando.org/pooch>`_
+library.
+
+"""
+
+from __future__ import annotations
+
+__all__ = ['fetch']
+
+from typing import Any
+
+import pooch
+
+TESTS = pooch.create(
+    path=pooch.os_cache('phasorpy'),
+    base_url='doi:10.5281/zenodo.8417894',
+    registry={
+        'flimage.int.bin': (
+            'sha256:'
+            '5d470ed31ed0611b43270261341bc1c41f55fda665eaf529d848a139fcae5fc8'
+        ),
+        'flimage.int.bin.zip': (
+            'sha256:'
+            '51062322891b4c22d577100395d8c02297c5494030d2c550a0fd6c90f73cc211'
+        ),
+        'flimage.mod.bin': (
+            'sha256:'
+            'b0312f6f9f1f24e228b2c3a3cb07e18d80b35f31109f8c771b088b54419c5200'
+        ),
+        'flimage.phi.bin': (
+            'sha256:'
+            'd593acc698a1226c7a4571fa61f6751128584dcca6ed4449d655283cd231b125'
+        ),
+        'flimfast.flif': (
+            'sha256:'
+            'b12cedf299831a46baf80dcfe7bfb9f366fee30fb3e2b3039d4346f1bbaf3e2c'
+        ),
+        'flimfast.flif.zip': (
+            'sha256:'
+            'b25642b1a2dbc547f0cdaadc13ce89ecaf372f90a20978910c02b13beb138c2e'
+        ),
+        'frequency_domain.ifli': (
+            'sha256:'
+            '56015b98a2edaf4ee1262b5e1034305aa29dd8b20e301ced9cd7a109783cd171'
+        ),
+        'frequency_domain.ifli.zip': (
+            'sha256:'
+            '93066cc48028360582f6e3380d09d2c5a6f540a8f931639da3cfca158926df9b'
+        ),
+        'paramecium.lsm': (
+            'sha256:'
+            'b3b3b80be244a41352c56390191a50e4010d52e5ca341dc51bd1d7c89f10cedf'
+        ),
+        'paramecium.lsm.zip': (
+            'sha256:'
+            '7828a80e878ee7ab88f9bd9a6cda72e5d698394d37f69a7bee5b0b31b3856919'
+        ),
+        'simfcs.b64': (
+            'sha256:'
+            '5ccccd0bcd46c66ea174b6074975f631bdf163fcb047e35f9310aaf67c320fb8'
+        ),
+        'simfcs.b64.zip': (
+            'sha256:'
+            'b176761905fc5916d0770bd6baaa0e31af5981f92ec323e588f9ce398324818e'
+        ),
+        'simfcs.b&h': (
+            'sha256:'
+            '6a406c4fd862318a51370461c7607390f022afdcb2ce27c4600df4b5af83c26e'
+        ),
+        'simfcs.b&h.zip': (
+            'sha256:'
+            'ec14666be76bd5bf2dcaee63435332857795173c8dc94be8778697f32b041aa1'
+        ),
+        'simfcs.bhz': (
+            'sha256:'
+            '14f8b5287e257514945ca17a8398425fc040c00bfad2d8a3c6adb4790862d211'
+        ),
+        'simfcs.r64': (
+            'sha256:'
+            'ead3b2df45c1dff91e91a325f97225f4837c372db04c2e49437ee9ec68532946'
+        ),
+        'simfcs.ref': (
+            'sha256:'
+            '697dad17fb3a3cf7329a45b43ba9ae5f7220c1f3d5f08749f2ce3eadb0598420'
+        ),
+        'simfcs.ref.zip': (
+            'sha256:'
+            '482331ec5586973e9eb5c2e4f793d9621cc756ce8f4093f5e21906a7ce5726f8'
+        ),
+        'simfcs.z64': (
+            'sha256:'
+            'f1dd861f80528c77bb581023c05c7bf7293d6ad3c4a3d10f9a50b8b5618a8099'
+        ),
+        'simfcs_1000.int': (
+            'sha256:'
+            'bb5bde0ecf24243865cdbc2b065358fe8c557696de18567dbb3f75adfb2ab51a'
+        ),
+        'simfcs_1000.int.zip': (
+            'sha256:'
+            'f75e211dc344f194a871f0b3af3f6d8a9e4850e9718526f2bfad87ef16c1c377'
+        ),
+        'simfcs_1000.mod': (
+            'sha256:'
+            '84265df08d48ff56f6844d55392fccac9fa429c481d1ac81b07c23738075d336'
+        ),
+        'simfcs_1000.phs': (
+            'sha256:'
+            '8a39d2abd3999ab73c34db2476849cddf303ce389b35826850f9a700589b4a90'
+        ),
+        'tcspc.sdt': (
+            'sha256:'
+            '0ff0b25b36cb9a7657112a3b081ff479bcae487ce8100b8756e5780e0957708d'
+        ),
+        'tcspc.sdt.zip': (
+            'sha256:'
+            '57a772bc413e85e0f13eb996f8c2484dfb3d15df67ffa6c3b968d3a03c27fdc3'
+        ),
+    },
+)
+
+LFD_WORKSHOP = pooch.create(
+    path=pooch.os_cache('phasorpy'),
+    base_url='doi:10.5281/zenodo.8411056',
+    registry={
+        '4-22-03-2-A5-CHO-CELL3B.tif': (
+            'sha256:'
+            '015d4b5a4cbb6cc40ac0c39f7a0b57ff31173df5b3112627b551e4d8ce8c3b02'
+        ),
+        '1011rac1002.ref': (
+            'sha256:'
+            'b8eb374d21ba74519342187aa0b6f67727983c1e9d02a9b86bde7e323f5545ac'
+        ),
+        'CFP and CFP-YFp.ref': (
+            'sha256:'
+            'f4f494d5e71836aeacfa8796dcf9b92bbc0f62b8176d6c10d5ab9ce202313257'
+        ),
+        'CFP-YFP many cells with background.ref': (
+            'sha256:'
+            '7cb88018be807144edbb2746d0ec6548eeb3ddc4aa176f3fba4223990aa21754'
+        ),
+        'CFPpax8651866.ref': (
+            'sha256:'
+            'eda9177f2841229d120782862779e2db295ad773910b308bc2c360c22c75f391'
+        ),
+        'Paxillins013.bin': (
+            'sha256:'
+            'b979e3112dda2fa1cc34a351dab7b0c82009ef07eaa34829503fb79f7a6bb7d2'
+        ),
+        'capillaries1001.ref': (
+            'sha256:'
+            '27f071ae31032ed4e79c365bb2076044876f7fc10ef622aff458945f33e60984'
+        ),
+        'pax1023.bin': (
+            'sha256:'
+            'f467e8264bb10fc12a19506693837f384e32ca01c0cac0b25704c19ceb8d7d5a'
+        ),
+    },
+)
+
+REPOSITORIES: tuple[pooch.Pooch, ...] = (TESTS, LFD_WORKSHOP)
+"""Pooch repositories."""
+
+
+def fetch(
+    filename: str,
+    /,
+    *,
+    extract_dir: str | None = '.',
+    **kwargs: Any,
+) -> str:
+    """Return absolute path to sample file in local storage.
+
+    The file is downloaded from a remote repository if the file does not
+    already exist in the local storage.
+
+    Parameters
+    ----------
+    filename : str
+        Name of file to fetch from local storage.
+    extract_dir : str or None, optional
+        Path, relative to cache location, where ZIP files will be unpacked.
+    **kwargs : optional
+        Additional parameters passed to ``pooch.fetch()``.
+
+    Returns
+    -------
+    full_path : str
+        Absolute path of file in local storage.
+
+    Examples
+    --------
+    >>> fetch('simfcs.r64')
+    '...simfcs.r64'
+
+    """
+    for repo in REPOSITORIES:
+        if filename + '.zip' in repo.registry:
+            # download and extract ZIP, return file name
+            return repo.fetch(
+                filename + '.zip',
+                processor=_Unzip([filename], extract_dir),
+                **kwargs,
+            )
+        if filename in repo.registry:
+            if filename.endswith('.zip'):
+                # download and extract ZIP, return all file names in ZIP
+                return repo.fetch(
+                    filename,
+                    processor=pooch.processors.Unzip(extract_dir=extract_dir),
+                    **kwargs,
+                )
+            # download file, return file name
+            return repo.fetch(filename, **kwargs)
+    raise ValueError('file not found')
+
+
+class _Unzip(pooch.processors.ExtractorProcessor):
+    """Pooch processor that unpacks ZIP archive and returns single file."""
+
+    def __call__(self, fname, action, pooch_):
+        filenames = pooch.processors.ExtractorProcessor.__call__(
+            self, fname, action, pooch_
+        )
+        return filenames[0]
+
+    def _extract_file(self, fname, extract_dir):
+        """Extract all files from ZIP archive."""
+        from zipfile import ZipFile
+
+        with ZipFile(fname, 'r') as zip_file:
+            zip_file.extractall(path=extract_dir)

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -165,13 +165,16 @@ def write_ometiff_phasor(
         Refer to the OME model for allowed axes and their order.
     bigtiff : bool, optional
         Write BigTIFF file, which can exceed 4 GB.
-    **kwargs : optional
+    **kwargs : dict, optional
         Additional parameters passed to ``tifffile.TiffWriter.write``,
         for example ``compression``.
 
     Examples
     --------
-    >>> write_ometiff_phasor('_phasor.ome.tif', [[1]], [[0.5]], [[0.5]])
+    >>> dc, re, im = numpy.random.rand(3, 32, 32, 32)
+    >>> write_ometiff_phasor(
+    ...     '_phasor.ome.tif', dc, re, im, axes='ZYX', compression='zlib'
+    ... )
 
     """
     import tifffile
@@ -220,14 +223,14 @@ def read_ometiff_phasor(
 
     Examples
     --------
-    >>> write_ometiff_phasor('_phasor.ome.tif', [[1]], [[0.5]], [[0.5]])
+    >>> write_ometiff_phasor('_phasor.ome.tif', *numpy.random.rand(3, 32, 32))
     >>> dc, re, im = read_ometiff_phasor('_phasor.ome.tif')
     >>> dc.data
     array(...)
     >>> dc.dtype
     dtype('float32')
     >>> dc.shape
-    (1, 1)
+    (32, 32)
     >>> dc.dims
     ('Y', 'X')
 
@@ -271,7 +274,7 @@ def read_lsm(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Hyperspectral image data.
         Usually, a 3 to 5 dimensional array of type ``uint8`` or ``uint16``.
 
@@ -359,6 +362,7 @@ def read_ifli(
     filename: str | PathLike[Any],
     /,
     channel: int = 0,
+    **kwargs: Any,
 ) -> DataArray:
     """Return image and metadata from ISS IFLI file.
 
@@ -372,10 +376,13 @@ def read_ifli(
         Name of ISS IFLI file to read.
     channel : int, optional
         Index of channel to return. The first channel is returned by default.
+    **kwargs : dict, optional
+        Additional parameters passed to ``lfdfiles.VistaIfli.asarray``,
+        for example ``memmap=True``.
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Average intensity and phasor coordinates.
         An array of up to 8 dimensions and type ``float32``.
         The last dimension contains `dc`, `re`, and `im` phasor coordinates.
@@ -415,7 +422,7 @@ def read_ifli(
 
     with lfdfiles.VistaIfli(filename) as ifli:
         assert ifli.axes is not None
-        data = ifli.asarray()[:, channel : channel + 1]
+        data = ifli.asarray(**kwargs)[:, channel : channel + 1]
         shape, axes, _ = _squeeze_axes(data.shape, ifli.axes, skip='FYX')
         data = data.reshape(shape)
         header = ifli.header
@@ -464,7 +471,7 @@ def read_sdt(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Time correlated single photon counting image data
         of type ``uint16``, ``uint32``, or ``float32``.
 
@@ -532,7 +539,7 @@ def read_ref(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Referenced fluorescence lifetime polar coordinates.
         An array of 5 (rarely more) 256x256 images of type ``float32``:
 
@@ -589,7 +596,7 @@ def read_r64(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Referenced fluorescence lifetime polar coordinates.
         An array of 5 (rarely more) 256x256 images of type ``float32``:
 
@@ -648,7 +655,7 @@ def read_b64(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Stack of square-sized intensity images of type ``int16``.
 
     Raises
@@ -703,7 +710,7 @@ def read_z64(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Single or stack of square-sized images of type ``float32``.
 
     Raises
@@ -749,7 +756,7 @@ def read_bh(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Time-domain fluorescence lifetime histogram of shape
         ``(256, 256, 256)`` and type ``float32``.
 
@@ -797,7 +804,7 @@ def read_bhz(
 
     Returns
     -------
-    data : xarray.DataArray
+    xarray.DataArray
         Time-domain fluorescence lifetime histogram of shape
         ``(256, 256, 256)`` and type ``float32``.
 

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -1,0 +1,911 @@
+"""Read and write time-resolved and hyperspectral image file formats.
+
+The ``phasorpy.io`` module provides functions to
+
+- read time-resolved and hyperspectral image data and metadata from many
+  file formats used in bio-imaging.
+- write phasor coordinate images to OME-TIFF files for import in ImageJ
+  or Bio-Formats.
+
+These file formats are currently supported:
+
+- Zeiss LSM: :py:func:`read_lsm`
+- ISS IFLI: :py:func:`read_ifli`
+- Becker & Hickl SDT: :py:func:`read_sdt`
+- SimFCS REF: :py:func:`read_ref`
+- SimFCS R64: :py:func:`read_r64`
+- SimFCS B64: :py:func:`read_b64`
+- SimFCS Z64: :py:func:`read_z64`
+- SimFCS BHZ: :py:func:`read_bhz`
+- SimFCS B&H: :py:func:`read_bh`
+
+Support for other file formats is being considered:
+
+- OME-TIFF
+- Zeiss CZI
+- PicoQuant PTU
+- Leica LIF
+- Nikon ND2
+- Olympus OIB/OIF
+- Olympus OIR
+- FLIMbox FBD
+- FlimFast FLIF
+
+The functions are implemented as minimal wrappers around specialized
+third-party file reader libraries, currently
+`tifffile <https://github.com/cgohlke/tifffile>`_,
+`sdtfile <https://github.com/cgohlke/sdtfile>`_, and
+`lfdfiles <https://github.com/cgohlke/lfdfiles>`_.
+
+The read functions typically have the following signature::
+
+    read_ext(
+        filename: str | PathLike,
+        /,
+        **kwargs
+    ): -> xarray.DataArray
+
+where ``ext`` indicates the file format and ``kwargs`` are optional arguments
+passed to the underlying file reader library or used to select which data is
+returned. The returned `xarray.DataArray
+<https://docs.xarray.dev/en/stable/user-guide/data-structures.html>`_
+contains a n-dimensional array with labeled coordinates, dimensions, and
+attributes:
+
+- ``data`` or ``values`` (*array_like*)
+
+  Numpy array or array-like holding the array's values.
+
+- ``dims`` (*tuple of str*)
+
+  :ref:`Axes character codes <axes>` for each dimension in ``data``.
+  For example, ``('T', 'C', 'Y', 'X')`` defines the dimension order in a
+  4-dimensional array of a time-series of multi-channel images.
+
+- ``coords`` (*dict_like[str, array_like]*)
+
+  Coordinate arrays labelling each point in the data array.
+  The keys are :ref:`axes character codes <axes>`.
+  Values are 1-dimensional arrays of numbers or strings.
+  For example, ``coords['C']`` could be an array of emission wavelengths.
+
+- ``attrs`` (*dict[str, Any]*)
+
+  Arbitrary metadata such as measurement or calibration parameters required to
+  interpret the data values.
+  For example, the laser repetition frequency of a time-resolved measurement.
+
+.. _axes:
+
+Axes character codes from the OME model and tifffile library are used as
+``dims`` items and ``coords`` keys:
+
+- ``'X'`` : width (OME)
+- ``'Y'`` : height (OME)
+- ``'Z'`` : depth (OME)
+- ``'S'`` : sample (color components or phasor coordinates)
+- ``'I'`` : sequence (of images, frames, or planes)
+- ``'T'`` : time  (OME)
+- ``'C'`` : channel (OME. Acquisition path or emission wavelength)
+- ``'A'`` : angle (OME)
+- ``'P'`` : phase (OME. In LSM, ``'P'`` maps to position)
+- ``'R'`` : tile (OME. Region, position, or mosaic)
+- ``'H'`` : lifetime histogram (OME)
+- ``'E'`` : lambda (OME. Excitation wavelength)
+- ``'F'`` : frequency (ISS)
+- ``'Q'`` : other (OME)
+- ``'L'`` : exposure (FluoView)
+- ``'V'`` : event (FluoView)
+- ``'M'`` : mosaic (LSM 6)
+- ``'J'`` : column (NDTiff)
+- ``'K'`` : row (NDTiff)
+
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    'read_b64',
+    'read_bh',
+    'read_bhz',
+    # 'read_czi',
+    # 'read_fbd',
+    # 'read_flif',
+    'read_ifli',
+    # 'read_lif',
+    'read_lsm',
+    # 'read_nd2',
+    # 'read_oif',
+    # 'read_oir',
+    # 'read_ometiff',
+    'read_ometiff_phasor',
+    # 'read_ptu',
+    'read_r64',
+    'read_ref',
+    'read_sdt',
+    'read_z64',
+    'write_ometiff_phasor',
+]
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._typing import Any, ArrayLike, PathLike, Sequence
+
+import numpy
+from xarray import DataArray
+
+
+def write_ometiff_phasor(
+    filename: str | PathLike[Any],
+    dc: ArrayLike,
+    re: ArrayLike,
+    im: ArrayLike,
+    /,
+    *,
+    axes: str | None = None,
+    bigtiff: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Write phasor images and metadata to OME-TIFF file.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of OME-TIFF file to write.
+    dc : array_like
+        Average intensity image.
+    re : array_like
+        Image of real component of phasor coordinates.
+    im : array_like
+        Image of imaginary component of phasor coordinates.
+    axes : str, optional
+        Character codes for image array dimensions, for example 'TCYX'.
+        Refer to the OME model for allowed axes and their order.
+    bigtiff : bool, optional
+        Write BigTIFF file, which can exceed 4 GB.
+    **kwargs : optional
+        Additional parameters passed to ``tifffile.TiffWriter.write``,
+        for example ``compression``.
+
+    Examples
+    --------
+    >>> write_ometiff_phasor('_phasor.ome.tif', [[1]], [[0.5]], [[0.5]])
+
+    """
+    import tifffile
+
+    from .version import __version__
+
+    metadata = kwargs.pop('metadata', {})
+    metadata['Creator'] = f'phasorpy {__version__}'
+    if axes is not None:
+        metadata['axes'] = ''.join(tuple(axes))  # accepts dims tuple and str
+    if 'photometric' not in kwargs:
+        kwargs['photometric'] = 'minisblack'
+
+    with tifffile.TiffWriter(filename, ome=True, bigtiff=bigtiff) as tif:
+        for name, data in zip(['DC', 'RE', 'IM'], [dc, re, im]):
+            metadata['Name'] = 'Phasor ' + name
+            tif.write(
+                numpy.asarray(data, numpy.float32), metadata=metadata, **kwargs
+            )
+
+
+def read_ometiff_phasor(
+    filename: str | PathLike[Any],
+    /,
+) -> tuple[DataArray, DataArray, DataArray]:
+    """Return phasor images and metadata from OME-TIFF written by PhasorPy.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of OME-TIFF file to read.
+
+    Returns
+    -------
+    dc : xarray.DataArray
+        Average intensity image.
+    re : xarray.DataArray
+        Image of real component of phasor coordinates.
+    im : xarray.DataArray
+        Image of imaginary component of phasor coordinates.
+
+    Raises
+    ------
+    ValueError
+        File is not an OME-TIFF file written by PhasorPy.
+
+    Examples
+    --------
+    >>> write_ometiff_phasor('_phasor.ome.tif', [[1]], [[0.5]], [[0.5]])
+    >>> dc, re, im = read_ometiff_phasor('_phasor.ome.tif')
+    >>> dc.data
+    array(...)
+    >>> dc.dtype
+    dtype('float32')
+    >>> dc.shape
+    (1, 1)
+    >>> dc.dims
+    ('Y', 'X')
+
+    """
+    import tifffile
+
+    with tifffile.TiffFile(filename) as tif:
+        if (
+            not tif.is_ome
+            or len(tif.series) != 3
+            or tif.series[0].name != 'Phasor DC'
+            or tif.series[0].shape != tif.series[1].shape
+            or tif.series[0].shape != tif.series[2].shape
+        ):
+            raise ValueError(
+                f'{os.path.basename(filename)!r} '
+                'is not an OME-TIFF containing phasor images'
+            )
+        # TODO: read coords from OME-XML
+        name = os.path.basename(filename)
+        metadata = _metadata(tif.series[0].axes, tif.series[0].shape)
+        dc = DataArray(tif.series[0].asarray(), name='DC_' + name, **metadata)
+        re = DataArray(tif.series[1].asarray(), name='RE_' + name, **metadata)
+        im = DataArray(tif.series[2].asarray(), name='IM_' + name, **metadata)
+    return dc, re, im
+
+
+def read_lsm(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return hyperspectral image and metadata from Zeiss LSM file.
+
+    LSM files contain multi-dimensional image and metadata from laser
+    scanning microscopy measurements. The file format is based on TIFF.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of OME-TIFF file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Hyperspectral image data.
+        Usually, a 3 to 5 dimensional array of type ``uint8`` or ``uint16``.
+
+    Raises
+    ------
+    tifffile.TiffFileError
+        File is not a TIFF file.
+    ValueError
+        File is not an LSM file or does not contain hyperspectral image.
+
+    Examples
+    --------
+    >>> data = read_lsm(fetch('paramecium.lsm'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('uint8')
+    >>> data.shape
+    (30, 512, 512)
+    >>> data.dims
+    ('C', 'Y', 'X')
+    >>> data.coords['C'].data  # wavelengths
+    array(...)
+
+    """
+    import tifffile
+
+    with tifffile.TiffFile(filename) as tif:
+        if not tif.is_lsm:
+            raise ValueError(f'{tif.filename} is not an LSM file')
+
+        page = tif.pages.first
+        lsminfo = tif.lsm_metadata
+        channels = page.tags[258].count
+
+        if channels < 4 or lsminfo is None or lsminfo['SpectralScan'] != 1:
+            raise ValueError(
+                f'{tif.filename} does not contain hyperspectral image'
+            )
+
+        # TODO: contribute this to tifffile
+        series = tif.series[0]
+        data = series.asarray()
+        dims = tuple(series.axes)
+        coords = {}
+        # channel wavelengths
+        axis = dims.index('C')
+        wavelengths = lsminfo['ChannelWavelength'].mean(axis=1)
+        if wavelengths.size != data.shape[axis]:
+            raise ValueError(
+                f'{tif.filename} wavelengths do not match channel axis'
+            )
+        # stack may contain non-wavelength frame
+        indices = wavelengths > 0
+        wavelengths = wavelengths[indices]
+        if wavelengths.size < 3:
+            raise ValueError(
+                f'{tif.filename} does not contain hyperspectral image'
+            )
+        data = data.take(indices.nonzero()[0], axis=axis)
+        coords['C'] = wavelengths
+        # time stamps
+        if 'T' in dims:
+            coords['T'] = lsminfo['TimeStamps']
+            if coords['T'].size != data.shape[dims.index('T')]:
+                raise ValueError(
+                    f'{tif.filename} timestamps do not match time axis'
+                )
+        # spatial coordinates
+        for ax in 'ZYX':
+            if ax in dims:
+                size = data.shape[dims.index(ax)]
+                coords[ax] = numpy.linspace(
+                    lsminfo[f'Origin{ax}'],
+                    size * lsminfo[f'VoxelSize{ax}'],
+                    size,
+                    endpoint=False,
+                    dtype=numpy.float64,
+                )
+        metadata = _metadata(series.axes, data.shape, filename, **coords)
+    return DataArray(data, **metadata)
+
+
+def read_ifli(
+    filename: str | PathLike[Any],
+    /,
+    channel: int = 0,
+) -> DataArray:
+    """Return image and metadata from ISS IFLI file.
+
+    ISS VistaVision IFLI files contain phasor coordinates for several
+    positions, wavelengths, time points, channels, slices, and frequencies
+    from analog or digital frequency-domain fluorescence lifetime measurements.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of ISS IFLI file to read.
+    channel : int, optional
+        Index of channel to return. The first channel is returned by default.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Average intensity and phasor coordinates.
+        An array of up to 8 dimensions and type ``float32``.
+        The last dimension contains `dc`, `re`, and `im` phasor coordinates.
+
+        - ``coords['F']``: modulation frequencies.
+        - ``coords['C']``: emission wavelengths, if any.
+        - ``attrs['ref_tau']``: reference lifetimes.
+        - ``attrs['ref_tau_frac']``: reference lifetime fractions.
+        - ``attrs['ref_phasor']``: reference phasor coordinates for all
+          frequencies.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not an ISS IFLI file.
+
+    Examples
+    --------
+    >>> data = read_ifli(fetch('frequency_domain.ifli'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (256, 256, 4, 3)
+    >>> data.dims
+    ('Y', 'X', 'F', 'S')
+    >>> data.coords['F'].data
+    array([8.033...])
+    >>> data.coords['S'].data
+    array(['dc', 're', 'im'], dtype='<U2')
+    >>> data.attrs
+    {'ref_tau': (2.5, 0.0), 'ref_tau_frac': (1.0, 0.0), 'ref_phasor': array...}
+
+    """
+    import lfdfiles
+
+    with lfdfiles.VistaIfli(filename) as ifli:
+        assert ifli.axes is not None
+        data = ifli.asarray()[:, channel : channel + 1]
+        shape, axes, _ = _squeeze_axes(data.shape, ifli.axes, skip='FYX')
+        data = data.reshape(shape)
+        header = ifli.header
+        coords: dict[str, Any] = {}
+        coords['S'] = ['dc', 're', 'im']
+        coords['F'] = numpy.array(header['ModFrequency'])
+        # TODO: how to distinguish time- from frequency-domain?
+        # TODO: how extract spatial coordinates?
+        if 'T' in axes:
+            coords['T'] = numpy.array(header['TimeTags'])
+        if 'E' in axes:
+            coords['E'] = numpy.array(header['SpectrumInfo'])
+        # if 'Z' in axes:
+        #     coords['Z'] = numpy.array(header[])
+        metadata = _metadata(axes, shape, filename, **coords)
+        attrs = metadata['attrs']
+        attrs['ref_tau'] = (
+            header['RefLifetime'][channel],
+            header['RefLifetime2'][channel],
+        )
+        attrs['ref_tau_frac'] = (
+            header['RefLifetimeFrac'][channel],
+            1.0 - header['RefLifetimeFrac'][channel],
+        )
+        attrs['ref_phasor'] = numpy.array(header['RefDCPhasor'][channel])
+    return DataArray(data, **metadata)
+
+
+def read_sdt(
+    filename: str | PathLike[Any],
+    /,
+    *,
+    index: int = 0,
+) -> DataArray:
+    """Return time-resolved image and metadata from Becker & Hickl SDT file.
+
+    SDT files contain time correlated single photon counting measurement data
+    and instrumentation parameters.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SDT file to read.
+    index : int
+        Index of dataset to read in case the file contains multiple datasets.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Time correlated single photon counting image data
+        of type ``uint16``, ``uint32``, or ``float32``.
+
+        - ``coords['H']``: times of the histogram bins.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+
+    Raises
+    ------
+    ValueError
+        File is not a SDT file or is not a "SPC Setup & Data File" containing
+        time correlated single photon counting data.
+
+    Examples
+    --------
+    >>> data = read_sdt(fetch('tcspc.sdt'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('uint16')
+    >>> data.shape
+    (128, 128, 256)
+    >>> data.dims
+    ('Y', 'X', 'H')
+    >>> data.coords['H'].data
+    array(...)
+    >>> data.attrs['frequency']
+    79...
+
+    """
+    import sdtfile
+
+    with sdtfile.SdtFile(filename) as sdt:
+        if 'SPC Setup & Data File' not in sdt.info.id:
+            # skip FCS and DLL data
+            raise ValueError(
+                f'{os.path.basename(filename)!r} '
+                'is not a SDT "SPC Setup & Data File"'
+            )
+        # filter block types?
+        # sdtfile.BlockType(sdt.block_headers[index].block_type).contents
+        # == 'PAGE_BLOCK'
+        data = sdt.data[index]
+        times = sdt.times[index]
+
+    # TODO: get spatial coordinates from scanner settings?
+    metadata = _metadata('QYXH'[-data.ndim :], data.shape, filename, H=times)
+    metadata['attrs']['frequency'] = 1e-6 / (times[-1] + times[1])
+    return DataArray(data, **metadata)
+
+
+def read_ref(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return referenced lifetime data and metadata from SimFCS REF file.
+
+    REF files contain referenced fluorescence lifetime image data:
+    an average intensity image and lifetime polar coordinates for two
+    harmonics. REF files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS REF file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Referenced fluorescence lifetime polar coordinates.
+        An array of 5 (rarely more) 256x256 images of type ``float32``:
+
+        0. average intensity
+        1. phase of 1st harmonic in degrees
+        2. modulation of 1st harmonic normalized
+        3. phase of 2nd harmonic in degrees
+        4. modulation of 2nd harmonic normalized
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS REF file.
+
+    Examples
+    --------
+    >>> data = read_ref(fetch('simfcs.ref'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (5, 256, 256)
+    >>> data.dims
+    ('S', 'Y', 'X')
+    >>> data.coords['S'].data
+    array(['dc', 'ph1', 'md1', 'ph2', 'md2'], dtype='<U3')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsRef(filename) as ref:
+        data = ref.asarray()[:5]
+        metadata = _metadata(
+            ref.axes, data.shape, S=['dc', 'ph1', 'md1', 'ph2', 'md2']
+        )
+    return DataArray(data, **metadata)
+
+
+def read_r64(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return referenced lifetime data and metadata from SimFCS R64 file.
+
+    R64 files contain referenced fluorescence lifetime image data:
+    an average intensity image and lifetime polar coordinates for two
+    harmonics. R64 files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS R64 file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Referenced fluorescence lifetime polar coordinates.
+        An array of 5 (rarely more) 256x256 images of type ``float32``:
+
+        0. average intensity
+        1. phase of 1st harmonic in degrees
+        2. modulation of 1st harmonic normalized
+        3. phase of 2nd harmonic in degrees
+        4. modulation of 2nd harmonic normalized
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS R64 file.
+
+    Examples
+    --------
+    >>> data = read_r64(fetch('simfcs.r64'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (5, 256, 256)
+    >>> data.dims
+    ('S', 'Y', 'X')
+    >>> data.coords['S'].data
+    array(['dc', 'ph1', 'md1', 'ph2', 'md2'], dtype='<U3')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsR64(filename) as r64:
+        data = r64.asarray()[:5]
+        metadata = _metadata(
+            r64.axes,
+            data.shape,
+            filename,
+            S=['dc', 'ph1', 'md1', 'ph2', 'md2'],
+        )
+    return DataArray(data, **metadata)
+
+
+def read_b64(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return intensity image and metadata from SimFCS B64 file.
+
+    B64 files contain one or more square intensity image(s), a carpet
+    of lines, or a stream of intensity data. B64 files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS B64 file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Stack of square-sized intensity images of type ``int16``.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS B64 file.
+    ValueError
+        File does not contain an image stack.
+
+    Examples
+    --------
+    >>> data = read_b64(fetch('simfcs.b64'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('int16')
+    >>> data.shape
+    (22, 1024, 1024)
+    >>> data.dtype
+    dtype('int16')
+    >>> data.dims
+    ('I', 'Y', 'X')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsB64(filename) as b64:
+        data = b64.asarray()
+        if data.ndim != 3:
+            raise ValueError(
+                f'{os.path.basename(filename)!r} '
+                'does not contain an image stack'
+            )
+        metadata = _metadata(b64.axes, data.shape, filename)
+    return DataArray(data, **metadata)
+
+
+def read_z64(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return image and metadata from SimFCS Z64 file.
+
+    Z64 files contain stacks of square images such as intensity volumes
+    or time-domain fluorescence lifetime histograms acquired from
+    Becker & Hickl(r) TCSPC cards. Z64 files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS Z64 file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Single or stack of square-sized images of type ``float32``.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS Z64 file.
+
+    Examples
+    --------
+    >>> data = read_z64(fetch('simfcs.z64'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (256, 256, 256)
+    >>> data.dims
+    ('Q', 'Y', 'X')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsZ64(filename) as z64:
+        data = z64.asarray()
+        metadata = _metadata(z64.axes, data.shape, filename)
+    return DataArray(data, **metadata)
+
+
+def read_bh(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return image and metadata from SimFCS B&H file.
+
+    B&H files contain time-domain fluorescence lifetime histogram data,
+    acquired from Becker & Hickl(r) TCSPC cards, or converted from other
+    data sources. B&H files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS B&H file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Time-domain fluorescence lifetime histogram of shape
+        ``(256, 256, 256)`` and type ``float32``.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS B&H file.
+
+    Examples
+    --------
+    >>> data = read_bh(fetch('simfcs.b&h'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (256, 256, 256)
+    >>> data.dims
+    ('H', 'Y', 'X')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsBh(filename) as bnh:
+        assert bnh.axes is not None
+        data = bnh.asarray()
+        metadata = _metadata(bnh.axes.replace('Q', 'H'), data.shape, filename)
+    return DataArray(data, **metadata)
+
+
+def read_bhz(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return image and metadata from SimFCS BHZ file.
+
+    BHZ files contain time-domain fluorescence lifetime histogram data,
+    acquired from Becker & Hickl(r) TCSPC cards, or converted from other
+    data sources. BHZ files contain no metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of SimFCS BHZ file to read.
+
+    Returns
+    -------
+    data : xarray.DataArray
+        Time-domain fluorescence lifetime histogram of shape
+        ``(256, 256, 256)`` and type ``float32``.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a SimFCS BHZ file.
+
+    Examples
+    --------
+    >>> data = read_bhz(fetch('simfcs.bhz'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('float32')
+    >>> data.shape
+    (256, 256, 256)
+    >>> data.dims
+    ('H', 'Y', 'X')
+
+    """
+    import lfdfiles
+
+    with lfdfiles.SimfcsBhz(filename) as bhz:
+        assert bhz.axes is not None
+        data = bhz.asarray()
+        metadata = _metadata(bhz.axes.replace('Q', 'H'), data.shape, filename)
+    return DataArray(data, **metadata)
+
+
+def _metadata(
+    dims: Sequence[str] | None,
+    shape: tuple[int, ...],
+    /,
+    name: str | PathLike | None = None,
+    **coords: Any,
+) -> dict[str, Any]:
+    """Return xarray-style dims, coords, and attrs in a dict.
+
+    >>> _metadata('SYX', (3, 2, 1), S=['0', '1', '2'])
+    {'dims': ('S', 'Y', 'X'), 'coords': {'S': ['0', '1', '2']}, 'attrs': {}}
+
+    """
+    assert dims is not None
+    dims = tuple(dims)
+    if len(dims) != len(shape):
+        raise ValueError(
+            f'dims do not match shape {len(dims)} != {len(shape)}'
+        )
+    coords = {dim: coords[dim] for dim in dims if dim in coords}
+    metadata = {'dims': dims, 'coords': coords, 'attrs': {}}
+    if name:
+        metadata['name'] = os.path.basename(name)
+    return metadata
+
+
+def _squeeze_axes(
+    shape: Sequence[int],
+    axes: str,
+    /,
+    skip: str = 'XY',
+) -> tuple[tuple[int, ...], str, tuple[bool, ...]]:
+    """Return shape and axes with length-1 dimensions removed.
+
+    Remove unused dimensions unless their axes are listed in ``skip``.
+
+    Adapted from `tifffile <https://github.com/cgohlke/tifffile/>`_.
+
+    Parameters:
+        shape:
+            Sequence of dimension sizes.
+        axes:
+            Character codes for dimensions in ``shape``.
+        skip:
+            Character codes for dimensions whose length-1 dimensions are
+            not removed. The default is 'XY'.
+
+    Returns:
+        shape:
+            Sequence of dimension sizes with length-1 dimensions removed.
+        axes:
+            Character codes for dimensions in output `shape`.
+        squeezed:
+            Dimensions were kept (True) or removed (False).
+
+    Examples:
+        >>> _squeeze_axes((5, 1, 2, 1, 1), 'TZYXC')
+        ((5, 2, 1), 'TYX', (True, False, True, True, False))
+        >>> _squeeze_axes((1,), 'Q')
+        ((1,), 'Q', (True,))
+
+    """
+    if len(shape) != len(axes):
+        raise ValueError('dimensions of axes and shape do not match')
+    if not axes:
+        return tuple(shape), axes, ()
+    squeezed: list[bool] = []
+    shape_squeezed: list[int] = []
+    axes_squeezed: list[str] = []
+    for size, ax in zip(shape, axes):
+        if size > 1 or ax in skip:
+            squeezed.append(True)
+            shape_squeezed.append(size)
+            axes_squeezed.append(ax)
+        else:
+            squeezed.append(False)
+    if len(shape_squeezed) == 0:
+        squeezed[-1] = True
+        shape_squeezed.append(shape[-1])
+        axes_squeezed.append(axes[-1])
+    return tuple(shape_squeezed), ''.join(axes_squeezed), tuple(squeezed)

--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -39,13 +39,15 @@ def versions(*, sep: str = '\n') -> str:
         'numpy',
         'matplotlib',
         'click',
+        'pooch',
+        'xarray',
         'tifffile',
+        'lfdfiles',
+        'sdtfile',
         # 'scipy',
         # 'skimage',
         # 'sklearn',
         # 'aicsimageio',
-        # 'lfdfiles',
-        # 'sdtfile',
     ):
         try:
             __import__(module)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,38 @@
+"""Tests for the phasorpy.datasets module."""
+
+import os
+
+import pytest
+
+from phasorpy.datasets import fetch
+
+
+def test_fetch():
+    """Test fetch file."""
+    filename = fetch('simfcs.r64')
+    assert os.path.exists(filename)
+
+
+def test_fetch_inzip():
+    """Test fetch file from ZIP."""
+    filename = fetch('simfcs.b&h')
+    assert os.path.exists(filename)
+
+
+def test_fetch_zip():
+    """Test fetch ZIP file."""
+    filename = fetch('flimage.int.bin.zip', extract_dir='unzipped')[0]
+    assert os.path.exists(filename)
+    assert 'unzipped' in filename
+
+
+def test_fetch_compound():
+    """Test fetch compound file in ZIP."""
+    filename = fetch('simfcs_1000.int')
+    assert os.path.exists(filename.replace('int', 'mod'))
+
+
+def test_fetch_nonexistent():
+    """Test fetch non-existent file."""
+    with pytest.raises(ValueError):
+        fetch('non-existent.file')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,242 @@
+"""Tests for the phasorpy.io module."""
+
+import os
+import tempfile
+
+import numpy
+import pytest
+from numpy.testing import assert_almost_equal, assert_array_equal
+
+from phasorpy.datasets import fetch
+from phasorpy.io import (
+    read_b64,
+    read_bh,
+    read_bhz,
+    read_ifli,
+    read_lsm,
+    read_ometiff_phasor,
+    read_r64,
+    read_ref,
+    read_sdt,
+    read_z64,
+    write_ometiff_phasor,
+)
+
+HERE = os.path.dirname(__file__)
+TEMP_DIR = os.path.normpath(
+    os.environ.get('PHASORPY_TEMP', tempfile.gettempdir())
+)
+DATA_DIR = os.path.normpath(
+    os.environ.get('PHASORPY_DATA', os.path.join(HERE, '..', 'data'))
+)
+PRIVATE_DIR = os.path.join(DATA_DIR, 'private')
+
+SKIP_PRIVATE = not os.path.exists(PRIVATE_DIR)
+SKIP_FETCH = os.environ.get('SKIP_FETCH', False)
+
+
+class TempFileName:
+    """Temporary file name context manager."""
+
+    name: str
+    remove: bool
+
+    def __init__(self, name=None, remove=False):
+        self.remove = remove or TEMP_DIR == tempfile.gettempdir()
+        if not name:
+            fh = tempfile.NamedTemporaryFile(prefix='test_')
+            self.name = fh.named
+            fh.close()
+        else:
+            self.name = os.path.join(TEMP_DIR, f'test_{name}')
+
+    def __enter__(self) -> str:
+        return self.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.remove:
+            try:
+                os.remove(self.name)
+            except Exception:
+                pass
+
+
+def private_file(filename: str, /) -> str:
+    """Return path to private test file."""
+    return os.path.normpath(os.path.join(PRIVATE_DIR, filename))
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_read_lsm_non_hyperspectral():
+    """Test read non-hyperspectral LSM image fails."""
+    filename = private_file('non_hyperspectral.lsm')
+    with pytest.raises(ValueError):
+        read_lsm(filename)
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_read_lsm_tzcyx():
+    """Test read TZC hyperspectral LSM image."""
+    filename = private_file('tzcyx.lsm')
+    data = read_lsm(filename)
+    assert data.shape == (10, 21, 32, 256, 256)
+    assert data.dtype == numpy.uint16
+    assert data.dims == ('T', 'Z', 'C', 'Y', 'X')
+    assert_almost_equal(
+        data.coords['C'][[0, -1]],
+        [414.936272e-9, 690.47537e-9],
+        decimal=12,
+    )
+    assert_almost_equal(
+        data.coords['T'][[0, -1]], [40557.75229085, 42488.21737206]
+    )
+    assert_almost_equal(data.coords['Z'][[0, -1]], [0.0, 7.4440772e-05])
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_lsm_paramecium():
+    """Test read paramecium.lsm."""
+    filename = fetch('paramecium.lsm')
+    data = read_lsm(filename)
+    assert data.shape == (30, 512, 512)
+    assert data.dtype == numpy.uint8
+    assert data.dims == ('C', 'Y', 'X')
+    assert_almost_equal(
+        data.coords['C'][[0, -1]], [4.2301329e-7, 7.1301329e-7], decimal=12
+    )
+    assert_almost_equal(
+        data.coords['X'][[0, -1]], [0.0, 0.000424265835], decimal=9
+    )
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_sdt():
+    """Test read Becker & Hickl SDT file."""
+    filename = fetch('tcspc.sdt')
+    data = read_sdt(filename)
+    assert data.shape == (128, 128, 256)
+    assert data.dtype == numpy.uint16
+    assert data.dims == ('Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'][[0, -1]], [0.0, 1.2451172e-8], decimal=12
+    )
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_ifli():
+    """Test read ISS VistaVision file."""
+    filename = fetch('frequency_domain.ifli')
+    data = read_ifli(filename)
+    assert data.shape == (256, 256, 4, 3)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('Y', 'X', 'F', 'S')
+    assert_array_equal(data.coords['S'].data, ['dc', 're', 'im'])
+    assert_almost_equal(
+        data.coords['F'],
+        (80332416.0, 160664832.0, 240997248.0, 401662080.0),
+    )
+    assert_almost_equal(
+        data.attrs['ref_phasor'][0], (1.1425294e7, 5.9600395e-1, -9.4883347e-1)
+    )
+    assert data.attrs['ref_tau'] == (2.5, 0.0)
+    assert data.attrs['ref_tau_frac'] == (1.0, 0.0)
+    assert data.attrs['ref_phasor'].shape == (4, 3)
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_bh():
+    """Test read SimFCS B&H file."""
+    filename = fetch('simfcs.b&h')
+    data = read_bh(filename)
+    assert data.shape == (256, 256, 256)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('H', 'Y', 'X')
+    assert not data.coords
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_bhz():
+    """Test read SimFCS BHZ file."""
+    filename = fetch('simfcs.bhz')
+    data = read_bhz(filename)
+    assert data.shape == (256, 256, 256)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('H', 'Y', 'X')
+    assert not data.coords
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_ref():
+    """Test read SimFCS REF file."""
+    filename = fetch('simfcs.ref')
+    data = read_ref(filename)
+    assert data.shape == (5, 256, 256)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('S', 'Y', 'X')
+    assert_array_equal(
+        data.coords['S'].data, ['dc', 'ph1', 'md1', 'ph2', 'md2']
+    )
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_r64():
+    """Test read SimFCS R64 file."""
+    filename = fetch('simfcs.r64')
+    data = read_r64(filename)
+    assert data.shape == (5, 256, 256)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('S', 'Y', 'X')
+    assert_array_equal(
+        data.coords['S'].data, ['dc', 'ph1', 'md1', 'ph2', 'md2']
+    )
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_b64():
+    """Test read SimFCS B64 file."""
+    filename = fetch('simfcs.b64')
+    data = read_b64(filename)
+    assert data.shape == (22, 1024, 1024)
+    assert data.dtype == numpy.int16
+    assert data.dims == ('I', 'Y', 'X')
+    assert not data.coords
+    # filename = fetch('simfcs_image.b64')
+    # with pytest.raises(ValueError):
+    #     read_b64(filename)
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_z64():
+    """Test read SimFCS Z64 file."""
+    filename = fetch('simfcs.z64')
+    data = read_z64(filename)
+    assert data.shape == (256, 256, 256)
+    assert data.dtype == numpy.float32
+    assert data.dims == ('Q', 'Y', 'X')
+    assert not data.coords
+
+
+def test_ometiff_phasor():
+    """Test writing and reading phasor coordinates to OME-TIFF."""
+    data = numpy.random.random_sample((3, 31, 35, 31)).astype(numpy.float32)
+    dims = ('T', 'Y', 'X')
+    with TempFileName('ometiff_phasor.ome.tif') as filename:
+        write_ometiff_phasor(
+            filename,
+            data[0],
+            data[1],
+            data[2],
+            bigtiff=False,
+            axes=''.join(dims),
+            compression='adobe_deflate',
+        )
+        dc, re, im = read_ometiff_phasor(filename)
+        # TODO: test that file can be opened by Bio-Formats/Fiji
+
+    assert_array_equal(dc, data[0])
+    assert_array_equal(re, data[1])
+    assert_array_equal(im, data[2])
+    assert dc.dims == dims
+    assert re.dims == dims
+    assert im.dims == dims
+    assert not dc.coords

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -126,7 +126,7 @@ def test_read_sdt():
 def test_read_ifli():
     """Test read ISS VistaVision file."""
     filename = fetch('frequency_domain.ifli')
-    data = read_ifli(filename)
+    data = read_ifli(filename, memmap=True)
     assert data.shape == (256, 256, 4, 3)
     assert data.dtype == numpy.float32
     assert data.dims == ('Y', 'X', 'F', 'S')


### PR DESCRIPTION
This PR adds two new modules to the phasorpy library:

1. ``datasets``  provides a ``fetch`` function to automatically download sample data files from the [PhasorPy community repositories on Zenodo](https://zenodo.org/communities/phasorpy/). 

2. ``io`` provides functions to read time-resolved and hyperspectral image data and metadata from many file formats used in bio-imaging. This version includes readers for LSM, IFLI, SDT, and SimFCS formats. There are also convenience functions to read and write phasor coordinates (dc, re, im) to OME-TIFF (not sure how useful they are).

The PR adds new dependencies:

1. [Pooch](https://pypi.org/project/pooch/) is a lightweight package for managing sample files in remote repositories. Pooch is used by Scipy, scikit-image, and other related projects.

2. [xarray](https://pypi.org/project/xarray/) is a library providing a N-D labeled array object based on numpy ndarray. Xarray is used in the phasorpy.io module to return array and metadata from file reader functions in one object. Xarray is not a lightweight dependency since it depends on [Pandas](https://pypi.org/project/pandas/). However, Pandas itself will probably be used in the phasorpy library at some point, Xarray and Pandas are widely used in the scientific Python community. By using xarray we avoid the overhead for implementing, testing, and documenting proprietary data structures returned by the file reader functions.

3. [tifffile](https://pypi.org/project/tifffile/) is required for reading and writing TIFF-like file formats. It's a common dependency, for example, for scikit-image or imageio.

4. [lfdfiles](https://pypi.org/project/lfdfiles/) and [sdtfile](https://pypi.org/project/sdtfile/) are optional dependencies, only required when reading SimFCS, IFLI, and SDT formats.

TODO
----

The metadata returned in xarray's ``dims`` and ``attrs`` need to be standardized/normalized to match parameters used in analysis functions.

Unfortunately, it appears that fetching sample files from Zenodo is a major bottleneck during continuous integration testing and creation of documentation. It might work better to also store the sample files in a Git Large File Storage (LFS) repository or on an UCI server.

We don't have the full specification for the IFLI format, and very limited datasets for SDT and IFLI. The Zeiss CZI format is not included in this PR due to lack of hyperspectral data files and dependency issues.

@bruno-pannunzio @schutyb: Please try the file reader functions in your code and report any issues or feedback...