### PR TITLE
Add phasor_at_harmonic function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -784,3 +784,25 @@ cdef (double, double) _polar_from_reference_phasor(
     if fabs(measured_modulation) == 0.0:
         return known_phase - measured_phase, INFINITY
     return known_phase - measured_phase, known_modulation / measured_modulation
+
+
+@cython.ufunc
+cdef (double, double) _phasor_at_harmonic(
+    float_t real,
+    int harmonic,
+    int other_harmonic,
+) noexcept nogil:
+    """Return phasor coordinates on semicircle at other harmonic."""
+    if real <= 0.0:
+        return 0.0, 0.0
+    if real >= 1.0:
+        return 1.0, 0.0
+
+    harmonic *= harmonic
+    other_harmonic *= other_harmonic
+
+    real = (
+        harmonic * real / (other_harmonic + (harmonic - other_harmonic) * real)
+    )
+
+    return real, sqrt(real - real * real)

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1274,7 +1274,11 @@ def phasor_at_harmonic(
     /,
     **kwargs: Any,
 ) -> tuple[NDArray[numpy.float64], NDArray[numpy.float64]]:
-    r"""Return phasor coordinates on semicircle at other harmonics.
+    r"""Return phasor coordinates on universal semicircle at other harmonics.
+
+    Return phasor coordinates at any harmonic, given the real component of
+    phasor coordinates of a single exponential lifetime at a certain harmonic.
+    The input and output phasor coordinates lie on the universal semicircle.
 
     Parameters
     ----------
@@ -1318,10 +1322,8 @@ def phasor_at_harmonic(
         phasor_from_lifetime(
             frequency=other_harmonic,
             lifetime=phasor_to_apparent_lifetime(
-                real,
-                sqrt(real - real * real),
-                frequency=harmonic
-            )[0]
+                real, sqrt(real - real * real), frequency=harmonic
+            )[0],
         )
 
     Examples
@@ -1340,7 +1342,7 @@ def phasor_at_harmonic(
     if numpy.any(other_harmonic < 1):
         raise ValueError('invalid other_harmonic')
 
-    return _phasor_at_harmonic(real, harmonic, other_harmonic)
+    return _phasor_at_harmonic(real, harmonic, other_harmonic, **kwargs)
 
 
 def phasor_from_lifetime(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from phasorpy import versions
 from phasorpy.utils import number_threads
 
 
-def pytest_report_header(config, start_path, startdir):
+def pytest_report_header(config, start_path):
     """Return versions of relevant installed packages."""
     return '\n'.join(
         (

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -26,6 +26,7 @@ from phasorpy.phasor import (
     fraction_to_amplitude,
     frequency_from_lifetime,
     frequency_to_lifetime,
+    phasor_at_harmonic,
     phasor_calibrate,
     phasor_center,
     phasor_from_apparent_lifetime,
@@ -1377,3 +1378,50 @@ def test_fraction_from_amplitude():
             [numpy.nan, numpy.nan],
             atol=1e-3,
         )
+
+
+def test_phasor_at_harmonic():
+    """Test phasor_at_harmonic function."""
+    # identity
+    assert_allclose(phasor_at_harmonic(0.5, 1, 1), [0.5, 0.5], atol=1e-6)
+    assert_allclose(phasor_at_harmonic(0.5, 2, 2), [0.5, 0.5], atol=1e-6)
+    # up
+    assert_allclose(phasor_at_harmonic(0.5, 1, 2), [0.2, 0.4], atol=1e-6)
+    # down
+    assert_allclose(phasor_at_harmonic(0.5, 2, 1), [0.8, 0.4], atol=1e-6)
+    # phasor array
+    assert_allclose(
+        phasor_at_harmonic([0.4, 0.6], 1, 2),
+        [[0.14285714, 0.27272727], [0.34992711, 0.44536177]],
+        atol=1e-6,
+    )
+    # harmonic array
+    assert_allclose(
+        phasor_at_harmonic(0.5, 1, [1, 2, 4, 8]),
+        [[0.5, 0.2, 0.058824, 0.015385], [0.5, 0.4, 0.235294, 0.123077]],
+        atol=1e-6,
+    )
+    # out of bounds
+    assert_array_equal(
+        phasor_at_harmonic([-0.1, 1.0], 1, 1),
+        [[0.0, 1.0], [0.0, 0.0]],
+    )
+    # test against phasor_from_lifetime
+    real = 0.8
+    harmonic = 1
+    other_harmonic = [2, 3]
+    assert_allclose(
+        phasor_at_harmonic(real, harmonic, other_harmonic),
+        phasor_from_lifetime(
+            frequency=other_harmonic,
+            lifetime=phasor_to_apparent_lifetime(
+                real, math.sqrt(real - real * real), frequency=harmonic
+            )[0],
+        ),
+        atol=1e-6,
+    )
+    # errors
+    with pytest.raises(ValueError):
+        phasor_at_harmonic(0.5, 0, 1)
+    with pytest.raises(ValueError):
+        phasor_at_harmonic(0.5, 1, 0)


### PR DESCRIPTION
## Description

This PR adds a convenience function, `phasor_at_harmonic`, which calculates, given the real component of phasor coordinates of a single exponential lifetime at a certain harmonic, the phasor coordinates at other harmonics. It is implemented as a numpy ufunc in Cython.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add phasor_at_harmonic function
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
