### PR TITLE
Add `skip_axes` to `phasor_calibrate`

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -513,7 +513,7 @@ def phasor_calibrate(
             f'!= reference_imag.shape{ref_im.shape}'
         )
     measured_re, measured_im = phasor_center(
-        reference_real, reference_imag, skip_axes=skip_axes,method=method
+        reference_real, reference_imag, skip_axes=skip_axes, method=method
     )
     known_re, known_im = phasor_from_lifetime(
         frequency,

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -402,6 +402,7 @@ def phasor_calibrate(
     preexponential: bool = False,
     unit_conversion: float = 1e-3,
     method: Literal['mean', 'median'] = 'mean',
+    skip_axes: tuple[int, ...] | None = None,
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """
     Return calibrated/referenced phasor coordinates.
@@ -447,6 +448,9 @@ def phasor_calibrate(
 
         - ``'mean'``: Arithmetic mean of phasor coordinates.
         - ``'median'``: Spatial median of phasor coordinates.
+    skip_axes : tuple of int, optional
+        Axes to be excluded during center calculation. If None, all
+        axes are considered.
 
     Returns
     -------
@@ -509,7 +513,7 @@ def phasor_calibrate(
             f'!= reference_imag.shape{ref_im.shape}'
         )
     measured_re, measured_im = phasor_center(
-        reference_real, reference_imag, method=method
+        reference_real, reference_imag, skip_axes=skip_axes,method=method
     )
     known_re, known_im = phasor_from_lifetime(
         frequency,


### PR DESCRIPTION
## Description
This PR adds the `skip_axes` parameter to `phasor_calibrate` function for the center calculation of reference coordinates.
...

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add `skip_axes` parameter to `phasor_calibrate`
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
