### PR TITLE
Add interactive FRET phasor plot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,7 @@ pygments_style = 'sphinx'
 napoleon_google_docstring = False
 napoleon_numpy_docstring = True
 todo_include_todos = True
+napoleon_use_param = True
 
 html_theme_options = {
     'logo': {

--- a/src/phasorpy/cli.py
+++ b/src/phasorpy/cli.py
@@ -47,6 +47,29 @@ def fetch(files, hideprogress):
     click.echo(f'Cached at {os.path.commonpath(files)}')
 
 
+@main.command(help='Start interactive FRET phasor plot.')
+@click.option(
+    '--hide',
+    default=False,
+    is_flag=True,
+    type=click.BOOL,
+    help='Do not show interactive plot.',
+)
+def fret(hide):
+    """FRET command group."""
+    from .plot import PhasorPlotFret
+
+    plot = PhasorPlotFret(
+        frequency=60.0,
+        donor_lifetime=4.2,
+        acceptor_lifetime=3.0,
+        fret_efficiency=0.5,
+        interactive=True,
+    )
+    if not hide:
+        plot.show()
+
+
 if __name__ == '__main__':
     import sys
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -147,6 +147,11 @@ def phasor_from_signal(
     imag : ndarray
         Imaginary component of phasor coordinates at `harmonic` along `axis`.
 
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_signal_fft
+    :ref:`sphx_glr_tutorials_benchmarks_phasorpy_phasor_from_signal.py`
+
     Notes
     -----
     Compared to the :py:func:`phasor_from_signal_fft` reference implementation,
@@ -303,6 +308,7 @@ def phasor_from_signal_fft(
         The default is the first harmonic (fundamental frequency).
     fft_func : callable, optional
         A drop-in replacement function for ``numpy.fft.fft``.
+        For example, ``scipy.fft.fft`` or ``mkl_fft._numpy_fft.fft``.
 
     Returns
     -------
@@ -320,6 +326,11 @@ def phasor_from_signal_fft(
     IndexError
         `harmonic` is smaller than 1 or greater than half the samples along
         `axis`.
+
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_signal
+    :ref:`sphx_glr_tutorials_benchmarks_phasorpy_phasor_from_signal.py`
 
     Examples
     --------
@@ -381,21 +392,21 @@ def phasor_from_signal_fft(
 
 
 def phasor_semicircle(
-    samples: int = 33, /
+    samples: int = 101, /
 ) -> tuple[NDArray[numpy.float64], NDArray[numpy.float64]]:
     r"""Return equally spaced phasor coordinates on universal semicircle.
 
     Parameters
     ----------
-    samples : int, optional
-        Number of coordinates to return. The default is 33.
+    samples : int, optional, default: 101
+        Number of coordinates to return.
 
     Returns
     -------
     real : ndarray
-        Real component of phasor coordinates.
+        Real component of semicircle phasor coordinates.
     imag : ndarray
-        Imaginary component of phasor coordinates.
+        Imaginary component of semicircle phasor coordinates.
 
     Raises
     ------
@@ -510,6 +521,13 @@ def phasor_calibrate(
     ValueError
         The array shapes of `real` and `imag`, or `reference_real` and
         `reference_imag` do not match.
+
+    See Also
+    --------
+    phasorpy.phasor.phasor_transform
+    phasorpy.phasor.polar_from_reference_phasor
+    phasorpy.phasor.phasor_center
+    phasorpy.phasor.phasor_from_lifetime
 
     Notes
     -----
@@ -691,6 +709,10 @@ def polar_from_reference_phasor(
     modulation_zero : ndarray
         Radial component of polar coordinates for calibration.
 
+    See Also
+    --------
+    phasorpy.phasor.polar_from_reference
+
     Notes
     -----
     This function performs the following operations:
@@ -748,6 +770,10 @@ def polar_from_reference(
     modulation_zero : ndarray
         Radial component of polar coordinates for calibration.
 
+    See Also
+    --------
+    phasorpy.phasor.polar_from_reference_phasor
+
     Examples
     --------
     >>> polar_from_reference(0.2, 0.4, 0.4, 1.3)
@@ -800,6 +826,10 @@ def phasor_to_polar(
     modulation : ndarray
         Radial component of polar coordinates.
 
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_polar
+
     Examples
     --------
     Calculate polar coordinates from three phasor coordinates:
@@ -835,6 +865,10 @@ def phasor_from_polar(
         Real component of phasor coordinates.
     imag : ndarray
         Imaginary component of phasor coordinates.
+
+    See Also
+    --------
+    phasorpy.phasor.phasor_to_polar
 
     Notes
     -----
@@ -894,6 +928,10 @@ def phasor_to_apparent_lifetime(
         Apparent single lifetime from angular component of phasor coordinates.
     modulation_lifetime : ndarray
         Apparent single lifetime from radial component of phasor coordinates.
+
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_apparent_lifetime
 
     Notes
     -----
@@ -973,6 +1011,10 @@ def phasor_from_apparent_lifetime(
         Real component of phasor coordinates.
     imag : ndarray
         Imaginary component of phasor coordinates.
+
+    See Also
+    --------
+    phasorpy.phasor.phasor_to_apparent_lifetime
 
     Notes
     -----
@@ -1081,14 +1123,14 @@ def phasor_from_lifetime(
 
         \omega &= 2 \pi f
 
-        g_{j} &= a_{j} / (1 + (\omega \tau_{j})^2)
+        g_{j} &= \alpha_{j} / (1 + (\omega \tau_{j})^2)
 
         G &= \sum_{j} g_{j}
 
         S &= \sum_{j} \omega \tau_{j} g_{j}
 
-    The relation between pre-exponential amplitudes :math:`\alpha` and
-    fractional intensities :math:`a` is:
+    The relation between pre-exponential amplitudes :math:`a` and
+    fractional intensities :math:`\alpha` is:
 
     .. math::
         F_{DC} &= \sum_{j} a_{j} \tau_{j}
@@ -1270,6 +1312,10 @@ def polar_to_apparent_lifetime(
     modulation_lifetime : ndarray
         Apparent single lifetime from `modulation`.
 
+    See Also
+    --------
+    phasorpy.phasor.polar_from_apparent_lifetime
+
     Notes
     -----
     The polar coordinates `phase` (:math:`\phi`) and `modulation` (:math:`M`)
@@ -1336,6 +1382,10 @@ def polar_from_apparent_lifetime(
         Angular component of polar coordinates.
     modulation : ndarray
         Radial component of polar coordinates.
+
+    See Also
+    --------
+    phasorpy.phasor.polar_to_apparent_lifetime
 
     Notes
     -----
@@ -1407,13 +1457,15 @@ def phasor_from_fret_donor(
     donor_freting : array_like, optional, default 1
         Fraction of donors participating in FRET. Range [0..1].
     donor_background : array_like, optional, default 0
-        Fraction of background fluorescence in unquenched donor channel.
-        Range [0..1].
+        Weight of background fluorescence in donor channel
+        relative to fluorescence of donor without FRET.
+        A weight of 1 means the fluorescence of background and donor
+        without FRET are equal.
     background_real : array_like, optional, default 0
-        Real component of phasor coordinate of background fluorescence
+        Real component of background fluorescence phasor coordinate
         at `frequency`.
     background_imag : array_like, optional, default 0
-        Imaginary component of phasor coordinate of background fluorescence
+        Imaginary component of background fluorescence phasor coordinate
         at `frequency`.
     unit_conversion : float, optional
         Product of `frequency` and `lifetime` units' prefix factors.
@@ -1430,6 +1482,11 @@ def phasor_from_fret_donor(
     imag : ndarray
         Imaginary component of donor channel phasor coordinates.
 
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_fret_acceptor
+    :ref:`sphx_glr_tutorials_phasorpy_fret.py`
+
     Examples
     --------
     Compute the phasor coordinates of a FRET donor channel at three
@@ -1444,7 +1501,7 @@ def phasor_from_fret_donor(
     ...     background_real=0.11,
     ...     background_imag=0.12,
     ... )  # doctest: +NUMBER
-    (array([0.1759, 0.2716, 0.1447]), array([0.3602, 0.4095, 0.2464]))
+    (array([0.1766, 0.2737, 0.1466]), array([0.3626, 0.4134, 0.2534]))
 
     """
     omega = numpy.array(frequency, dtype=numpy.float64, copy=True)
@@ -1469,7 +1526,7 @@ def phasor_from_fret_acceptor(
     fret_efficiency: ArrayLike = 0.0,
     donor_freting: ArrayLike = 1.0,
     donor_bleedthrough: ArrayLike = 0.0,
-    acceptor_excitation: ArrayLike = 0.0,
+    acceptor_bleedthrough: ArrayLike = 0.0,
     acceptor_background: ArrayLike = 0.0,
     background_real: ArrayLike = 0.0,
     background_imag: ArrayLike = 0.0,
@@ -1504,16 +1561,26 @@ def phasor_from_fret_acceptor(
     donor_freting : array_like, optional, default 1
         Fraction of donors participating in FRET. Range [0..1].
     donor_bleedthrough : array_like, optional, default 0
-        Fraction of donor fluorescence in acceptor channel. Range [0..1].
-    acceptor_excitation : array_like, optional, default 0
-        Fraction of acceptor that is directly excited. Range [0..1].
+        Weight of donor fluorescence in acceptor channel
+        relative to fluorescence of fully sensitized acceptor.
+        A weight of 1 means the fluorescence from donor and fully sensitized
+        acceptor are equal.
+        The background in the donor channel does not bleed through.
+    acceptor_bleedthrough : array_like, optional, default 0
+        Weight of fluorescence from directly excited acceptor
+        relative to fluorescence of fully sensitized acceptor.
+        A weight of 1 means the fluorescence from directly excited acceptor
+        and fully sensitized acceptor are equal.
     acceptor_background : array_like, optional, default 0
-        Fraction of background fluorescence in acceptor channel. Range [0..1].
+        Weight of background fluorescence in acceptor channel
+        relative to fluorescence of fully sensitized acceptor.
+        A weight of 1 means the fluorescence of background and fully
+        sensitized acceptor are equal.
     background_real : array_like, optional, default 0
-        Real component of phasor coordinate of background fluorescence
+        Real component of background fluorescence phasor coordinate
         at `frequency`.
     background_imag : array_like, optional, default 0
-        Imaginary component of phasor coordinate of background fluorescence
+        Imaginary component of background fluorescence phasor coordinate
         at `frequency`.
     unit_conversion : float, optional
         Product of `frequency` and `lifetime` units' prefix factors.
@@ -1530,6 +1597,11 @@ def phasor_from_fret_acceptor(
     imag : ndarray
         Imaginary component of acceptor channel phasor coordinates.
 
+    See Also
+    --------
+    phasorpy.phasor.phasor_from_fret_donor
+    :ref:`sphx_glr_tutorials_phasorpy_fret.py`
+
     Examples
     --------
     Compute the phasor coordinates of a FRET acceptor channel at three
@@ -1542,12 +1614,12 @@ def phasor_from_fret_acceptor(
     ...     fret_efficiency=[0.0, 0.3, 1.0],
     ...     donor_freting=0.9,
     ...     donor_bleedthrough=0.1,
-    ...     acceptor_excitation=0.1,
+    ...     acceptor_bleedthrough=0.1,
     ...     acceptor_background=0.1,
     ...     background_real=0.11,
     ...     background_imag=0.12,
     ... )  # doctest: +NUMBER
-    (array([0.1957, 0.0689, 0.2849]), array([0.319, 0.3116, 0.4261]))
+    (array([0.1996, 0.05772, 0.2867]), array([0.3225, 0.3103, 0.4292]))
 
     """
     omega = numpy.array(frequency, dtype=numpy.float64, copy=True)
@@ -1559,7 +1631,7 @@ def phasor_from_fret_acceptor(
         fret_efficiency,
         donor_freting,
         donor_bleedthrough,
-        acceptor_excitation,
+        acceptor_bleedthrough,
         acceptor_background,
         background_real,
         background_imag,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,3 +28,10 @@ def test_fetch():
     result = runner.invoke(main, ['fetch', 'simfcs.r64'])
     assert result.exit_code == 0
     assert result.output.strip().endswith('simfcs.r64')
+
+
+def test_fret():
+    """Test ``python -m phasorpy fret``."""
+    runner = CliRunner()
+    result = runner.invoke(main, ['fret', '--hide'])
+    assert result.exit_code == 0

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -242,6 +242,8 @@ def test_phasor_semicircle():
     real, imag = phasor_semicircle(3)
     assert_allclose(real, [0, 0.5, 1], atol=1e-6)
     assert_allclose(imag, [0.0, 0.5, 0], atol=1e-6)
+    real, imag = phasor_semicircle()
+    assert len(real) == 101
     with pytest.raises(ValueError):
         phasor_semicircle(0)
 
@@ -1171,7 +1173,7 @@ def test_phasor_from_fret_donor():
             background_real=0.11,
             background_imag=0.12,
         ),
-        [[0.175927, 0.286123, 0.11], [0.360186, 0.417005, 0.12]],
+        [[0.176593, 0.288569, 0.11], [0.362612, 0.42113, 0.12]],
         atol=1e-3,
     )
     # complex
@@ -1185,7 +1187,7 @@ def test_phasor_from_fret_donor():
             background_real=0.11,
             background_imag=0.12,
         ),
-        [[0.175927, 0.271566, 0.144698], [0.360186, 0.409499, 0.246414]],
+        [[0.176593, 0.273729, 0.146626], [0.362612, 0.413374, 0.253437]],
         atol=1e-3,
     )
 
@@ -1213,16 +1215,16 @@ def test_phasor_from_fret_acceptor():
         [[0.182643, -0.117851], [0.615661, 0.286433]],
         atol=1e-3,
     )
-    # acceptor_excitation
+    # acceptor_bleedthrough
     assert_allclose(
         phasor_from_fret_acceptor(
             80,
             4.2,
             3.0,
             fret_efficiency=[0.0, 0.3, 1.0],
-            acceptor_excitation=0.1,
+            acceptor_bleedthrough=0.1,
         ),
-        [[re, -0.003448, re], [im, 0.333503, im]],
+        [[re, -0.012028, re], [im, 0.329973, im]],
         atol=1e-3,
     )
     # donor_bleedthrough
@@ -1235,7 +1237,7 @@ def test_phasor_from_fret_acceptor():
             fret_efficiency=[0.0, 0.3, 1.0],
             donor_bleedthrough=0.1,
         ),
-        [[dre, -0.028924, re], [dim, 0.323021, im]],
+        [[dre, -0.036135, re], [dim, 0.320055, im]],
         atol=1e-3,
     )
     # donor_fretting
@@ -1248,7 +1250,7 @@ def test_phasor_from_fret_acceptor():
             donor_bleedthrough=0.1,
             donor_freting=0.9,
         ),
-        [[dre, -0.02221, 0.303951], [dim, 0.325042, 0.459695]],
+        [[dre, -0.02974, 0.3041], [dim, 0.322, 0.4598]],
         atol=1e-3,
     )
     # background
@@ -1262,7 +1264,7 @@ def test_phasor_from_fret_acceptor():
             background_real=0.11,
             background_imag=0.12,
         ),
-        [[0.11, -0.05627, 0.285897], [0.12, 0.241451, 0.426534]],
+        [[0.11, -0.060888, 0.287673], [0.12, 0.244825, 0.429631]],
         atol=1e-3,
     )
     # complex
@@ -1274,11 +1276,11 @@ def test_phasor_from_fret_acceptor():
             fret_efficiency=[0.0, 0.3, 1.0],
             donor_freting=0.9,
             donor_bleedthrough=0.1,
-            acceptor_excitation=0.1,
+            acceptor_bleedthrough=0.1,
             acceptor_background=0.1,
             background_real=0.11,
             background_imag=0.12,
         ),
-        [[0.195675, 0.068898, 0.28487], [0.319027, 0.311553, 0.426138]],
+        [[0.199564, 0.057723, 0.286733], [0.322489, 0.310325, 0.429246]],
         atol=1e-3,
     )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -9,6 +9,7 @@ from matplotlib import pyplot
 
 from phasorpy.plot import (
     PhasorPlot,
+    PhasorPlotFret,
     plot_phasor,
     plot_phasor_image,
     plot_polar_frequency,
@@ -48,6 +49,14 @@ class TestPhasorPlot:
         plot = PhasorPlot(ax=ax, title='axes')
         assert plot.ax == ax
         assert plot.fig == fig
+        self.show(plot)
+
+    def test_on_format_coord(self):
+        """Test on_format_coord callback."""
+        plot = PhasorPlot(frequency=80.0, title='on_format_coord')
+        coords = plot._on_format_coord(0.5, 0.5)
+        assert '0.5' in coords
+        assert 'ns' in coords
         self.show(plot)
 
     def test_save(self):
@@ -206,6 +215,52 @@ class TestPhasorPlot:
         plot = PhasorPlot(title='limits', xlim=(0.4, 0.6), ylim=(0.4, 0.6))
         plot.semicircle(frequency=80.0)
         self.show(plot)
+
+        plot = PhasorPlot(grid=False, title='use_lines')
+        plot.semicircle(frequency=80, use_lines=True)
+        self.show(plot)
+
+
+def test_fret_phasorplot():
+    """Test PhasorPlotFret."""
+    plot = PhasorPlotFret(
+        frequency=60.0,
+        donor_lifetime=4.2,
+        acceptor_lifetime=3.0,
+        fret_efficiency=0.5,
+        donor_freting=0.9,
+        donor_bleedthrough=0.1,
+        title='PhasorPlotFret',
+    )
+    if INTERACTIVE:
+        plot.show()
+    pyplot.close()
+
+
+def test_fret_phasorplot_interactive():
+    """Test PhasorPlotFret interactive."""
+    plot = PhasorPlotFret(
+        frequency=60.0,
+        donor_lifetime=4.2,
+        acceptor_lifetime=3.0,
+        fret_efficiency=0.5,
+        donor_background=0.1,
+        acceptor_background=0.1,
+        interactive=True,
+        title='PhasorPlotFret interactive',
+    )
+    plot._frequency_slider.set_val(80.0)
+    plot._donor_freting_slider.set_val(0.9)
+    plot._donor_bleedthrough_slider.set_val(0.1)
+    plot._donor_bleedthrough_slider.set_val(0.0)
+    plot._donor_background_slider.set_val(0.1)
+    plot._acceptor_background_slider.set_val(0.1)
+    plot._donor_background_slider.set_val(0.0)
+    plot._acceptor_background_slider.set_val(0.0)
+    plot._donor_freting_slider.set_val(0.0)
+    if INTERACTIVE:
+        plot.show()
+    pyplot.close()
 
 
 def test_plot_phasor():

--- a/tutorials/phasorpy_fret.py
+++ b/tutorials/phasorpy_fret.py
@@ -1,12 +1,13 @@
 """
-FRET calculations
-=================
+Förster Resonance Energy Transfer
+=================================
 
-Calculate phasor coordinates of FRET donor and acceptor channels.
+Calculate and plot phasor coordinates of FRET donor and acceptor channels.
 
-The :py:func:`phasorpy.phasor.phasor_from_fret_donor`
-and :py:func:`phasorpy.phasor.phasor_from_fret_acceptor`
-functions are used to calculate phasor coordinates of
+The :py:func:`phasorpy.phasor.phasor_from_fret_donor`,
+:py:func:`phasorpy.phasor.phasor_from_fret_acceptor`, and
+:py:class:`phasorpy.plot.PhasorPlotFret` functions and classes
+are used to calculate and plot phasor coordinates of
 FRET (Förster Resonance Energy Transfer) donor and acceptor channels
 as a function of:
 
@@ -14,126 +15,21 @@ as a function of:
 - donor and acceptor lifetimes
 - FRET efficiency
 - fraction of donors undergoing FRET
-- fraction of directly excited acceptors
-- fraction of donor fluorescence in acceptor channel
+- fraction of directly excited acceptors (acceptor bleedthrough)
+- fraction of donor fluorescence in acceptor channel (donor bleedthrough)
 - fraction of background fluorescence
 
 """
 
 # %%
-# Define a helper function to compute and plot phasor coordinates of
-# FRET donor and acceptor channels over a range of FRET efficiencies:
+# Define FRET model settings used throughout this tutorial:
 
-import numpy
-
-from phasorpy.phasor import (
-    phasor_from_fret_acceptor,
-    phasor_from_fret_donor,
-    phasor_from_lifetime,
-)
-from phasorpy.plot import PhasorPlot
-
-
-def plot_fret_trajectories(
-    frequency=60.0,  # MHz
-    donor_lifetime=4.2,  # ns
-    acceptor_lifetime=3.0,  # ns
-    fret_efficiency=numpy.linspace(0.0, 1.0, 101),  # 0%..100%, 1% steps
-    *,
-    donor_freting=1.0,  # all donors participating in FRET
-    donor_bleedthrough=0.0,  # no donor fluorescence in acceptor channel
-    acceptor_excitation=0.0,  # no directly excited acceptor
-    acceptor_background=0.0,  # no background in acceptor channel
-    donor_background=0.0,  # no background in donor channel
-    background_real=0.0,
-    background_imag=0.0,
-    title=None,
-):
-    """Plot phasor coordinates of FRET donor and acceptor channels."""
-    # phasor of donor channel
-    donor_fret_real, donor_fret_imag = phasor_from_fret_donor(
-        frequency,
-        donor_lifetime,
-        fret_efficiency=fret_efficiency,
-        donor_freting=donor_freting,
-        donor_background=donor_background,
-        background_real=background_real,
-        background_imag=background_imag,
-    )
-
-    # phasor of acceptor channel
-    acceptor_fret_real, acceptor_fret_imag = phasor_from_fret_acceptor(
-        frequency,
-        donor_lifetime,
-        acceptor_lifetime,
-        fret_efficiency=fret_efficiency,
-        donor_freting=donor_freting,
-        donor_bleedthrough=donor_bleedthrough,
-        acceptor_excitation=acceptor_excitation,
-        acceptor_background=acceptor_background,
-        background_real=background_real,
-        background_imag=background_imag,
-    )
-
-    # phasor of donor lifetime
-    donor_real, donor_imag = phasor_from_lifetime(frequency, donor_lifetime)
-
-    # phasor of acceptor lifetime
-    acceptor_real, acceptor_imag = phasor_from_lifetime(
-        frequency, acceptor_lifetime
-    )
-
-    plot = PhasorPlot(
-        title=title,
-        frequency=frequency,
-        xlim=[-0.2, 1.1],
-    )
-    plot.semicircle(phasor_reference=(acceptor_real, acceptor_imag))
-    if donor_background > 0.0:
-        plot.line(
-            [donor_real, background_real],
-            [donor_imag, background_imag],
-        )
-    if acceptor_background > 0.0:
-        plot.line(
-            [acceptor_real, background_real],
-            [acceptor_imag, background_imag],
-        )
-    plot.plot(
-        donor_fret_real,
-        donor_fret_imag,
-        fmt='-',
-        color='tab:green',
-    )
-    plot.plot(
-        acceptor_fret_real,
-        acceptor_fret_imag,
-        fmt='-',
-        color='tab:red',
-    )
-    plot.plot(
-        donor_real,
-        donor_imag,
-        fmt='o',
-        color='tab:green',
-        label='Donor',
-    )
-    plot.plot(
-        acceptor_real,
-        acceptor_imag,
-        fmt='o',
-        color='tab:red',
-        label='Acceptor',
-    )
-    if donor_background > 0.0 or acceptor_background > 0.0:
-        plot.plot(
-            background_real,
-            background_imag,
-            fmt='o',
-            color='black',
-            label='Background',
-        )
-    plot.show()
+settings = {
+    'frequency': 60.0,  # MHz
+    'donor_lifetime': 4.2,  # ns
+    'acceptor_lifetime': 3.0,  # ns
+    'fret_efficiency': 0.5,  # 50%
+}
 
 
 # %%
@@ -160,7 +56,12 @@ def plot_fret_trajectories(
 # at different FRET efficiencies lie outside the universal semicircle of
 # the donor.
 
-plot_fret_trajectories(title='FRET efficiency trajectories')
+from phasorpy.plot import PhasorPlotFret
+
+PhasorPlotFret(
+    **settings,
+    title='FRET efficiency trajectories',
+).show()
 
 
 # %%
@@ -168,29 +69,31 @@ plot_fret_trajectories(title='FRET efficiency trajectories')
 # ----------------------
 #
 # Adding fractions of donors not participating in FRET and fractions
-# of directly excited acceptors pulls the FRET trajectories of the donor
-# and acceptor channels towards the phasor coordinates of the donor and
-# acceptor without FRET:
+# of directly excited acceptors (acceptor bleedthrough) pulls the
+# FRET trajectories of the donor and acceptor channels towards the
+# phasor coordinates of the donor and acceptor without FRET:
 
-plot_fret_trajectories(
-    title='FRET efficiency trajectories with fractions not FRETing',
+PhasorPlotFret(
+    **settings,
     donor_freting=0.9,  # 90%
-    acceptor_excitation=0.1,  # 10%
-)
+    acceptor_bleedthrough=0.1,  # 10%
+    title='FRET efficiency trajectories with fractions not FRETing',
+).show()
 
 
 # %%
 # Donor bleedthrough
 # ------------------
 #
-# If the acceptor channel contains fractions of donor fluorescence,
-# the FRET efficiency trajectory of the acceptor channel is pulled towards
-# the phasor coordinates of the donor channel:
+# If the acceptor channel contains fractions of donor fluorescence
+# (donor bleedthrough), the FRET efficiency trajectory of the acceptor
+# channel is pulled towards the phasor coordinates of the donor channel:
 
-plot_fret_trajectories(
-    title='FRET efficiency trajectories with donor bleedthrough',
+PhasorPlotFret(
+    **settings,
     donor_bleedthrough=0.1,  # 10%
-)
+    title='FRET efficiency trajectories with donor bleedthrough',
+).show()
 
 
 # %%
@@ -200,17 +103,19 @@ plot_fret_trajectories(
 # In the presence of background fluorescence, the FRET efficiency trajectories
 # are linear combinations with the background phasor coordinates.
 # At 100% energy transfer, the donor channel only contains background
-# fluorescence.
+# fluorescence if all donors participate in FRET.
 # At 0% energy transfer, in the absence of donor bleedthrough and directly
 # excited acceptor, the acceptor channel only contains background fluorescence:
 
-plot_fret_trajectories(
-    title='FRET efficiency trajectories with background',
+PhasorPlotFret(
+    **settings,
+    donor_freting=1.0,
     acceptor_background=0.1,  # 10%
     donor_background=0.1,  # 10%
     background_real=0.5,
     background_imag=0.2,
-)
+    title='FRET efficiency trajectories with background',
+).show()
 
 
 # %%
@@ -230,16 +135,37 @@ plot_fret_trajectories(
 # - donor bleedthrough
 # - background fluorescence
 
-plot_fret_trajectories(
-    title='FRET efficiency trajectories with many parameters',
+PhasorPlotFret(
+    **settings,
     donor_freting=0.9,
     donor_bleedthrough=0.1,
-    acceptor_excitation=0.1,
+    acceptor_bleedthrough=0.1,
     acceptor_background=0.1,
     donor_background=0.1,
     background_real=0.5,
     background_imag=0.2,
-)
+    title='FRET efficiency trajectories with many parameters',
+).show()
+
+
+# %%
+# Interactive plot
+# ----------------
+#
+# Run the FRET phasor plot interactively::
+#
+#     $ python -m phasorpy fret
+#
+# or
+
+PhasorPlotFret(
+    **settings,
+    donor_freting=0.9,
+    donor_bleedthrough=0.1,
+    interactive=True,
+    title='Interactive FRET phasor plot',
+).show()
+
 
 # %%
 # Multi-frequency plot
@@ -251,16 +177,22 @@ plot_fret_trajectories(
 # Background fluorescence is omitted from this example to model an
 # in vitro experiment:
 
-from phasorpy.phasor import phasor_to_polar
+import numpy
+
+from phasorpy.phasor import (
+    phasor_from_fret_acceptor,
+    phasor_from_fret_donor,
+    phasor_to_polar,
+)
 from phasorpy.plot import plot_polar_frequency
 
-frequency = numpy.logspace(0, 4, 64).reshape(-1, 1)  # 1-1000 MHz
+frequency = numpy.logspace(0, 4, 64).reshape(-1, 1)  # 1-10000 MHz
 fret_efficiency = numpy.array([0.05, 0.95]).reshape(1, -1)  # 5% and 95%
-donor_lifetime = 4.2  # ns
-acceptor_lifetime = 3.0  # ns
-donor_freting = 0.9  # 90%
-donor_bleedthrough = 0.1  # 10%
-acceptor_excitation = 0.1  # 10%
+donor_lifetime = 4.2
+acceptor_lifetime = 3.0
+donor_freting = 0.9
+donor_bleedthrough = 0.1
+acceptor_bleedthrough = 0.1
 
 donor_real, donor_imag = phasor_from_fret_donor(
     frequency,
@@ -277,7 +209,7 @@ acceptor_real, acceptor_imag = phasor_from_fret_acceptor(
     fret_efficiency=fret_efficiency,
     donor_freting=donor_freting,
     donor_bleedthrough=donor_bleedthrough,
-    acceptor_excitation=acceptor_excitation,
+    acceptor_bleedthrough=acceptor_bleedthrough,
 )
 
 plot_polar_frequency(
@@ -295,5 +227,7 @@ plot_polar_frequency(
     title='Acceptor channel',
 )
 
+
 # %%
 # sphinx_gallery_thumbnail_number = 5
+# mypy: disable-error-code="arg-type"


### PR DESCRIPTION
## Description

This PR proposes the following changes:

- add a `PhasorPlotFret` class, which plots FRET efficiency trajectories of donor and acceptor channels in phasor space. The class can be run in interactive mode, using matplotlib slider widgets to control FRET model parameters.

- add a command line option to run `PhasorPlotFret` in interactive mode: `python -m phasorpy fret`

- simplify the `phasorpy_fret.py` tutorial using `PhasorPlotFret`. Mark the actual phasor coordinates of the donor and acceptor channels.

- add a mouse cursor callback function to `PhasorPlot`, which displays (in the matplotlib toolbar) polar coordinates and apparent lifetimes (if possible) in addition to phasor coordinates.

- rename `acceptor_excitation` to `acceptor_bleedthrough`.

- change the definition of `donor_bleedthrough`, `acceptor_excitation`, `acceptor_background`, and `donor_background` of the FRET model to weights relative to the fluorescence of the acceptor at 100% energy transfer respectively donor at 0% energy transfer.

- add some cross references to docstrings.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add interactive FRET phasor plot
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
