### PR TITLE
WIP: Build with NumPy 2

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
+          CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
+          CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -27,7 +27,6 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
-          CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -25,7 +25,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
-          CIBW_BEFORE_BUILD: python -m pip install numpy>=2.0.0rc1
+          CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
-          CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=1"
+          CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -88,8 +88,6 @@ jobs:
         env:
           CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_TEST_REQUIRES: numpy>=2.0.0rc1
-          CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
+          CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_TEST: pip install -U numpy>=2.0.0rc1
           CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,9 +86,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
-          CIBW_ENVIRONMENT: "PIP_NO_BUILD_ISOLATION=1"
+          CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_BEFORE_TEST: pip install -U numpy>=2.0.0rc1
+          CIBW_TEST_REQUIRES: numpy>=2.0.0rc1
           CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
+          CIBW_BUILD_VERBOSITY: 3
           CIBW_BEFORE_TEST: pip install -U numpy>=2.0.0rc1
           CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,8 +86,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.17.0
         env:
-          CIBW_BEFORE_TEST: python -m pip install numpy>=2.0.0rc1
-          CIBW_BEFORE_BUILD: python -m pip install numpy>=2.0.0rc1
+          CIBW_BEFORE_TEST: pip install -U numpy>=2.0.0rc1
+          CIBW_BEFORE_BUILD: pip install -U numpy>=2.0.0rc1
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:
       - uses: actions/upload-artifact@v4

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,10 @@ from setuptools import Extension, setup
 
 DEBUG = bool(os.environ.get('PHASORPY_DEBUG', False))
 
+print()
+print(f'Building with numpy-{numpy.__version__}')
+print()
+
 if sys.platform == 'win32':
     extra_compile_args = ['/openmp']
     extra_link_args: list[str] = []


### PR DESCRIPTION
## Description

Even though `CIBW_BEFORE_BUILD` and `CIBW_BEFORE_TEST` were set to install `numpy >= 2.0.0rc1` in #61, the wheels are neither built nor tested with numpy 2.0.0rc1 in CI. The environment variable `PIP_PRE=1` needs to be set, otherwise pip downgrades to the latest 1.x release.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Build with NumPy 2
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
