### PR TITLE
Fix PhasorPlot.semicircle changes axes limits

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -668,6 +668,12 @@ class PhasorPlot:
                 **kwargs,
             )
 
+        # somehow above code changes the axes limits, so reset them
+        try:
+            self._ax.set(xlim=self._limits[0], ylim=self._limits[1])
+        except AttributeError:
+            pass
+
 
 class SemicircleTicks(AbstractPathEffect):
     """Draw ticks on universal semicircle.

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -190,6 +190,10 @@ class TestPhasorPlot:
         plot.semicircle(frequency=80.0, phasor_reference=(0.2, 0.4))
         self.show(plot)
 
+        plot = PhasorPlot(title='limits', xlim=(0.4, 0.6), ylim=(0.4, 0.6))
+        plot.semicircle(frequency=80.0)
+        self.show(plot)
+
 
 def test_plot_phasor():
     """Test plot_phasor function."""


### PR DESCRIPTION
## Description

Somehow ``PhasorPlot.semicircle`` changed the axes limits, so re-apply the limits at the end of the method.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Fix PhasorPlot.semicircle changes axes limits
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
