### PR TITLE
Add datasets and enable mass downloads

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -33,5 +33,5 @@ Any data files necessary to run the code can be attached to the issue or shared 
 Information how PhasorPy was installed (pip, conda, or other) and the console output of:
 
 ```
-$ python -m phasorpy --versions
+$ python -m phasorpy versions
 ```

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install -r requirements_dev.txt
     - name: Print dependency versions
       run: |
-        phasorpy --versions
+        phasorpy versions
     - name: Test with pytest
       run: |
         python -X dev -m pytest

--- a/docs/acknowledgments.rst
+++ b/docs/acknowledgments.rst
@@ -28,4 +28,4 @@ bug fixes, or expertise:
 - Enrico Gratton
 - :user:`Leonel Malacrida <lmalacrida>`
 - :user:`Bruno Pannunzio <bruno-pannunzio>`
-- :user:`Bruno Schuty <schutyb>`
+- :user:`Bruno Schüty <schutyb>`

--- a/docs/api/cli.rst
+++ b/docs/api/cli.rst
@@ -3,3 +3,4 @@ Command line interface
 
 .. click:: phasorpy.cli:main
    :prog: python -m phasorpy
+   :nested: full

--- a/docs/api/datasets.rst
+++ b/docs/api/datasets.rst
@@ -3,3 +3,7 @@ phasorpy.datasets
 
 .. automodule:: phasorpy.datasets
     :members:
+    :exclude-members: REPOSITORIES
+
+.. autodata:: phasorpy.datasets.REPOSITORIES
+   :no-value:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -58,7 +58,7 @@ and include the following items in the bug report:
 - Information how PhasorPy was installed (pip, conda, or other) and the output
   of::
 
-    $ python -m phasorpy --versions
+    $ python -m phasorpy versions
     Python 3.11.4 ...
     phasorpy 0.1.dev ...
     numpy 1.25.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "matplotlib",
     "click",
     "pooch",
+    "tqdm",
     "xarray",
     "tifffile",
     # "scipy",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,6 +10,7 @@ numpy >= 1.25; python_version > "3.10"
 matplotlib
 click
 pooch
+tqdm
 xarray
 tifffile
 #

--- a/src/phasorpy/cli.py
+++ b/src/phasorpy/cli.py
@@ -8,27 +8,43 @@ Invoke the command line application with::
 
 from __future__ import annotations
 
+import os
+
 import click
 
 from . import version
 
 
-@click.command(help='PhasorPy package command line interface.')
+@click.group(help='PhasorPy package command line interface.')
 @click.version_option(version=version.__version__)
+def main() -> int:
+    """PhasorPy command line interface."""
+    return 0
+
+
+@main.command(help='Show runtime versions.')
+def versions():
+    """Versions command group."""
+    click.echo(version.versions())
+
+
+@main.command(help='Fetch sample files from remote repositories.')
+@click.argument('files', nargs=-1)
 @click.option(
-    '--versions',
+    '--hideprogress',
     default=False,
     is_flag=True,
-    show_default=True,
-    help='Show runtime versions and exit.',
     type=click.BOOL,
+    help='Hide progressbar.',
 )
-def main(versions: bool) -> int:
-    """PhasorPy command line interface."""
-    if versions:
-        click.echo(version.versions())
-        return 0
-    return 0
+def fetch(files, hideprogress):
+    """Fetch command group."""
+    from . import datasets
+
+    files = datasets.fetch(
+        *files, return_scalar=False, progressbar=not hideprogress
+    )
+    click.echo(f'Cached at {os.path.commonpath(files)}')
 
 
 if __name__ == '__main__':

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -166,7 +166,7 @@ def write_ometiff_phasor(
     bigtiff : bool, optional
         Write BigTIFF file, which can exceed 4 GB.
     **kwargs : dict, optional
-        Additional parameters passed to ``tifffile.TiffWriter.write``,
+        Additional arguments passed to ``tifffile.TiffWriter.write``,
         for example ``compression``.
 
     Examples
@@ -377,7 +377,7 @@ def read_ifli(
     channel : int, optional
         Index of channel to return. The first channel is returned by default.
     **kwargs : dict, optional
-        Additional parameters passed to ``lfdfiles.VistaIfli.asarray``,
+        Additional arguments passed to ``lfdfiles.VistaIfli.asarray``,
         for example ``memmap=True``.
 
     Returns

--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -40,6 +40,7 @@ def versions(*, sep: str = '\n') -> str:
         'matplotlib',
         'click',
         'pooch',
+        'tqdm',
         'xarray',
         'tifffile',
         'lfdfiles',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,15 +10,21 @@ def test_version():
     """Test ``python -m phasorpy --version``."""
     runner = CliRunner()
     result = runner.invoke(main, ['--version'])
-
     assert result.exit_code == 0
     assert __version__ in result.output
 
 
 def test_versions():
-    """Test ``python -m phasorpy --versions``."""
+    """Test ``python -m phasorpy versions``."""
     runner = CliRunner()
-    result = runner.invoke(main, ['--versions'])
-
+    result = runner.invoke(main, ['versions'])
     assert result.exit_code == 0
     assert result.output.strip() == versions()
+
+
+def test_fetch():
+    """Test ``python -m phasorpy fetch``."""
+    runner = CliRunner()
+    result = runner.invoke(main, ['fetch', 'simfcs.r64'])
+    assert result.exit_code == 0
+    assert result.output.strip().endswith('simfcs.r64')

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,11 +6,18 @@ import pytest
 
 from phasorpy.datasets import fetch
 
+# skip large downloads by default
+SKIP_LARGE = bool(int(os.environ.get('SKIP_LARGE', 1)))
+
 
 def test_fetch():
     """Test fetch file."""
-    filename = fetch('simfcs.r64')
+    name = 'simfcs.r64'
+    filename = fetch(name)
+    assert filename.endswith(name)
     assert os.path.exists(filename)
+    filename = fetch(name, return_scalar=False)
+    assert filename[0].endswith(name)
 
 
 def test_fetch_inzip():
@@ -36,3 +43,32 @@ def test_fetch_nonexistent():
     """Test fetch non-existent file."""
     with pytest.raises(ValueError):
         fetch('non-existent.file')
+
+
+def test_fetch_multi():
+    """Test fetch multiple files."""
+    filenames = fetch('simfcs.r64', 'simfcs.ref')
+    for filename in filenames:
+        assert os.path.exists(filename)
+
+
+def test_fetch_list():
+    """Test fetch multiple files."""
+    filenames = fetch(['simfcs.r64', 'simfcs.ref'])
+    assert len(filenames) == 2
+
+
+@pytest.mark.skipif(SKIP_LARGE, reason='large download')
+def test_fetch_repo():
+    """Test fetch repo."""
+    filenames = fetch('tests')
+    for filename in filenames:
+        assert os.path.exists(filename)
+
+
+@pytest.mark.skipif(SKIP_LARGE, reason='large download')
+def test_fetch_all():
+    """Test fetch all files."""
+    filenames = fetch()
+    for filename in filenames:
+        assert os.path.exists(filename)


### PR DESCRIPTION
This PR adds datasets from the [FLUTE](https://zenodo.org/record/8046636) and [napari-flim-phasor-plotter](https://github.com/zoccoler/napari-flim-phasor-plotter/tree/main/src/napari_flim_phasor_plotter/data) projects and enables downloading multiple or all sample files at once via the `datasets.fetch` function or `python -m phasorpy fetch` command.

The PR introduces [tqdm](https://github.com/tqdm/tqdm) as new dependency, a popular and lightweight library to display progress bars for command line apps.