### PR TITLE
Enable Dependabot version updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,7 @@ docs/build/
 docs/_build/
 docs/examples/
 docs/tutorials/
+docs/sg_execution_times.rst
 
 # PyBuilder
 .pybuilder/


### PR DESCRIPTION
See [Enabling Dependabot version updates for actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions).