### PR TITLE
Add PhasorPlot.cursor method

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -488,6 +488,55 @@ class PhasorPlot:
         )
         self._ax.add_patch(Circle((real, imag), radius, **kwargs))
 
+    def cursor(
+        self,
+        real: float,
+        imag: float,
+        /,
+        real_limit: float | None = None,
+        imag_limit: float | None = None,
+        radius: float | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Plot phase and modulation grid lines and arcs at phasor coordinates.
+
+        Parameters
+        ----------
+        real : float
+            Real component of phasor coordinate.
+        imag : float
+            Imaginary component of phasor coordinate.
+        real_limit : float, optional
+            Real component of limiting phasor coordinate.
+        imag_limit : float, optional
+            Imaginary component of limiting phasor coordinate.
+        radius : float, optional
+            Radius of circle limiting phase and modulation grid lines and arcs.
+        **kwargs
+            Additional parameters passed to
+            :py:class:`matplotlib.lines.Line2D`,
+            :py:class:`matplotlib.patches.Circle`, and
+            :py:class:`matplotlib.patches.Arc`.
+
+        See Also
+        --------
+        phasorpy.plot.PhasorPlot.polar_cursor
+
+        """
+        if real_limit is not None and imag_limit is not None:
+            return self.polar_cursor(
+                *phasor_to_polar_scalar(real, imag),
+                *phasor_to_polar_scalar(real_limit, imag_limit),
+                radius=radius,
+                **kwargs,
+            )
+        return self.polar_cursor(
+            *phasor_to_polar_scalar(real, imag),
+            radius=radius,
+            # _circle_only=True,
+            **kwargs,
+        )
+
     def polar_cursor(
         self,
         phase: float | None = None,
@@ -519,6 +568,10 @@ class PhasorPlot:
             :py:class:`matplotlib.patches.Circle`, and
             :py:class:`matplotlib.patches.Arc`.
 
+        See Also
+        --------
+        phasorpy.plot.PhasorPlot.cursor
+
         """
         update_kwargs(
             kwargs,
@@ -527,11 +580,14 @@ class PhasorPlot:
             linewidth=GRID_LINEWIDH,
             fill=GRID_FILL,
         )
+        _circle_only = kwargs.pop('_circle_only', False)
         ax = self._ax
         if radius is not None and phase is not None and modulation is not None:
             x = modulation * math.cos(phase)
             y = modulation * math.sin(phase)
             ax.add_patch(Circle((x, y), radius, **kwargs))
+            if _circle_only:
+                return
             del kwargs['fill']
             p0, p1 = circle_line_intersection(x, y, radius, 0, 0, x, y)
             ax.add_line(Line2D((p0[0], p1[0]), (p0[1], p1[1]), **kwargs))
@@ -541,8 +597,8 @@ class PhasorPlot:
                     (0, 0),
                     modulation * 2,
                     modulation * 2,
-                    theta1=math.degrees(math.atan(p0[1] / p0[0])),
-                    theta2=math.degrees(math.atan(p1[1] / p1[0])),
+                    theta1=math.degrees(math.atan2(p0[1], p0[0])),
+                    theta2=math.degrees(math.atan2(p1[1], p1[0])),
                     fill=False,
                     **kwargs,
                 )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -153,15 +153,46 @@ class TestPhasorPlot:
         plot.circle(0.5, 0.2, 0.1, color='tab:red', linestyle='-')
         self.show(plot)
 
-    @pytest.mark.parametrize('allquadrants', (True, False))
-    def test_polar_cursor(self, allquadrants):
+    def test_cursor(self):
+        """Test cursor method."""
+        plot = PhasorPlot(title='cursor')
+        plot.cursor(0.4, 0.3, color='tab:blue', linestyle='-')
+        plot.cursor(0.52, 0.3, 0.78, 0.16, color='tab:orange')
+        plot.cursor(0.9, 0.3, radius=0.05, color='tab:green')
+        self.show(plot)
+
+    def test_cursor_allquadrants(self):
+        """Test cursor method with allquadrants."""
+        plot = PhasorPlot(title='cursor allquadrants', allquadrants=True)
+        plot.cursor(-0.4, -0.3, color='tab:blue', linestyle='-')
+        plot.cursor(-0.52, -0.3, -0.78, -0.16, color='tab:orange')
+        plot.cursor(-0.9, -0.3, radius=0.1, color='tab:green')
+        self.show(plot)
+
+    def test_polar_cursor(self):
         """Test polar_cursor method."""
