### PR TITLE
Hide typehints in API documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -113,3 +113,6 @@ intersphinx_mapping = {
 }
 
 intersphinx_disabled_reftypes = ['*']
+
+# do not show typehints
+autodoc_typehints = 'none'


### PR DESCRIPTION
## Description

This PR proposes to remove type annotations/hints from the autogenerated API documentation using the [autodoc_typehints](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_typehints) setting.

Typehints can be distracting and are repeated in numpy docstrings anyways. If needed, the typehints are one click away in the `[source]` link. Here's a comparison of ``PhasorPlot.semicircle`` method with and without typehints:

![image](https://github.com/phasorpy/phasorpy/assets/483428/568cee3d-03b4-4e64-81e7-62b9b77708c6)
---
![image](https://github.com/phasorpy/phasorpy/assets/483428/2c4c561e-01db-4120-9137-7283c0b7f8a8)

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Hide typehints in API documentation
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
