### PR TITLE
Add functions to convert between lifetime fractions and amplitudes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ else:
 
 ext_modules = [
     Extension(
-        'phasorpy._phasor',
-        ['src/phasorpy/_phasor.pyx'],
+        'phasorpy._phasorpy',
+        ['src/phasorpy/_phasorpy.pyx'],
         include_dirs=[numpy.get_include()],
         extra_compile_args=extra_compile_args,
         extra_link_args=extra_link_args,

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -784,27 +784,3 @@ cdef (double, double) _polar_from_reference_phasor(
     if fabs(measured_modulation) == 0.0:
         return known_phase - measured_phase, INFINITY
     return known_phase - measured_phase, known_modulation / measured_modulation
-
-
-@cython.ufunc
-cdef float_t _fractional_intensity_to_preexponential_amplitude(
-    float_t fractional_intensity,
-    float_t lifetime,
-    float_t mean,
-) noexcept nogil:
-    """Return preexponential amplitude from fractional intensity."""
-    if fabs(mean) == 0.0:
-        return INFINITY
-    return fractional_intensity * lifetime / mean
-
-
-@cython.ufunc
-cdef float_t _fractional_intensity_from_preexponential_amplitude(
-    float_t preexponential_amplitude,
-    float_t lifetime,
-    float_t mean,
-) noexcept nogil:
-    """Return fractional intensity from preexponential amplitude."""
-    if fabs(lifetime) == 0.0:
-        return INFINITY
-    return preexponential_amplitude / lifetime * mean

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -22,6 +22,8 @@ except ImportError:
     mkl_fft = None
 
 from phasorpy.phasor import (
+    fraction_from_amplitude,
+    fraction_to_amplitude,
     frequency_from_lifetime,
     frequency_to_lifetime,
     phasor_calibrate,
@@ -1304,3 +1306,74 @@ def test_frequency_to_lifetime():
     assert_allclose(
         frequency_to_lifetime([46.503916, 186.015665]), [4.0, 1.0], atol=1e-3
     )
+
+
+def test_fraction_to_amplitude():
+    """Test fraction_to_amplitude function."""
+    # assert isinstance(fraction_to_amplitude(1.0, 1.0), float)
+    assert_allclose(fraction_to_amplitude(1.0, 1.0), 1.0, atol=1e-3)
+    assert_allclose(
+        fraction_to_amplitude([4.0, 1.0], [1.6, 0.4]),
+        [0.2, 0.2],
+        atol=1e-3,
+    )
+    assert_allclose(
+        fraction_to_amplitude([[4.0], [1.0]], [[1.6], [0.4]], axis=0),
+        [[0.2], [0.2]],
+        atol=1e-3,
+    )
+    assert_allclose(
+        fraction_to_amplitude([4.0, 1.0], [1.6, 0.0]),
+        [0.25, 0.0],
+        atol=1e-3,
+    )
+    with pytest.warns(RuntimeWarning):
+        assert_allclose(
+            fraction_to_amplitude([4.0, 0.0], [1.6, 0.4]),
+            [0.2, numpy.inf],
+            atol=1e-3,
+        )
+    with pytest.warns(RuntimeWarning):
+        assert_allclose(
+            fraction_to_amplitude([4.0, 1.0], [0.0, 0.0]),
+            [numpy.nan, numpy.nan],
+            atol=1e-3,
+        )
+
+
+def test_fraction_from_amplitude():
+    """Test fraction_from_amplitude function."""
+    # assert isinstance(fraction_from_amplitude(1.0, 1.0), float)
+    assert_allclose(fraction_from_amplitude(1.0, 1.0), 1.0, atol=1e-3)
+    assert_allclose(
+        fraction_from_amplitude([4.0, 1.0], [0.4, 0.4]),
+        [0.8, 0.2],
+        atol=1e-3,
+    )
+    assert_allclose(
+        fraction_from_amplitude([[4.0], [1.0]], [[0.4], [0.4]], axis=0),
+        [[0.8], [0.2]],
+        atol=1e-3,
+    )
+    assert_allclose(
+        fraction_from_amplitude([4.0, 1.0], [0.5, 0.0]),
+        [1.0, 0.0],
+        atol=1e-3,
+    )
+    assert_allclose(
+        fraction_from_amplitude([4.0, 0.0], [0.4, 10.0]),
+        [1.0, 0.0],
+        atol=1e-3,
+    )
+    with pytest.warns(RuntimeWarning):
+        assert_allclose(
+            fraction_from_amplitude([0.0, 0.0], [0.4, 0.4]),
+            [numpy.nan, numpy.nan],
+            atol=1e-3,
+        )
+    with pytest.warns(RuntimeWarning):
+        assert_allclose(
+            fraction_from_amplitude([4.0, 1.0], [0.0, 0.0]),
+            [numpy.nan, numpy.nan],
+            atol=1e-3,
+        )


### PR DESCRIPTION
## Description

Add two helper functions to the `phasor` module to convert between lifetime fractional intensities and pre-exponential amplitudes. These functions will probably be moved to a `lifetime` module at some point.

Also rename the Cython extension module from `_phasor` to `_phasorpy` since it will contain functions not related to the `phasor` module.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add functions to convert between lifetime fractions and amplitudes
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
