### PR TITLE
Add dtime parameter to read_ptu function

### DIFF
--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -549,6 +549,7 @@ def read_ptu(
     dtype: DTypeLike | None = None,
     frame: int | None = None,
     channel: int | None = None,
+    dtime: int | None = 0,
     keepdims: bool = True,
 ) -> DataArray:
     """Return image histogram and metadata from PicoQuant PTU T3 mode file.
@@ -560,7 +561,7 @@ def read_ptu(
     ----------
     filename : str or Path
         Name of PTU file to read.
-    selection : sequence of index types
+    selection : sequence of index types, optional
         Indices for all dimensions:
 
         - ``None``: return all items along axis (default).
@@ -570,19 +571,24 @@ def read_ptu(
           ``slice.step`` is binning factor.
           If ``slice.step=-1``, integrate all items along axis.
 
-    trimdims : str
-        Axes to trim. The default is ``'TCH'``.
-    dtype : dtype-like
+    trimdims : str, optional, default: 'TCH'
+        Axes to trim.
+    dtype : dtype-like, optional, default: uint16
         Unsigned integer type of image histogram array.
-        The default is ``uint16``. Increase the bit depth to avoid
-        overflows when integrating.
-    frame : int
+        Increase the bit depth to avoid overflows when integrating.
+    frame : int, optional
         If < 0, integrate time axis, else return specified frame.
-        Overrides ``selection`` for axis ``T``.
-    channel : int
+        Overrides `selection` for axis ``T``.
+    channel : int, optional
         If < 0, integrate channel axis, else return specified channel.
-        Overrides ``selection`` for axis ``C``.
-    keepdims :
+        Overrides `selection` for axis ``C``.
+    dtime : int, optional, default: 0
+        Specifies number of bins in image histogram.
+        If 0 (default), return number of bins in one period.
+        If < 0, integrate delay time axis.
+        If > 0, return up to specified bin.
+        Overrides `selection` for axis ``H``.
+    keepdims : bool, optional, default: True
         If true (default), reduced axes are left as size-one dimension.
 
     Returns
@@ -611,7 +617,7 @@ def read_ptu(
     >>> data.dtype
     dtype('uint16')
     >>> data.shape
-    (5, 256, 256, 1, 139)
+    (5, 256, 256, 1, 132)
     >>> data.dims
     ('T', 'Y', 'X', 'C', 'H')
     >>> data.coords['H'].data
@@ -633,11 +639,12 @@ def read_ptu(
             dtype=dtype,
             frame=frame,
             channel=channel,
+            dtime=dtime,
             keepdims=keepdims,
             asxarray=True,
         )
         assert isinstance(data, DataArray)
-        data.attrs['frequency'] = ptu.syncrate * 1e-6  # MHz
+        data.attrs['frequency'] = ptu.frequency * 1e-6  # MHz
 
     return data
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -189,13 +189,28 @@ def test_read_flif():
 def test_read_ptu():
     """Test read PicoQuant PTU file."""
     filename = fetch('hazelnut_FLIM_single_image.ptu')
+    data = read_ptu(filename, frame=-1, channel=0, dtime=0, keepdims=False)
+    assert data.values.sum(dtype=numpy.uint64) == 6064854
+    assert data.dtype == numpy.uint16
+    assert data.shape == (256, 256, 132)
+    assert data.dims == ('Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'].data[[1, -1]], [9.69696970e-11, 1.2703030e-08]
+    )
+    assert data.attrs['frequency'] == 78.02
+
     data = read_ptu(
-        filename, frame=-1, channel=0, keepdims=False, trimdims='TC'
+        filename,
+        frame=-1,
+        channel=0,
+        dtime=None,
+        keepdims=True,
+        trimdims='TC',
     )
     assert data.values.sum(dtype=numpy.uint64) == 6065123
     assert data.dtype == numpy.uint16
-    assert data.shape == (256, 256, 4096)
-    assert data.dims == ('Y', 'X', 'H')
+    assert data.shape == (1, 256, 256, 1, 4096)
+    assert data.dims == ('T', 'Y', 'X', 'C', 'H')
     assert_almost_equal(
         data.coords['H'].data[[1, -1]], [9.69696970e-11, 3.97090909e-07]
     )


### PR DESCRIPTION
## Description

Return number of bins in one period (1/frequency) by default.

Requires ptufile >= 2024.2.20.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add dtime parameter to read_ptu function
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
