### PR TITLE
Fix contour offsets

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -244,6 +244,13 @@ class PhasorPlot:
             **kwargs,
         )
 
+    def _reset_limits(self) -> None:
+        """Reset axes limits."""
+        try:
+            self._ax.set(xlim=self._limits[0], ylim=self._limits[1])
+        except AttributeError:
+            pass
+
     def hist2d(
         self,
         real: ArrayLike,
@@ -278,6 +285,7 @@ class PhasorPlot:
         if cmax is not None:
             h[h > cmax] = None
         self._ax.pcolormesh(xedges, yedges, h.T, **kwargs)
+        self._reset_limits()
 
     def contour(
         self,
@@ -305,9 +313,10 @@ class PhasorPlot:
             kwargs, 'bins', 'range', 'density', 'weights'
         )
         h, xedges, yedges = self._histogram2d(real, imag, **kwargs_hist2d)
-        xedges = xedges[:-1] + (xedges[1] - xedges[0])
-        yedges = yedges[:-1] + (yedges[1] - yedges[0])
+        xedges = xedges[:-1] + ((xedges[1] - xedges[0]) / 2.0)
+        yedges = yedges[:-1] + ((yedges[1] - yedges[0]) / 2.0)
         self._ax.contour(xedges, yedges, h.T, **kwargs)
+        self._reset_limits()
 
     def imshow(
         self,
@@ -667,12 +676,7 @@ class PhasorPlot:
                 path_effects=[SemicircleTicks(labels=labels)],
                 **kwargs,
             )
-
-        # somehow above code changes the axes limits, so reset them
-        try:
-            self._ax.set(xlim=self._limits[0], ylim=self._limits[1])
-        except AttributeError:
-            pass
+        self._reset_limits()
 
 
 class SemicircleTicks(AbstractPathEffect):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -69,6 +69,7 @@ class TestPhasorPlot:
             'x',
             label='3',
         )
+        plot.plot(-0.5, -0.5, label='4')
         self.show(plot)
 
     def test_hist2d(self):
@@ -97,6 +98,18 @@ class TestPhasorPlot:
 
         plot = PhasorPlot(title='contour parameters', allquadrants=True)
         plot.contour(real, imag, bins=200, cmap='viridis', norm='linear')
+        self.show(plot)
+
+    def test_histogram_contour(self):
+        """Test histogram and contour match."""
+        real, imag = numpy.random.multivariate_normal(
+            (0.6, 0.4), [[3e-3, -1e-3], [-1e-3, 1e-3]], (256, 256)
+        ).T
+        plot = PhasorPlot(
+            title='histogram and contour', xlim=(0.4, 0.8), ylim=(0.25, 0.55)
+        )
+        plot.hist2d(real, imag, bins=32, cmap='Blues')
+        plot.contour(real, imag, bins=32, levels=4, cmap='Reds')
         self.show(plot)
 
     def test_imshow(self):


### PR DESCRIPTION
## Description

Fix contour coordinates are offset by half a pixel in each direction.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Fix contour offsets
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
