### PR TITLE
Format docstring examples with blackdoc

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -117,6 +117,9 @@ jobs:
     - name: Test with black
       run: |
         python -m black --check src/phasorpy tutorials docs
+    - name: Test with blackdoc
+      run: |
+        python -m blackdoc --check src/phasorpy
     - name: Test with mypy
       run: |
         python -m mypy

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -188,13 +188,15 @@ Configuration settings for pytest and other tools are in the
 Code standards
 ..............
 
-All the PhasorPy source code must conform to the
+All the PhasorPy source code, including tutorials and docstring examples,
+must conform to the
 `PEP8 <https://peps.python.org/pep-0008/>`_
 standard and be formatted with
 `black <https://black.readthedocs.io/en/stable/>`_
 (single quotes and lines up to 79 characters are allowed)::
 
     $ python -m black .
+    $ python -m blackdoc src/phasorpy
 
 User-facing classes and functions must use
 `type hints <https://peps.python.org/pep-0484/>`_

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -38,6 +38,7 @@ pytest-doctestplus
 # tools requirements
 tomli; python_version < "3.11"
 black
+blackdoc
 flake8
 isort
 mypy

--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -67,7 +67,7 @@ def parse_kwargs(
 def update_kwargs(kwargs: dict[str, Any], /, **keyvalues: Any) -> None:
     """Update dict with keys and values if keys do not already exist.
 
-    >>> kwargs = {'one': 1, }
+    >>> kwargs = {'one': 1}
     >>> update_kwargs(kwargs, one=None, two=2)
     >>> kwargs == {'one': 1, 'two': 2}
     True

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -81,7 +81,7 @@ def two_fractions_from_phasor(
     --------
     >>> two_fractions_from_phasor(
     ...     [0.6, 0.5, 0.4], [0.4, 0.3, 0.2], [0.2, 0.9], [0.4, 0.3]
-    ... ) # doctest: +NUMBER
+    ... )  # doctest: +NUMBER
     (array([0.44, 0.56, 0.68]), array([0.56, 0.44, 0.32]))
 
     """

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -205,10 +205,10 @@ def phasor_from_signal(
 
     >>> sample_phase = numpy.linspace(0, 2 * math.pi, 5, endpoint=False)[::-1]
     >>> signal = 1.1 * (
-    ...     numpy.cos(sample_phase - 0.78539816) * 2 *  0.70710678 + 1
+    ...     numpy.cos(sample_phase - 0.78539816) * 2 * 0.70710678 + 1
     ... )
     >>> phasor_from_signal(
-    ...    signal, sample_phase=sample_phase
+    ...     signal, sample_phase=sample_phase
     ... )  # doctest: +NUMBER
     (1.1, 0.5, 0.5)
 
@@ -352,7 +352,7 @@ def phasor_from_signal_fft(
 
     >>> sample_phase = numpy.linspace(0, 2 * math.pi, 5, endpoint=False)
     >>> signal = 1.1 * (
-    ...     numpy.cos(sample_phase - 0.78539816) * 2 *  0.70710678 + 1
+    ...     numpy.cos(sample_phase - 0.78539816) * 2 * 0.70710678 + 1
     ... )
     >>> phasor_from_signal_fft(signal, harmonic=[1, 2])  # doctest: +NUMBER
     (1.1, array([0.5, 0.0]), array([0.5, -0]))
@@ -572,10 +572,13 @@ def phasor_calibrate(
     Examples
     --------
     >>> phasor_calibrate(
-    ...    [0.1, 0.2, 0.3], [0.4, 0.5, 0.6],
-    ...    [0.2, 0.3, 0.4], [0.5, 0.6, 0.7],
-    ...    frequency=80, lifetime=4
-    ... ) # doctest: +NUMBER
+    ...     [0.1, 0.2, 0.3],
+    ...     [0.4, 0.5, 0.6],
+    ...     [0.2, 0.3, 0.4],
+    ...     [0.5, 0.6, 0.7],
+    ...     frequency=80,
+    ...     lifetime=4,
+    ... )  # doctest: +NUMBER
     (array([0.0658, 0.132, 0.198]), array([0.2657, 0.332, 0.399]))
 
     """
@@ -663,18 +666,15 @@ def phasor_transform(
     Use scalar reference coordinates to rotate and scale phasor coordinates:
 
     >>> phasor_transform(
-    ...     [0.1, 0.2, 0.3],
-    ...     [0.4, 0.5, 0.6],
-    ...     0.1,
-    ...     0.5
-    ... ) # doctest: +NUMBER
+    ...     [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], 0.1, 0.5
+    ... )  # doctest: +NUMBER
     (array([0.0298, 0.0745, 0.119]), array([0.204, 0.259, 0.3135]))
 
     Use separate reference coordinates for each phasor coordinate:
 
     >>> phasor_transform(
     ...     [0.1, 0.2, 0.3], [0.4, 0.5, 0.6], [0.2, 0.2, 0.3], [0.5, 0.2, 0.3]
-    ... ) # doctest: +NUMBER
+    ... )  # doctest: +NUMBER
     (array([0.00927, 0.0193, 0.0328]), array([0.206, 0.106, 0.1986]))
 
     """
@@ -735,7 +735,7 @@ def polar_from_reference_phasor(
 
         polar_from_reference(
             *phasor_to_polar(measured_real, measured_imag),
-            *phasor_to_polar(known_real, known_imag)
+            *phasor_to_polar(known_real, known_imag),
         )
 
     Examples
@@ -969,7 +969,7 @@ def phasor_to_apparent_lifetime(
     only if the phasor coordinates lie on the universal semicircle:
 
     >>> phasor_to_apparent_lifetime(
-    ...    0.5, [0.5, 0.45], frequency=80
+    ...     0.5, [0.5, 0.45], frequency=80
     ... )  # doctest: +NUMBER
     (array([1.989, 1.79]), array([1.989, 2.188]))
 
@@ -1386,7 +1386,7 @@ def phasor_from_lifetime(
     Phasor coordinates of many single-component lifetimes (fractions omitted):
 
     >>> phasor_from_lifetime(
-    ...     80.0, [3.9788735, 1.9894368, 0.9947183],
+    ...     80.0, [3.9788735, 1.9894368, 0.9947183]
     ... )  # doctest: +NUMBER
     (array([0.2, 0.5, 0.8]), array([0.4, 0.5, 0.4]))
 
@@ -1412,7 +1412,7 @@ def phasor_from_lifetime(
     ...     [40e6, 80e6],
     ...     [[1e-9, 0.9947183e-9], [3.9788735e-9, 0.9947183e-9]],
     ...     [[0, 1], [0.5, 0.5]],
-    ...    unit_conversion=1.0
+    ...     unit_conversion=1.0,
     ... )  # doctest: +NUMBER
     (array([[0.941, 0.721], [0.8, 0.5]]), array([[0.235, 0.368], [0.4, 0.4]]))
 


### PR DESCRIPTION
## Description

This PR applies [black](https://github.com/psf/black) formatting to docstring examples using [blackdoc](https://github.com/keewis/blackdoc) (a new development dependency). It also adds a check to the GitHub Action tests.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Format docstring examples with blackdoc
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
