### PR TITLE
Add read functions for PTU, FBD, and FLIF files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 _/*
 data/*
+testdata/*
+test_data/*
+tests/data/*
 tutorials/data/*
 *.tif
 *.tiff
@@ -43,6 +46,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+*.whl
 MANIFEST
 
 # PyInstaller

--- a/docs/phasor_approach.rst
+++ b/docs/phasor_approach.rst
@@ -172,7 +172,7 @@ approach to analyze fluorescence time-resolved or spectral images:
   is a commercial software by FLIM LABS, a vendor of portable devices for
   fluorescence lifetime imaging and spectroscopy. The software provides
   real-time FLIM phasor-plot analysis, AI-driven phasor-plot analysis
-  techniques, and an application programming interface. Python modules 
+  techniques, and an application programming interface. Python modules
   by FLIM LABS are available on `GitHub <https://github.com/FLIMLABS>`_.
 
 - `VistaVision <https://iss.com/software/vistavision>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ test = [
     "pytest-doctestplus",
     "coverage",
 ]
-io = ["lfdfiles", "sdtfile"]
+io = ["lfdfiles", "sdtfile", "ptufile"]
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -52,3 +52,4 @@ codespell
 # bioio
 lfdfiles
 sdtfile
+ptufile

--- a/src/phasorpy/_typing.py
+++ b/src/phasorpy/_typing.py
@@ -29,6 +29,7 @@ from collections.abc import (
     ValuesView,
 )
 from os import PathLike
+from types import EllipsisType
 from typing import (
     Any,
     BinaryIO,

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -617,7 +617,7 @@ def read_ptu(
     >>> data.coords['H'].data
     array(...)
     >>> data.attrs['frequency']
-    2.51...
+    78.02
 
     """
     import ptufile
@@ -636,9 +636,9 @@ def read_ptu(
             keepdims=keepdims,
             asxarray=True,
         )
+        assert isinstance(data, DataArray)
+        data.attrs['frequency'] = ptu.syncrate * 1e-6  # MHz
 
-    assert isinstance(data, DataArray)
-    data.attrs['frequency'] *= 1e-6  # MHz
     return data
 
 

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -2,16 +2,19 @@
 
 The ``phasorpy.io`` module provides functions to
 
-- read time-resolved and hyperspectral image data and metadata from many
-  file formats used in bio-imaging.
+- read time-resolved and hyperspectral image data and metadata (as relevant
+  to phasor analysis) from many file formats used in bio-imaging.
 - write phasor coordinate images to OME-TIFF files for import in ImageJ
   or Bio-Formats.
 
-These file formats are currently supported:
+The following file formats are currently supported:
 
 - Zeiss LSM: :py:func:`read_lsm`
 - ISS IFLI: :py:func:`read_ifli`
 - Becker & Hickl SDT: :py:func:`read_sdt`
+- PicoQuant PTU: :py:func:`read_ptu`
+- FLIMbox FBD: :py:func:`read_fbd`
+- FlimFast FLIF: :py:func:`read_flif`
 - SimFCS REF: :py:func:`read_ref`
 - SimFCS R64: :py:func:`read_r64`
 - SimFCS B64: :py:func:`read_b64`
@@ -23,19 +26,18 @@ Support for other file formats is being considered:
 
 - OME-TIFF
 - Zeiss CZI
-- PicoQuant PTU
 - Leica LIF
 - Nikon ND2
 - Olympus OIB/OIF
 - Olympus OIR
-- FLIMbox FBD
-- FlimFast FLIF
 
 The functions are implemented as minimal wrappers around specialized
 third-party file reader libraries, currently
 `tifffile <https://github.com/cgohlke/tifffile>`_,
+`ptufile <https://github.com/cgohlke/ptufile>`_,
 `sdtfile <https://github.com/cgohlke/sdtfile>`_, and
 `lfdfiles <https://github.com/cgohlke/lfdfiles>`_.
+For advanced or unsupported use cases, consider using these libraries directly.
 
 The read functions typically have the following signature::
 
@@ -49,7 +51,7 @@ where ``ext`` indicates the file format and ``kwargs`` are optional arguments
 passed to the underlying file reader library or used to select which data is
 returned. The returned `xarray.DataArray
 <https://docs.xarray.dev/en/stable/user-guide/data-structures.html>`_
-contains a n-dimensional array with labeled coordinates, dimensions, and
+contains an n-dimensional array with labeled coordinates, dimensions, and
 attributes:
 
 - ``data`` or ``values`` (*array_like*)
@@ -109,8 +111,8 @@ __all__ = [
     'read_bh',
     'read_bhz',
     # 'read_czi',
-    # 'read_fbd',
-    # 'read_flif',
+    'read_fbd',
+    'read_flif',
     'read_ifli',
     # 'read_lif',
     'read_lsm',
@@ -119,19 +121,28 @@ __all__ = [
     # 'read_oir',
     # 'read_ometiff',
     'read_ometiff_phasor',
-    # 'read_ptu',
+    'read_ptu',
     'read_r64',
     'read_ref',
     'read_sdt',
     'read_z64',
     'write_ometiff_phasor',
+    '_squeeze_axes',
 ]
 
 import os
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._typing import Any, ArrayLike, PathLike, Sequence
+    from ._typing import (
+        Any,
+        ArrayLike,
+        PathLike,
+        Sequence,
+        DTypeLike,
+        EllipsisType,
+        Literal,
+    )
 
 import numpy
 from xarray import DataArray
@@ -384,7 +395,8 @@ def read_ifli(
     -------
     xarray.DataArray
         Average intensity and phasor coordinates.
-        An array of up to 8 dimensions and type ``float32``.
+        An array of up to 8 dimensions with :ref:`axes codes <axes>`
+        ``'RCTZYXFS'`` and type ``float32``.
         The last dimension contains `dc`, `re`, and `im` phasor coordinates.
 
         - ``coords['F']``: modulation frequencies.
@@ -422,19 +434,21 @@ def read_ifli(
 
     with lfdfiles.VistaIfli(filename) as ifli:
         assert ifli.axes is not None
-        data = ifli.asarray(**kwargs)[:, channel : channel + 1]
+        # always return one acquisition channel to simplify metadata handling
+        data = ifli.asarray(**kwargs)[:, channel : channel + 1].copy()
         shape, axes, _ = _squeeze_axes(data.shape, ifli.axes, skip='FYX')
+        axes = axes.replace('E', 'C')  # spectral axis
         data = data.reshape(shape)
         header = ifli.header
         coords: dict[str, Any] = {}
         coords['S'] = ['dc', 're', 'im']
         coords['F'] = numpy.array(header['ModFrequency'])
         # TODO: how to distinguish time- from frequency-domain?
-        # TODO: how extract spatial coordinates?
+        # TODO: how to extract spatial coordinates?
         if 'T' in axes:
             coords['T'] = numpy.array(header['TimeTags'])
-        if 'E' in axes:
-            coords['E'] = numpy.array(header['SpectrumInfo'])
+        if 'C' in axes:
+            coords['C'] = numpy.array(header['SpectrumInfo'])
         # if 'Z' in axes:
         #     coords['Z'] = numpy.array(header[])
         metadata = _metadata(axes, shape, filename, **coords)
@@ -459,7 +473,7 @@ def read_sdt(
 ) -> DataArray:
     """Return time-resolved image and metadata from Becker & Hickl SDT file.
 
-    SDT files contain time correlated single photon counting measurement data
+    SDT files contain time-correlated single photon counting measurement data
     and instrumentation parameters.
 
     Parameters
@@ -472,8 +486,9 @@ def read_sdt(
     Returns
     -------
     xarray.DataArray
-        Time correlated single photon counting image data
-        of type ``uint16``, ``uint32``, or ``float32``.
+        Time correlated single photon counting image data with
+        :ref:`axes codes <axes>` ``'YXH'`` and type ``uint16``, ``uint32``,
+        or ``float32``.
 
         - ``coords['H']``: times of the histogram bins.
         - ``attrs['frequency']``: repetition frequency in MHz.
@@ -481,8 +496,8 @@ def read_sdt(
     Raises
     ------
     ValueError
-        File is not a SDT file or is not a "SPC Setup & Data File" containing
-        time correlated single photon counting data.
+        File is not an SDT file containing time-correlated single photon
+        counting data.
 
     Examples
     --------
@@ -504,11 +519,14 @@ def read_sdt(
     import sdtfile
 
     with sdtfile.SdtFile(filename) as sdt:
-        if 'SPC Setup & Data File' not in sdt.info.id:
-            # skip FCS and DLL data
+        if (
+            'SPC Setup & Data File' not in sdt.info.id
+            and 'SPC FCS Data File' not in sdt.info.id
+        ):
+            # skip DLL data
             raise ValueError(
                 f'{os.path.basename(filename)!r} '
-                'is not a SDT "SPC Setup & Data File"'
+                'is not an SDT file containing TCSPC data'
             )
         # filter block types?
         # sdtfile.BlockType(sdt.block_headers[index].block_type).contents
@@ -519,6 +537,266 @@ def read_sdt(
     # TODO: get spatial coordinates from scanner settings?
     metadata = _metadata('QYXH'[-data.ndim :], data.shape, filename, H=times)
     metadata['attrs']['frequency'] = 1e-6 / (times[-1] + times[1])
+    return DataArray(data, **metadata)
+
+
+def read_ptu(
+    filename: str | PathLike[Any],
+    /,
+    selection: Sequence[int | slice | EllipsisType | None] | None = None,
+    *,
+    trimdims: Sequence[Literal['T', 'C', 'H']] | None = None,
+    dtype: DTypeLike | None = None,
+    frame: int | None = None,
+    channel: int | None = None,
+    keepdims: bool = True,
+) -> DataArray:
+    """Return image histogram and metadata from PicoQuant PTU T3 mode file.
+
+    PTU files contain time-correlated single photon counting measurement data
+    and instrumentation parameters.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of PTU file to read.
+    selection : sequence of index types
+        Indices for all dimensions:
+
+        - ``None``: return all items along axis (default).
+        - ``Ellipsis``: return all items along multiple axes.
+        - ``int``: return single item along axis.
+        - ``slice``: return chunk of axis.
+          ``slice.step`` is binning factor.
+          If ``slice.step=-1``, integrate all items along axis.
+
+    trimdims : str
+        Axes to trim. The default is ``'TCH'``.
+    dtype : dtype-like
+        Unsigned integer type of image histogram array.
+        The default is ``uint16``. Increase the bit depth to avoid
+        overflows when integrating.
+    frame : int
+        If < 0, integrate time axis, else return specified frame.
+        Overrides ``selection`` for axis ``T``.
+    channel : int
+        If < 0, integrate channel axis, else return specified channel.
+        Overrides ``selection`` for axis ``C``.
+    keepdims :
+        If true (default), reduced axes are left as size-one dimension.
+
+    Returns
+    -------
+    xarray.DataArray
+        Decoded TTTR T3 records as up to 5-dimensional image array
+        with :ref:`axes codes <axes>` ``'TYXCH'`` and type specified
+        in ``dtype``:
+
+        - ``coords['H']``: times of the histogram bins.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+
+    Raises
+    ------
+    ptufile.PqFileError
+        File is not a PicoQuant PTU file or is corrupted.
+    ValueError
+        File is not a PicoQuant PTU T3 mode file containing time-correlated
+        single photon counting data.
+
+    Examples
+    --------
+    >>> data = read_ptu(fetch('hazelnut_FLIM_single_image.ptu'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('uint16')
+    >>> data.shape
+    (5, 256, 256, 1, 139)
+    >>> data.dims
+    ('T', 'Y', 'X', 'C', 'H')
+    >>> data.coords['H'].data
+    array(...)
+    >>> data.attrs['frequency']
+    2.51...
+
+    """
+    import ptufile
+
+    with ptufile.PtuFile(filename, trimdims=trimdims) as ptu:
+        if not ptu.is_t3 or not ptu.is_image:
+            raise ValueError(
+                f'{os.path.basename(filename)!r} '
+                'is not a PTU file containing a T3 mode image'
+            )
+        data = ptu.decode_image(
+            selection,
+            dtype=dtype,
+            frame=frame,
+            channel=channel,
+            keepdims=keepdims,
+            asxarray=True,
+        )
+
+    assert isinstance(data, DataArray)
+    data.attrs['frequency'] *= 1e-6  # MHz
+    return data
+
+
+def read_flif(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return frequency-domain image and metadata from FlimFast FLIF file.
+
+    FlimFast FLIF files contain camera images and metadata from
+    frequency-domain fluorescence lifetime measurements.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of FlimFast FLIF file to read.
+
+    Returns
+    -------
+    xarray.DataArray
+        Frequency-domain phase images with :ref:`axes codes <axes>` ``'THYX'``
+        and type ``uint16``:
+
+        - ``coords['H']``: phases in radians.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+        - ``attrs['ref_phase']``: measured phase of reference.
+        - ``attrs['ref_mod']``: measured modulation of reference.
+        - ``attrs['ref_tauphase']``: lifetime from phase of reference.
+        - ``attrs['ref_taumod']``: lifetime from modulation of reference.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a FlimFast FLIF file.
+
+    Examples
+    --------
+    >>> data = read_flif(fetch('flimfast.flif'))
+    >>> data.values
+    array(...)
+    >>> data.dtype
+    dtype('uint16')
+    >>> data.shape
+    (32, 220, 300)
+    >>> data.dims
+    ('H', 'Y', 'X')
+    >>> data.coords['H'].data
+    array(...)
+    >>> data.attrs['frequency']
+    80.65...
+
+    """
+    import lfdfiles
+
+    with lfdfiles.FlimfastFlif(filename) as flif:
+        nphases = int(flif.header.phases)
+        data = flif.asarray()
+        if data.shape[0] < nphases:
+            raise ValueError(f'measured phases {data.shape[0]} < {nphases=}')
+        if data.shape[0] % nphases != 0:
+            data = data[: (data.shape[0] // nphases) * nphases]
+        data = data.reshape(-1, nphases, data.shape[1], data.shape[2])
+        if data.shape[0] == 1:
+            data = data[0]
+            axes = 'HYX'
+        else:
+            axes = 'THYX'
+        # TODO: check if phases are ordered
+        phases = numpy.radians(flif.records['phase'][:nphases])
+        metadata = _metadata(axes, data.shape, H=phases)
+        attrs = metadata['attrs']
+        attrs['frequency'] = float(flif.header.frequency)
+        attrs['ref_phase'] = float(flif.header.measured_phase)
+        attrs['ref_mod'] = float(flif.header.measured_mod)
+        attrs['ref_tauphase'] = float(flif.header.ref_tauphase)
+        attrs['ref_taumod'] = float(flif.header.ref_taumod)
+
+    return DataArray(data, **metadata)
+
+
+def read_fbd(
+    filename: str | PathLike[Any],
+    /,
+    *,
+    channel: int | None = None,
+    laser_factor: float = -1.0,
+    integrate_frames: int = 1,
+) -> DataArray:
+    """Return frequency-domain image and metadata from FLIMbox FBD file.
+
+    FDB files contain encoded data from the FLIMbox device, which can be
+    decoded to photon arrival windows, channels, and global times.
+    The encoding scheme depends on the FLIMbox device's firmware.
+    The FBD file format is undocumented.
+
+    This function may fail to produce expected results when files use unknown
+    firmware, do not contain image scans, settings were recorded incorrectly,
+    scanner and FLIMbox frequencies were out of sync, or scanner settings were
+    changed during acquisition.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of FLIMbox FBD file to read.
+    laser_factor : float
+        Factor to correct dwell_time/laser_frequency.
+    integrate_frames : int
+        Specifies which frames to sum. By default, all frames are summed
+        into one. If 0, no frames are summed.
+
+    Returns
+    -------
+    xarray.DataArray
+        Frequency-domain image histogram with :ref:`axes codes <axes>`
+        ``'CYXH'`` and type ``uint16``:
+
+        - ``coords['H']``: phases in radians.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+
+    Raises
+    ------
+    lfdfile.LfdFileError
+        File is not a FLIMbox FBD file.
+
+    Examples
+    --------
+    >>> data = read_fbd(fetch('convallaria_000$EI0S.fbd'))  # doctest: +SKIP
+    >>> data.values  # doctest: +SKIP
+    array(...)
+    >>> data.dtype  # doctest: +SKIP
+    dtype('uint16')
+    >>> data.shape  # doctest: +SKIP
+    (1, 2, 256, 256, 64)
+    >>> data.dims  # doctest: +SKIP
+    ('T', 'C', 'Y', 'X', 'H')
+    >>> data.coords['H'].data  # doctest: +SKIP
+    array(...)
+    >>> data.attrs['frequency']  # doctest: +SKIP
+    40.0
+
+    """
+    import lfdfiles
+
+    with lfdfiles.FlimboxFbd(filename, laser_factor=laser_factor) as fbd:
+        data = fbd.asimage(None, None, integrate_frames=integrate_frames)
+        if channel is not None:
+            data = data[:, channel].copy()
+            axes = 'TYXH'
+        else:
+            axes = 'TCYXH'
+        # TODO: return arrival window indices or micro-times as H coords?
+        phases = numpy.linspace(
+            0.0, numpy.pi * 2, data.shape[-1], endpoint=False
+        )
+        metadata = _metadata(axes, data.shape, H=phases)
+        attrs = metadata['attrs']
+        attrs['frequency'] = fbd.laser_frequency * 1e-6
+
     return DataArray(data, **metadata)
 
 
@@ -541,7 +819,7 @@ def read_ref(
     -------
     xarray.DataArray
         Referenced fluorescence lifetime polar coordinates.
-        An array of 5 (rarely more) 256x256 images of type ``float32``:
+        An array of five 256x256 images of type ``float32``:
 
         0. average intensity
         1. phase of 1st harmonic in degrees
@@ -598,7 +876,7 @@ def read_r64(
     -------
     xarray.DataArray
         Referenced fluorescence lifetime polar coordinates.
-        An array of 5 (rarely more) 256x256 images of type ``float32``:
+        An array of five 256x256 images of type ``float32``:
 
         0. average intensity
         1. phase of 1st harmonic in degrees
@@ -757,8 +1035,8 @@ def read_bh(
     Returns
     -------
     xarray.DataArray
-        Time-domain fluorescence lifetime histogram of shape
-        ``(256, 256, 256)`` and type ``float32``.
+        Time-domain fluorescence lifetime histogram with axes ``'HYX'``,
+        shape ``(256, 256, 256)``, and type ``float32``.
 
     Raises
     ------
@@ -805,8 +1083,8 @@ def read_bhz(
     Returns
     -------
     xarray.DataArray
-        Time-domain fluorescence lifetime histogram of shape
-        ``(256, 256, 256)`` and type ``float32``.
+        Time-domain fluorescence lifetime histogram with axes ``'HYX'``,
+        shape ``(256, 256, 256)``, and type ``float32``.
 
     Raises
     ------
@@ -871,30 +1149,33 @@ def _squeeze_axes(
 
     Remove unused dimensions unless their axes are listed in ``skip``.
 
-    Adapted from `tifffile <https://github.com/cgohlke/tifffile/>`_.
+    Adapted from the tifffile library.
 
-    Parameters:
-        shape:
-            Sequence of dimension sizes.
-        axes:
-            Character codes for dimensions in ``shape``.
-        skip:
-            Character codes for dimensions whose length-1 dimensions are
-            not removed. The default is 'XY'.
+    Parameters
+    ----------
+    shape : tuple of ints
+        Sequence of dimension sizes.
+    axes : str
+        Character codes for dimensions in ``shape``.
+    skip : str (optional)
+        Character codes for dimensions whose length-1 dimensions are
+        not removed. The default is 'XY'.
 
-    Returns:
-        shape:
-            Sequence of dimension sizes with length-1 dimensions removed.
-        axes:
-            Character codes for dimensions in output `shape`.
-        squeezed:
-            Dimensions were kept (True) or removed (False).
+    Returns
+    -------
+    shape : tuple of ints
+        Sequence of dimension sizes with length-1 dimensions removed.
+    axes : str
+        Character codes for dimensions in output `shape`.
+    squeezed : str
+        Dimensions were kept (True) or removed (False).
 
-    Examples:
-        >>> _squeeze_axes((5, 1, 2, 1, 1), 'TZYXC')
-        ((5, 2, 1), 'TYX', (True, False, True, True, False))
-        >>> _squeeze_axes((1,), 'Q')
-        ((1,), 'Q', (True,))
+    Examples
+    --------
+    >>> _squeeze_axes((5, 1, 2, 1, 1), 'TZYXC')
+    ((5, 2, 1), 'TYX', (True, False, True, True, False))
+    >>> _squeeze_axes((1,), 'Q')
+    ((1,), 'Q', (True,))
 
     """
     if len(shape) != len(axes):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -199,7 +199,7 @@ def test_read_ptu():
     assert_almost_equal(
         data.coords['H'].data[[1, -1]], [9.69696970e-11, 3.97090909e-07]
     )
-    assert_almost_equal(data.attrs['frequency'], 2.517700195304632)
+    assert data.attrs['frequency'] == 78.02
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -208,13 +208,33 @@ def test_read_fbd():
     # TODO: test files with different firmwares
     # TODO: gather public FBD files and upload to Zenodo
     filename = private_file('convallaria_000$EI0S.fbd')
-    data = read_fbd(filename, channel=0, integrate_frames=0)
+    data = read_fbd(filename)
     assert data.values.sum(dtype=numpy.uint64) == 9310275
     assert data.dtype == numpy.uint16
-    assert data.shape == (9, 256, 256, 64)
-    assert data.dims == ('T', 'Y', 'X', 'H')
+    assert data.shape == (9, 2, 256, 256, 64)
+    assert data.dims == ('T', 'C', 'Y', 'X', 'H')
     assert_almost_equal(data.coords['H'].data[[1, -1]], [0.0981748, 6.1850105])
     assert_almost_equal(data.attrs['frequency'], 40.0)
+
+    data = read_fbd(filename, frame=-1, channel=0)
+    assert data.values.sum(dtype=numpy.uint64) == 9310275
+    assert data.shape == (1, 1, 256, 256, 64)
+    assert data.dims == ('T', 'C', 'Y', 'X', 'H')
+
+    data = read_fbd(filename, frame=-1, channel=1, keepdims=False)
+    assert data.values.sum(dtype=numpy.uint64) == 0  # channel 1 is empty
+    assert data.shape == (256, 256, 64)
+    assert data.dims == ('Y', 'X', 'H')
+
+    data = read_fbd(filename, frame=1, channel=0, keepdims=False)
+    assert data.values.sum(dtype=numpy.uint64) == 1033137
+    assert data.shape == (256, 256, 64)
+    assert data.dims == ('Y', 'X', 'H')
+
+    data = read_fbd(filename, frame=1, channel=0)
+    assert data.values.sum(dtype=numpy.uint64) == 1033137
+    assert data.shape == (1, 1, 256, 256, 64)
+    assert data.dims == ('T', 'C', 'Y', 'X', 'H')
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -12,9 +12,12 @@ from phasorpy.io import (
     read_b64,
     read_bh,
     read_bhz,
+    read_fbd,
+    read_flif,
     read_ifli,
     read_lsm,
     read_ometiff_phasor,
+    read_ptu,
     read_r64,
     read_ref,
     read_sdt,
@@ -79,8 +82,9 @@ def test_read_lsm_tzcyx():
     """Test read TZC hyperspectral LSM image."""
     filename = private_file('tzcyx.lsm')
     data = read_lsm(filename)
-    assert data.shape == (10, 21, 32, 256, 256)
+    assert data.values.sum(dtype=numpy.uint64) == 142328063165
     assert data.dtype == numpy.uint16
+    assert data.shape == (10, 21, 32, 256, 256)
     assert data.dims == ('T', 'Z', 'C', 'Y', 'X')
     assert_almost_equal(
         data.coords['C'][[0, -1]],
@@ -98,8 +102,9 @@ def test_read_lsm_paramecium():
     """Test read paramecium.lsm."""
     filename = fetch('paramecium.lsm')
     data = read_lsm(filename)
-    assert data.shape == (30, 512, 512)
+    assert data.values.sum(dtype=numpy.uint64) == 14050194
     assert data.dtype == numpy.uint8
+    assert data.shape == (30, 512, 512)
     assert data.dims == ('C', 'Y', 'X')
     assert_almost_equal(
         data.coords['C'][[0, -1]], [4.2301329e-7, 7.1301329e-7], decimal=12
@@ -114,21 +119,39 @@ def test_read_sdt():
     """Test read Becker & Hickl SDT file."""
     filename = fetch('tcspc.sdt')
     data = read_sdt(filename)
-    assert data.shape == (128, 128, 256)
+    assert data.values.sum(dtype=numpy.uint64) == 224606420
     assert data.dtype == numpy.uint16
+    assert data.shape == (128, 128, 256)
     assert data.dims == ('Y', 'X', 'H')
     assert_almost_equal(
         data.coords['H'][[0, -1]], [0.0, 1.2451172e-8], decimal=12
     )
 
 
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_read_sdt_fcs():
+    """Test read Becker & Hickl SDT FCS file."""
+    # file provided by lmalacrida via email on Nov 13, 2023
+    filename = private_file('j3_405_z1.sdt')
+    data = read_sdt(filename)
+    assert data.values.sum(dtype=numpy.uint64) == 16929780
+    assert data.dtype == numpy.uint16
+    assert data.shape == (512, 512, 1024)
+    assert data.dims == ('Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'][[0, -1]], [0.0, 1.666157034737e-08], decimal=12
+    )
+
+
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_read_ifli():
     """Test read ISS VistaVision file."""
+    # TODO: test spectral file
     filename = fetch('frequency_domain.ifli')
     data = read_ifli(filename, memmap=True)
-    assert data.shape == (256, 256, 4, 3)
+    assert data.values.sum() == 62603316.0
     assert data.dtype == numpy.float32
+    assert data.shape == (256, 256, 4, 3)
     assert data.dims == ('Y', 'X', 'F', 'S')
     assert_array_equal(data.coords['S'].data, ['dc', 're', 'im'])
     assert_almost_equal(
@@ -144,12 +167,64 @@ def test_read_ifli():
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_flif():
+    """Test read FlimFast FLIF file."""
+    # TODO: test time series
+    filename = fetch('flimfast.flif')
+    data = read_flif(filename)
+    data = read_flif(fetch('flimfast.flif'))
+    assert data.values.sum(dtype=numpy.uint64) == 706233156
+    assert data.dtype == 'uint16'
+    assert data.shape == (32, 220, 300)
+    assert data.dims == ('H', 'Y', 'X')
+    assert_almost_equal(data.coords['H'].data[[1, -1]], [0.1963495, 6.086836])
+    assert_almost_equal(data.attrs['frequency'], 80.6520004272461)
+    assert_almost_equal(data.attrs['ref_phase'], 120.63999938964844)
+    assert_almost_equal(data.attrs['ref_mod'], 31.670000076293945)
+    assert_almost_equal(data.attrs['ref_tauphase'], 1.0160000324249268)
+    assert_almost_equal(data.attrs['ref_taumod'], 1.2580000162124634)
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_read_ptu():
+    """Test read PicoQuant PTU file."""
+    filename = fetch('hazelnut_FLIM_single_image.ptu')
+    data = read_ptu(
+        filename, frame=-1, channel=0, keepdims=False, trimdims='TC'
+    )
+    assert data.values.sum(dtype=numpy.uint64) == 6065123
+    assert data.dtype == numpy.uint16
+    assert data.shape == (256, 256, 4096)
+    assert data.dims == ('Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'].data[[1, -1]], [9.69696970e-11, 3.97090909e-07]
+    )
+    assert_almost_equal(data.attrs['frequency'], 2.517700195304632)
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_read_fbd():
+    """Test read FLIMbox FBD file."""
+    # TODO: test files with different firmwares
+    # TODO: gather public FBD files and upload to Zenodo
+    filename = private_file('convallaria_000$EI0S.fbd')
+    data = read_fbd(filename, channel=0, integrate_frames=0)
+    assert data.values.sum(dtype=numpy.uint64) == 9310275
+    assert data.dtype == numpy.uint16
+    assert data.shape == (9, 256, 256, 64)
+    assert data.dims == ('T', 'Y', 'X', 'H')
+    assert_almost_equal(data.coords['H'].data[[1, -1]], [0.0981748, 6.1850105])
+    assert_almost_equal(data.attrs['frequency'], 40.0)
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_read_bh():
     """Test read SimFCS B&H file."""
     filename = fetch('simfcs.b&h')
     data = read_bh(filename)
-    assert data.shape == (256, 256, 256)
+    assert data.values.sum() == 7973051.0
     assert data.dtype == numpy.float32
+    assert data.shape == (256, 256, 256)
     assert data.dims == ('H', 'Y', 'X')
     assert not data.coords
 
@@ -159,8 +234,9 @@ def test_read_bhz():
     """Test read SimFCS BHZ file."""
     filename = fetch('simfcs.bhz')
     data = read_bhz(filename)
-    assert data.shape == (256, 256, 256)
+    assert data.values.sum() == 7973051.0
     assert data.dtype == numpy.float32
+    assert data.shape == (256, 256, 256)
     assert data.dims == ('H', 'Y', 'X')
     assert not data.coords
 
@@ -170,8 +246,9 @@ def test_read_ref():
     """Test read SimFCS REF file."""
     filename = fetch('simfcs.ref')
     data = read_ref(filename)
-    assert data.shape == (5, 256, 256)
+    assert data.values.sum() == 20583368.0
     assert data.dtype == numpy.float32
+    assert data.shape == (5, 256, 256)
     assert data.dims == ('S', 'Y', 'X')
     assert_array_equal(
         data.coords['S'].data, ['dc', 'ph1', 'md1', 'ph2', 'md2']
@@ -183,8 +260,9 @@ def test_read_r64():
     """Test read SimFCS R64 file."""
     filename = fetch('simfcs.r64')
     data = read_r64(filename)
-    assert data.shape == (5, 256, 256)
+    assert data.values.sum() == 5032296.5
     assert data.dtype == numpy.float32
+    assert data.shape == (5, 256, 256)
     assert data.dims == ('S', 'Y', 'X')
     assert_array_equal(
         data.coords['S'].data, ['dc', 'ph1', 'md1', 'ph2', 'md2']
@@ -196,8 +274,9 @@ def test_read_b64():
     """Test read SimFCS B64 file."""
     filename = fetch('simfcs.b64')
     data = read_b64(filename)
-    assert data.shape == (22, 1024, 1024)
+    assert data.values.sum(dtype=numpy.int64) == 8386914853
     assert data.dtype == numpy.int16
+    assert data.shape == (22, 1024, 1024)
     assert data.dims == ('I', 'Y', 'X')
     assert not data.coords
     # filename = fetch('simfcs_image.b64')
@@ -210,8 +289,9 @@ def test_read_z64():
     """Test read SimFCS Z64 file."""
     filename = fetch('simfcs.z64')
     data = read_z64(filename)
-    assert data.shape == (256, 256, 256)
+    assert data.values.sum() == 5536049.0
     assert data.dtype == numpy.float32
+    assert data.shape == (256, 256, 256)
     assert data.dims == ('Q', 'Y', 'X')
     assert not data.coords
 


### PR DESCRIPTION
## Description

This PR adds read functions for PTU, FBD, and FLIF files to the `phasorpy.io` module. It also fixes the IFLI spectral axes code and makes `read_sdt` accept SDT FCS data files.

The [ptufile](https://github.com/cgohlke/ptufile) library is added as an optional dependency required for reading PTU files.

Partly addresses issue #10.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add read functions for PTU, FBD, and FLIF files
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
