### PR TITLE
Add functions to convert optimal frequency and lifetime

### DIFF
--- a/docs/phasor_approach.rst
+++ b/docs/phasor_approach.rst
@@ -63,49 +63,75 @@ Talks
 Articles
 --------
 
-- Vallmitjana A, Lepanto P, Irigoin F, Malacrida L.
+-
+  .. _vallmitjana-2022:
+
+  Vallmitjana A, Lepanto P, Irigoin F, Malacrida L.
   `Phasor-based multi-harmonic unmixing for in-vivo hyperspectral imaging
   <https://doi.org/10.1088/2050-6120/ac9ae9>`_.
   *Methods Appl Fluoresc*. 11(1): 014001 (2022)
 
-- Torrado B, Malacrida L, Ranjit S.
+-
+  .. _torrado-2022:
+
+  Torrado B, Malacrida L, Ranjit S.
   `Linear combination properties of the phasor space in fluorescence imaging
   <https://doi.org/10.3390/s22030999>`_.
   *Sensors*. 22(3): 999 (2022)
 
+-
   .. _malacrida-2021:
-- Malacrida L, Ranjit S, Jameson DM, Gratton E.
+
+  Malacrida L, Ranjit S, Jameson DM, Gratton E.
   `The phasor plot: a universal circle to advance fluorescence lifetime
   analysis and interpretation
   <https://doi.org/10.1146/annurev-biophys-062920-063631>`_.
   *Annu Rev Biophys*. 50:575-593 (2021)
 
-- Ranjit S, Malacrida L, Jameson DM, Gratton E.
+-
+  .. _ranjit-2018:
+
+  Ranjit S, Malacrida L, Jameson DM, Gratton E.
   `Fit-free analysis of fluorescence lifetime imaging data using the phasor
   approach <https://doi.org/10.1038/s41596-018-0026-5>`_.
   *Nat Protoc*. 13(9): 1979-2004 (2018)
 
-- Malacrida L, Jameson DM, Gratton E.
+-
+  .. _malacrida-2017:
+
+  Malacrida L, Jameson DM, Gratton E.
   `A multidimensional phasor approach reveals LAURDAN photophysics in NIH-3T3
   cell membranes <https://doi.org/10.1038/s41598-017-08564-z>`_.
   *Sci Rep*. 7(1): 9215 (2017)
 
-- Fereidouni F, Bader AN, Gerritsen HC.
+-
+  .. _fereidouni-2012:
+
+  Fereidouni F, Bader AN, Gerritsen HC.
   `Spectral phasor analysis allows rapid and reliable unmixing of fluorescence
   microscopy spectral images <https://doi.org/10.1364/OE.20.012729>`_.
   *Opt Express*. 20(12): 12729-41 (2012)
 
-- Digman MA, Caiolfa VR, Zamai M, Gratton E.
+-
+  .. _digman-2008:
+
+  Digman MA, Caiolfa VR, Zamai M, Gratton E.
   `The phasor approach to fluorescence lifetime imaging analysis
   <https://doi.org/10.1529/biophysj.107.120154>`_.
   *Biophys J*. 94(2): L14-16 (2008)
 
-- Redford GI, Clegg RM.
+-
+  .. _redford-clegg-2005:
+
+  Redford GI, Clegg RM.
   `Polar plot representation for frequency-domain analysis of fluorescence
   lifetimes <https://doi.org/10.1007/s10895-005-2990-8>`_.
   *J Fluoresc*. 15(5): 805-15 (2005)
 
-- Clayton AHA, Hanley QS, Verveer PJ.
+-
+  .. _clayton-2004:
+
+  Clayton AHA, Hanley QS, Verveer PJ.
   `Graphical representation and multicomponent analysis of single-frequency
   fluorescence lifetime imaging microscopy data
   <https://doi.org/10.1111/j.1365-2818.2004.01265.x>`_.
@@ -117,7 +143,10 @@ Software
 Besides the PhasorPy library, several other software implemented the phasor
 approach to analyze fluorescence time-resolved or spectral images:
 
-- `Globals for Images · SimFCS <https://www.lfd.uci.edu/globals/>`_
+-
+  .. _simfcs:
+
+  `Globals for Images · SimFCS <https://www.lfd.uci.edu/globals/>`_
   is a free, closed-source, Windows desktop application for fluorescence image
   analysis, visualization, simulation, and acquisition.
   The software was developed by Enrico Gratton during 1998-2022 at the

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1094,7 +1094,8 @@ def frequency_from_lifetime(
     Notes
     -----
     The optimal frequency :math:`f` to resolve a single component lifetime
-    :math:`\tau` is:
+    :math:`\tau` is
+    (:ref:`Redford & Clegg 2005 <redford-clegg-2005>`. Eq. B.6):
 
     .. math::
 
@@ -1139,7 +1140,8 @@ def frequency_to_lifetime(
 
     Notes
     -----
-    The lifetime :math:`\tau` that is best resolved at frequency :math:`f` is:
+    The lifetime :math:`\tau` that is best resolved at frequency :math:`f` is
+    (:ref:`Redford & Clegg 2005 <redford-clegg-2005>`. Eq. B.6):
 
     .. math::
 

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -22,6 +22,8 @@ except ImportError:
     mkl_fft = None
 
 from phasorpy.phasor import (
+    frequency_from_lifetime,
+    frequency_to_lifetime,
     phasor_calibrate,
     phasor_center,
     phasor_from_apparent_lifetime,
@@ -1283,4 +1285,22 @@ def test_phasor_from_fret_acceptor():
         ),
         [[0.199564, 0.057723, 0.286733], [0.322489, 0.310325, 0.429246]],
         atol=1e-3,
+    )
+
+
+def test_frequency_from_lifetime():
+    """Test frequency_from_lifetime function."""
+    assert isinstance(frequency_from_lifetime(1.0), float)
+    assert frequency_from_lifetime(1.0) == pytest.approx(186.015665)
+    assert_allclose(
+        frequency_from_lifetime([4.0, 1.0]), [46.503916, 186.015665], atol=1e-3
+    )
+
+
+def test_frequency_to_lifetime():
+    """Test frequency_to_lifetime function."""
+    assert isinstance(frequency_to_lifetime(186.015665), float)
+    assert frequency_to_lifetime(186.015665) == pytest.approx(1.0)
+    assert_allclose(
+        frequency_to_lifetime([46.503916, 186.015665]), [4.0, 1.0], atol=1e-3
     )


### PR DESCRIPTION
## Description

This PR adds two utility functions to the `phasor` module:

- `frequency_from_lifetime`: Return optimal frequency for resolving single component lifetime.
- `frequency_to_lifetime`: Return single component lifetime best resolved at frequency.

I added the functions to the `phasor` module for now since we plan to move a bunch of functions from this module into a `lifetime` module or a flat namespace...

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add functions to convert optimal frequency and lifetime
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
