### PR TITLE
Add phasor_from_fret functions

### DIFF
--- a/src/phasorpy/_phasor.pyx
+++ b/src/phasorpy/_phasor.pyx
@@ -524,7 +524,7 @@ cdef (double, double) _phasor_from_fret_acceptor(
         sensitized_imag,
         acceptor_real,
         acceptor_imag,
-        donor_freting * fret_efficiency,
+        donor_freting * fret_efficiency,  # SimFCS uses 1.0
         1.0,
         1.0 - acceptor_excitation
     )
@@ -538,6 +538,7 @@ cdef (double, double) _phasor_from_fret_acceptor(
             acceptor_imag,
             background_real,
             background_imag,
+            # SimFCS uses 1.0
             donor_freting * fret_efficiency + acceptor_excitation,
             1.0,
             1.0 - acceptor_background
@@ -545,6 +546,7 @@ cdef (double, double) _phasor_from_fret_acceptor(
 
     # phasor of excited acceptor with background and donor bleedthrough
     if donor_bleedthrough > 0.0:
+        # SimFCS also includes donor channel background in donor bleedthrough
         acceptor_real, acceptor_imag = linear_combination(
             acceptor_real,
             acceptor_imag,
@@ -555,7 +557,7 @@ cdef (double, double) _phasor_from_fret_acceptor(
             (
                 donor_freting * fret_efficiency
                 + acceptor_excitation + acceptor_background
-            ),
+            ),  # SimFCS uses 1.0
             1.0 - donor_freting * fret_efficiency,
             1.0 - donor_bleedthrough
         )

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -914,7 +914,7 @@ def phasor_to_apparent_lifetime(
     Examples
     --------
     The apparent single lifetimes from phase and modulation are equal
-    only if the phasor coordinates lie on the universal circle:
+    only if the phasor coordinates lie on the universal semicircle:
 
     >>> phasor_to_apparent_lifetime(
     ...    0.5, [0.5, 0.45], frequency=80
@@ -922,12 +922,12 @@ def phasor_to_apparent_lifetime(
     (array([1.989, 1.79]), array([1.989, 2.188]))
 
     Apparent single lifetimes of phasor coordinates outside the universal
-    circle are undefined:
+    semicircle are undefined:
 
     >>> phasor_to_apparent_lifetime(-0.1, 1.1, 80)  # doctest: +NUMBER
     (-21.8, 0.0)
 
-    Apparent single lifetimes at the universal circle endpoints are
+    Apparent single lifetimes at the universal semicircle endpoints are
     infinite and zero:
 
     >>> phasor_to_apparent_lifetime([0, 1], [0, 0], 80)  # doctest: +NUMBER
@@ -996,7 +996,7 @@ def phasor_from_apparent_lifetime(
     Examples
     --------
     If the apparent single lifetimes from phase and modulation are equal,
-    the phasor coordinates lie on the universal circle, else inside:
+    the phasor coordinates lie on the universal semicircle, else inside:
 
     >>> phasor_from_apparent_lifetime(
     ...     1.9894, [1.9894, 2.4113], frequency=80.0
@@ -1004,7 +1004,7 @@ def phasor_from_apparent_lifetime(
     (array([0.5, 0.45]), array([0.5, 0.45]))
 
     Zero and infinite apparent single lifetimes define the endpoints of the
-    universal circle:
+    universal semicircle:
 
     >>> phasor_from_apparent_lifetime(
     ...     [0.0, 1e9], [0.0, 1e9], frequency=80
@@ -1289,7 +1289,7 @@ def polar_to_apparent_lifetime(
     Examples
     --------
     The apparent single lifetimes from phase and modulation are equal
-    only if the polar coordinates lie on the universal circle:
+    only if the polar coordinates lie on the universal semicircle:
 
     >>> polar_to_apparent_lifetime(
     ...     math.pi / 4, numpy.hypot([0.5, 0.45], [0.5, 0.45]), frequency=80
@@ -1355,7 +1355,7 @@ def polar_from_apparent_lifetime(
     Examples
     --------
     If the apparent single lifetimes from phase and modulation are equal,
-    the polar coordinates lie on the universal circle, else inside:
+    the polar coordinates lie on the universal semicircle, else inside:
 
     >>> polar_from_apparent_lifetime(
     ...     1.9894, [1.9894, 2.4113], frequency=80.0
@@ -1386,9 +1386,9 @@ def phasor_from_fret_donor(
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """Return phasor coordinates of FRET donor channel.
 
-    Calculate phasor coordinates of a FRET donor channel as a function of
-    frequency, donor lifetime, FRET efficiency, fraction of donors undergoing
-    FRET, and background fluorescence.
+    Calculate phasor coordinates of a FRET (Förster Resonance Energy Transfer)
+    donor channel as a function of frequency, donor lifetime, FRET efficiency,
+    fraction of donors undergoing FRET, and background fluorescence.
 
     The phasor coordinates of the donor channel contain fractions of:
 
@@ -1432,8 +1432,8 @@ def phasor_from_fret_donor(
 
     Examples
     --------
-    Compute a donor channel FRET efficiency trajectory of a FRET donor
-    with 4.2 ns lifetime at 80 MHz:
+    Compute the phasor coordinates of a FRET donor channel at three
+    FRET efficiencies:
 
     >>> phasor_from_fret_donor(
     ...     frequency=80,
@@ -1478,10 +1478,11 @@ def phasor_from_fret_acceptor(
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """Return phasor coordinates of FRET acceptor channel.
 
-    Calculate phasor coordinates of a FRET acceptor channel as a function of
-    frequency, donor and acceptor lifetimes, FRET efficiency,
-    fraction of donors undergoing FRET, fraction of directly excited acceptors,
-    fraction of donor channel in acceptor channel, and background fluorescence.
+    Calculate phasor coordinates of a FRET (Förster Resonance Energy Transfer)
+    acceptor channel as a function of frequency, donor and acceptor lifetimes,
+    FRET efficiency, fraction of donors undergoing FRET, fraction of directly
+    excited acceptors, fraction of donor fluorescence in acceptor channel,
+    and background fluorescence.
 
     The phasor coordinates of the acceptor channel contain fractions of:
 
@@ -1531,8 +1532,8 @@ def phasor_from_fret_acceptor(
 
     Examples
     --------
-    Compute an acceptor channel FRET efficiency trajectory of a FRET donor and
-    acceptor pair with 4.2 ns and 3.0 ns lifetimes at 80 MHz:
+    Compute the phasor coordinates of a FRET acceptor channel at three
+    FRET efficiencies:
 
     >>> phasor_from_fret_acceptor(
     ...     frequency=80,

--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -64,7 +64,7 @@ class PhasorPlot:
     ----------
     allquadrants : bool, optional
         Show all quandrants of phasor space.
-        By default, only the first quadrant with universal semicricle is shown.
+        By default, only the first quadrant with universal semicircle is shown.
     ax : matplotlib axes, optional
         Matplotlib axes used for plotting.
         By default, a new subplot axes is created.
@@ -812,7 +812,8 @@ def plot_phasor(
         By default, only the first quadrant is shown.
     frequency : float, optional
         Frequency of phasor plot.
-        If provided, the universal circle is labeled with reference lifetimes.
+        If provided, the universal semicircle is labeled with reference
+        lifetimes.
     show : bool, optional, default: True
         Display figure.
     **kwargs

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -1134,10 +1134,11 @@ def test_polar_from_apparent_lifetime():
 
 def test_phasor_from_fret_donor():
     """Test phasor_from_fret_donor function."""
+    re, im = phasor_from_lifetime(80, 4.2)
     # no FRET
     assert_allclose(
         phasor_from_fret_donor(80, 4.2, fret_efficiency=0),
-        phasor_from_lifetime(80, 4.2),
+        [re, im],
         atol=1e-3,
     )
     # fret_efficiency
@@ -1153,7 +1154,6 @@ def test_phasor_from_fret_donor():
         atol=1e-3,
     )
     # donor_freting
-    re, im = phasor_from_lifetime(80, 4.2)
     assert_allclose(
         phasor_from_fret_donor(
             80, 4.2, fret_efficiency=[0.0, 0.3, 1.0], donor_freting=0.9

--- a/tutorials/phasorpy_fret.py
+++ b/tutorials/phasorpy_fret.py
@@ -1,0 +1,296 @@
+"""
+FRET calculations
+=================
+
+Calculate phasor coordinates of FRET donor and acceptor channels.
+
+The :py:func:`phasorpy.phasor.phasor_from_fret_donor`
+and :py:func:`phasorpy.phasor.phasor_from_fret_acceptor`
+functions are used to calculate phasor coordinates of
+FRET donor and acceptor channels as a function of
+
+- frequency
+- donor and acceptor lifetimes
+- FRET efficiency
+- fraction of donors undergoing FRET
+- fraction of directly excited acceptors
+- fraction of donor fluorescence in acceptor channel
+- fraction of background fluorescence
+
+"""
+
+# %%
+# Define a utility function to compute and plot phasor coordinates of
+# FRET donor and acceptor channels:
+
+import numpy
+
+from phasorpy.phasor import (
+    phasor_from_fret_acceptor,
+    phasor_from_fret_donor,
+    phasor_from_lifetime,
+)
+from phasorpy.plot import PhasorPlot
+
+
+def plot_fret_trajectories(
+    frequency=60.0,  # MHz
+    donor_lifetime=4.2,  # ns
+    acceptor_lifetime=3.0,  # ns
+    fret_efficiency=numpy.linspace(0.0, 1.0, 101),  # 1% steps
+    *,
+    donor_freting=1.0,
+    donor_bleedthrough=0.0,
+    acceptor_excitation=0.0,
+    acceptor_background=0.0,
+    donor_background=0.0,
+    background_real=0.0,
+    background_imag=0.0,
+    title=None,
+):
+    # phasor of donor channel
+    donor_fret_real, donor_fret_imag = phasor_from_fret_donor(
+        frequency,
+        donor_lifetime,
+        fret_efficiency=fret_efficiency,
+        donor_freting=donor_freting,
+        donor_background=donor_background,
+        background_real=background_real,
+        background_imag=background_imag,
+    )
+
+    # phasor of acceptor channel
+    acceptor_fret_real, acceptor_fret_imag = phasor_from_fret_acceptor(
+        frequency,
+        donor_lifetime,
+        acceptor_lifetime,
+        fret_efficiency=fret_efficiency,
+        donor_freting=donor_freting,
+        donor_bleedthrough=donor_bleedthrough,
+        acceptor_excitation=acceptor_excitation,
+        acceptor_background=acceptor_background,
+        background_real=background_real,
+        background_imag=background_imag,
+    )
+
+    # phasor of donor lifetime
+    donor_real, donor_imag = phasor_from_lifetime(frequency, donor_lifetime)
+
+    # phasor of acceptor lifetime
+    acceptor_real, acceptor_imag = phasor_from_lifetime(
+        frequency, acceptor_lifetime
+    )
+
+    plot = PhasorPlot(
+        title=title,
+        frequency=frequency,
+        xlim=[-0.2, 1.1],
+    )
+    plot.semicircle(phasor_reference=(acceptor_real, acceptor_imag))
+    if donor_background > 0.0:
+        plot.line(
+            [donor_real, background_real],
+            [donor_imag, background_imag],
+        )
+    if acceptor_background > 0.0:
+        plot.line(
+            [acceptor_real, background_real],
+            [acceptor_imag, background_imag],
+        )
+    plot.plot(
+        donor_fret_real,
+        donor_fret_imag,
+        fmt='-',
+        color='tab:green',
+    )
+    plot.plot(
+        acceptor_fret_real,
+        acceptor_fret_imag,
+        fmt='-',
+        color='tab:red',
+    )
+    plot.plot(
+        donor_real,
+        donor_imag,
+        fmt='o',
+        color='tab:green',
+        label='Donor',
+    )
+    plot.plot(
+        acceptor_real,
+        acceptor_imag,
+        fmt='o',
+        color='tab:red',
+        label='Acceptor',
+    )
+    if donor_background > 0.0 or acceptor_background > 0.0:
+        plot.plot(
+            background_real,
+            background_imag,
+            fmt='o',
+            color='black',
+            label='Background',
+        )
+    plot.show()
+
+
+# %%
+# FRET efficiency trajectories
+# ----------------------------
+#
+# The lifetime :math:`\tau_{DA}` and fluorescence intensity :math:`F_{DA}`
+# of a FRET donor quenched by energy transfer of efficiency :math:`E` is given
+# by :math:`\tau_{DA} = \tau_{D} (1 - E)` and :math:`F_{DA} = F_{D} (1 - E)`,
+# where :math:`\tau_{D}` and :math:`F_{D}` are the donor lifetime and
+# intensity in absence of energy transfer.
+#
+# Hence, in the absence of background fluorescence and donors not undergoing
+# energy transfer, the phasor coordinates of the donor channel at different
+# FRET efficiencies lie on the universal circle.
+# At 100% energy transfer, the donor lifetime and fluorescence intensity are
+# zero.
+#
+# The sensitized emission of a FRET acceptor is phase-shifted and demodulated
+# relative to the FRET donor because of the duration of, and dissipation
+# during, relaxation and energy transfer processes.
+# Hence, in the absence of directly excited acceptor, donor bleedthrough,
+# and background fluorescence, the phasor coordinates of the acceptor channel
+# at different FRET efficiencies lie outside the universal circle of the donor.
+
+plot_fret_trajectories(title='FRET efficiency trajectories')
+
+
+# %%
+# Fractions not FRETing
+# ----------------------
+#
+# Adding fractions of donors not participating in FRET, and fractions
+# of directly excited acceptors, pulls the FRET trajectories of the donor
+# and acceptor channels towards the phasor coordinates of the donor and
+# acceptor without FRET.
+
+plot_fret_trajectories(
+    title='FRET efficiency trajectories with fractions not FRETing',
+    donor_freting=0.9,  # 90%
+    acceptor_excitation=0.1,  # 10%
+)
+
+
+# %%
+# Donor bleedthrough
+# ------------------
+#
+# If the acceptor channel contains fractions of donor fluorescence,
+# the FRET efficiency trajectory of the acceptor channel is pulled towards
+# the phasor coordinates of the donor channel.
+
+plot_fret_trajectories(
+    title='FRET efficiency trajectories with donor bleedthrough',
+    donor_bleedthrough=0.1,  # 10%
+)
+
+
+# %%
+# Background fluorescence
+# -----------------------
+#
+# In the presence of background fluorescence, the FRET efficiency trajectories
+# are linear combinations with the background phasor coordinates.
+# At 0% energy transfer, the acceptor channel only contains background
+# fluorescence.
+# At 100% energy transfer, the donor channel only contains background
+# fluorescence.
+
+plot_fret_trajectories(
+    title='FRET efficiency trajectories with background',
+    acceptor_background=0.1,  # 10%
+    donor_background=0.1,  # 10%
+    background_real=0.5,
+    background_imag=0.2,
+)
+
+
+# %%
+# Many parameters
+# ---------------
+#
+# The phasor coordinates of the donor channel may contain fractions of
+#
+# - donor not undergoing energy transfer
+# - donor quenched by energy transfer
+# - background fluorescence
+#
+# The phasor coordinates of the acceptor channel may contain fractions of
+#
+# - acceptor sensitized by energy transfer
+# - directly excited acceptor
+# - donor bleedthrough
+# - background fluorescence
+
+plot_fret_trajectories(
+    title='FRET efficiency trajectories with many parameters',
+    donor_freting=0.9,
+    donor_bleedthrough=0.1,
+    acceptor_excitation=0.1,
+    acceptor_background=0.1,
+    donor_background=0.1,
+    background_real=0.5,
+    background_imag=0.2,
+)
+
+# %%
+# Multi-frequency plot
+# --------------------
+#
+# Since the components of the FRET model have different frequency responses,
+# the multi-frequency plots of donor and acceptor channels may show
+# complex patterns.
+# Background fluorescence is omitted from this example to model an
+# in vitro experiment:
+
+from phasorpy.phasor import phasor_to_polar
+from phasorpy.plot import plot_polar_frequency
+
+frequency = numpy.logspace(0, 4, 64).reshape(-1, 1)  # 1-1000 MHz
+fret_efficiency = numpy.array([0.05, 0.95]).reshape(1, -1)  # 5% and 95%
+donor_lifetime = 4.2  # ns
+acceptor_lifetime = 3.0  # ns
+donor_freting = 0.9  # 90%
+donor_bleedthrough = 0.1  # 10%
+acceptor_excitation = 0.1  # 10%
+
+donor_real, donor_imag = phasor_from_fret_donor(
+    frequency,
+    donor_lifetime,
+    fret_efficiency=fret_efficiency,
+    donor_freting=donor_freting,
+)
+
+# phasor of acceptor channel
+acceptor_real, acceptor_imag = phasor_from_fret_acceptor(
+    frequency,
+    donor_lifetime,
+    acceptor_lifetime,
+    fret_efficiency=fret_efficiency,
+    donor_freting=donor_freting,
+    donor_bleedthrough=donor_bleedthrough,
+    acceptor_excitation=acceptor_excitation,
+)
+
+plot_polar_frequency(
+    frequency,
+    phasor_to_polar(donor_real, donor_imag)[0],
+    phasor_to_polar(donor_real, donor_imag)[1],
+    title='Donor channel',
+)
+
+# %%
+
+plot_polar_frequency(
+    frequency,
+    *phasor_to_polar(acceptor_real, acceptor_imag),
+    title='Acceptor channel',
+)
+
+# %%
+# sphinx_gallery_thumbnail_number = 5

--- a/tutorials/phasorpy_fret.py
+++ b/tutorials/phasorpy_fret.py
@@ -7,9 +7,10 @@ Calculate phasor coordinates of FRET donor and acceptor channels.
 The :py:func:`phasorpy.phasor.phasor_from_fret_donor`
 and :py:func:`phasorpy.phasor.phasor_from_fret_acceptor`
 functions are used to calculate phasor coordinates of
-FRET donor and acceptor channels as a function of
+FRET (Förster Resonance Energy Transfer) donor and acceptor channels
+as a function of:
 
-- frequency
+- laser pulse or modulation frequency
 - donor and acceptor lifetimes
 - FRET efficiency
 - fraction of donors undergoing FRET
@@ -20,8 +21,8 @@ FRET donor and acceptor channels as a function of
 """
 
 # %%
-# Define a utility function to compute and plot phasor coordinates of
-# FRET donor and acceptor channels:
+# Define a helper function to compute and plot phasor coordinates of
+# FRET donor and acceptor channels over a range of FRET efficiencies:
 
 import numpy
 
@@ -37,17 +38,18 @@ def plot_fret_trajectories(
     frequency=60.0,  # MHz
     donor_lifetime=4.2,  # ns
     acceptor_lifetime=3.0,  # ns
-    fret_efficiency=numpy.linspace(0.0, 1.0, 101),  # 1% steps
+    fret_efficiency=numpy.linspace(0.0, 1.0, 101),  # 0%..100%, 1% steps
     *,
-    donor_freting=1.0,
-    donor_bleedthrough=0.0,
-    acceptor_excitation=0.0,
-    acceptor_background=0.0,
-    donor_background=0.0,
+    donor_freting=1.0,  # all donors participating in FRET
+    donor_bleedthrough=0.0,  # no donor fluorescence in acceptor channel
+    acceptor_excitation=0.0,  # no directly excited acceptor
+    acceptor_background=0.0,  # no background in acceptor channel
+    donor_background=0.0,  # no background in donor channel
     background_real=0.0,
     background_imag=0.0,
     title=None,
 ):
+    """Plot phasor coordinates of FRET donor and acceptor channels."""
     # phasor of donor channel
     donor_fret_real, donor_fret_imag = phasor_from_fret_donor(
         frequency,
@@ -146,7 +148,7 @@ def plot_fret_trajectories(
 #
 # Hence, in the absence of background fluorescence and donors not undergoing
 # energy transfer, the phasor coordinates of the donor channel at different
-# FRET efficiencies lie on the universal circle.
+# FRET efficiencies lie on the universal semicircle.
 # At 100% energy transfer, the donor lifetime and fluorescence intensity are
 # zero.
 #
@@ -155,7 +157,8 @@ def plot_fret_trajectories(
 # during, relaxation and energy transfer processes.
 # Hence, in the absence of directly excited acceptor, donor bleedthrough,
 # and background fluorescence, the phasor coordinates of the acceptor channel
-# at different FRET efficiencies lie outside the universal circle of the donor.
+# at different FRET efficiencies lie outside the universal semicircle of
+# the donor.
 
 plot_fret_trajectories(title='FRET efficiency trajectories')
 
@@ -164,10 +167,10 @@ plot_fret_trajectories(title='FRET efficiency trajectories')
 # Fractions not FRETing
 # ----------------------
 #
-# Adding fractions of donors not participating in FRET, and fractions
-# of directly excited acceptors, pulls the FRET trajectories of the donor
+# Adding fractions of donors not participating in FRET and fractions
+# of directly excited acceptors pulls the FRET trajectories of the donor
 # and acceptor channels towards the phasor coordinates of the donor and
-# acceptor without FRET.
+# acceptor without FRET:
 
 plot_fret_trajectories(
     title='FRET efficiency trajectories with fractions not FRETing',
@@ -182,7 +185,7 @@ plot_fret_trajectories(
 #
 # If the acceptor channel contains fractions of donor fluorescence,
 # the FRET efficiency trajectory of the acceptor channel is pulled towards
-# the phasor coordinates of the donor channel.
+# the phasor coordinates of the donor channel:
 
 plot_fret_trajectories(
     title='FRET efficiency trajectories with donor bleedthrough',
@@ -196,10 +199,10 @@ plot_fret_trajectories(
 #
 # In the presence of background fluorescence, the FRET efficiency trajectories
 # are linear combinations with the background phasor coordinates.
-# At 0% energy transfer, the acceptor channel only contains background
-# fluorescence.
 # At 100% energy transfer, the donor channel only contains background
 # fluorescence.
+# At 0% energy transfer, in the absence of donor bleedthrough and directly
+# excited acceptor, the acceptor channel only contains background fluorescence:
 
 plot_fret_trajectories(
     title='FRET efficiency trajectories with background',
@@ -214,13 +217,13 @@ plot_fret_trajectories(
 # Many parameters
 # ---------------
 #
-# The phasor coordinates of the donor channel may contain fractions of
+# The phasor coordinates of the donor channel may contain fractions of:
 #
 # - donor not undergoing energy transfer
 # - donor quenched by energy transfer
 # - background fluorescence
 #
-# The phasor coordinates of the acceptor channel may contain fractions of
+# The phasor coordinates of the acceptor channel may contain fractions of:
 #
 # - acceptor sensitized by energy transfer
 # - directly excited acceptor

--- a/tutorials/phasorpy_phasor_from_lifetime.py
+++ b/tutorials/phasorpy_phasor_from_lifetime.py
@@ -24,7 +24,7 @@ from phasorpy.plot import PhasorPlot, plot_phasor, plot_polar_frequency
 # --------------------------
 #
 # The phasor coordinates of single-component lifetimes are located
-# on the universal circle.
+# on the universal semicircle.
 # For example, 3.9788735 ns and 0.9947183 ns at a frequency of 80 MHz:
 
 lifetime = numpy.array([3.9788735, 0.9947183])

--- a/tutorials/phasorpy_phasorplot.py
+++ b/tutorials/phasorpy_phasorplot.py
@@ -6,8 +6,8 @@ An introduction to plotting phasor coordinates.
 
 The :py:class:`phasorpy.plot.PhasorPlot` class is used to plot phasor
 coordinates as scattered points, lines, 2D histograms, and contours.
-The plots are supplemented with universal circles, polar grids, polar cursors,
-component mixture indicators, and manual annotations.
+The plots are supplemented with universal semicircles, polar grids,
+polar cursors, component mixture indicators, and manual annotations.
 
 """
 
@@ -25,7 +25,7 @@ from phasorpy.plot import PhasorPlot
 # -----------------
 #
 # Create an empty phasor plot, showing the first quadrant and the
-# universal semicricle:
+# universal semicircle:
 
 plot = PhasorPlot()
 plot.show()


### PR DESCRIPTION
## Description

This PR adds two functions to the `phasorpy.phasor` module:

- `phasor_from_fret_donor`: Calculate phasor coordinates of a FRET donor channel as a function of frequency, donor lifetime, FRET efficiency, fraction of donors undergoing FRET, and background fluorescence.
- `phasor_from_fret_acceptor`: Calculate phasor coordinates of a FRET acceptor channel as a function of frequency, donor and acceptor lifetimes, FRET efficiency, fraction of donors undergoing FRET, fraction of directly excited acceptors, fraction of donor channel in acceptor channel, and background fluorescence.

A new tutorial, `phasorpy_fret.py`, is included.

The functionality is inspired by the [SimFCS](https://www.lfd.uci.edu/globals/) FRET calculator and the [vLFD lifetime demo](https://www.cgohlke.com/vlfd_lifetime_demo.png). This implementation does not follow SimFCS, which was found to have several issues. Instead, it is limited to single component FRET donor and acceptor lifetimes. For multi-component lifetimes, it should be possible to linearly combine the phasor coordinates obtained for the single components.

Ideally, the implementation should be tested against a formally derived FRET model. No such model exist to my knowledge.

Implements the FRET calculations proposed in #6.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add phasor_from_fret functions
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