-        plot = PhasorPlot(title='polar_cursor', allquadrants=allquadrants)
+        plot = PhasorPlot(title='polar_cursor')
         plot.polar_cursor()
         plot.polar_cursor(0.6435, 0.5, color='tab:blue', linestyle='-')
         plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8, color='tab:orange')
         plot.polar_cursor(0.3233, 0.9482, radius=0.05, color='tab:green')
         plot.polar_cursor(0.3, color='tab:red', linestyle='--')
+        self.show(plot)
+
+    def test_polar_cursor_allquadrants(self):
+        """Test polar_cursor method with allquadrants."""
+        plot = PhasorPlot(title='polar_cursor allquadrants', allquadrants=True)
+        plot.polar_cursor()
+        plot.polar_cursor(
+            0.6435 + math.pi, 0.5, color='tab:blue', linestyle='-'
+        )
+        plot.polar_cursor(
+            0.5236 + math.pi, 0.6, 0.1963 + math.pi, 0.8, color='tab:orange'
+        )
+        plot.polar_cursor(
+            0.3233 + math.pi, 0.9482, radius=0.1, color='tab:green'
+        )
+        plot.polar_cursor(0.3 + math.pi, color='tab:red', linestyle='--')
         self.show(plot)
 
     def test_polar_grid(self):

--- a/tutorials/phasorpy_phasorplot.py
+++ b/tutorials/phasorpy_phasorplot.py
@@ -53,16 +53,27 @@ plot.plot([0.2, 0.9], [0.4, 0.3], '.-', label='2')
 plot.plot([0.39, 0.4, 0.41], [0.21, 0.19, 0.2], 'x', label='3')
 plot.show()
 
+
 # %%
-# Polar cursors
-# -------------
+# Cursors
+# -------
 #
-# Point out certain polar coordinates, and ranges thereof:
+# Point out certain polar coordinates, and ranges thereof,
+# using phasor coordinates:
+
+plot = PhasorPlot(frequency=80.0, title='Cursors')
+plot.cursor(0.4, 0.3)
+plot.cursor(0.5, 0.3, 0.8, 0.15)
+plot.cursor(0.9, 0.3, radius=0.05)
+plot.show()
+
+# %%
+# Alternatively, use polar coordinates:
 
 plot = PhasorPlot(frequency=80.0, title='Polar cursors')
-plot.polar_cursor(0.6435, 0.5)
-plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8)
-plot.polar_cursor(0.3233, 0.9482, radius=0.05)
+plot.polar_cursor(0.6435, 0.5, linestyle='-')
+plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8, linewidth=2)
+plot.polar_cursor(0.3233, 0.9482, radius=0.05, color='tab:red')
 plot.show()
 
 # %%
@@ -132,10 +143,8 @@ plot.contour(real, imag, bins=48, levels=3, cmap='summer_r', norm='log')
 plot.hist2d(real2, imag2, bins=64, cmap='Oranges')
 plot.plot(0.6, 0.4, '.', color='tab:blue')
 plot.plot(0.9, 0.2, '.', color='tab:orange')
-plot.polar_cursor(math.atan(0.4 / 0.6), math.hypot(0.6, 0.4), color='tab:blue')
-plot.polar_cursor(
-    math.atan(0.2 / 0.9), math.hypot(0.9, 0.2), color='tab:orange'
-)
+plot.cursor(0.9, 0.2, color='tab:orange')
+plot.polar_cursor(math.atan2(0.4, 0.6), math.hypot(0.6, 0.4), color='tab:blue')
 plot.semicircle(frequency=80.0, color='tab:purple')
 plot.show()
 
@@ -182,4 +191,4 @@ from phasorpy.plot import plot_phasor
 plot_phasor(real[0, :32], imag[0, :32], fmt='.', frequency=80.0)
 
 # %%
-# sphinx_gallery_thumbnail_number = 9
+# sphinx_gallery_thumbnail_number = 10


### PR DESCRIPTION
## Description

This PR adds a `cursor` method to the `PhasorPlot` class. It's a simple convenience wrapper of `PhasorPlot.polar_cursor()`, accepting phasor coordinates instead of polar coordinates.

Also fixes a bug in the `PhasorPlot.polar_cursor` method drawing circles in the third quadrant, found in #48.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add PhasorPlot.cursor method
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
