### PR TITLE
Numpy 2 is released

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.18.1
         env:
-          CIBW_ENVIRONMENT: "PIP_PRE=1"
+          # CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.18.1
         env:
-          CIBW_ENVIRONMENT: "PIP_PRE=1"
+          # CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:


### PR DESCRIPTION
Numpy 2 was released today. No need to use pre-releases to build phasorpy wheels.