### PR TITLE
Use phasorpy-data repo instead of Zenodo in GitHub Actions

### DIFF
--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -32,9 +32,17 @@ import pooch
 
 ENV = 'PHASORPY_DATA_DIR'
 
+DATA_ON_GITHUB = bool(
+    os.environ.get('PHASORPY_DATA_ON_GITHUB', False)
+) or bool(os.environ.get('GITHUB_ACTIONS', False))
+
 TESTS = pooch.create(
     path=pooch.os_cache('phasorpy'),
-    base_url='doi:10.5281/zenodo.8417894',
+    base_url=(
+        'https://github.com/phasorpy/phasorpy-data/raw/main/tests'
+        if DATA_ON_GITHUB
+        else 'doi:10.5281/zenodo.8417894'
+    ),
     env=ENV,
     registry={
         'flimage.int.bin': (
@@ -142,7 +150,11 @@ TESTS = pooch.create(
 
 LFD_WORKSHOP = pooch.create(
     path=pooch.os_cache('phasorpy'),
-    base_url='doi:10.5281/zenodo.8411056',
+    base_url=(
+        'https://github.com/phasorpy/phasorpy-data/raw/main/lfd_workshop'
+        if DATA_ON_GITHUB
+        else 'doi:10.5281/zenodo.8411056'
+    ),
     env=ENV,
     registry={
         '4-22-03-2-A5-CHO-CELL3B.tif': (

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -4,10 +4,16 @@ import os
 
 import pytest
 
-from phasorpy.datasets import fetch
+from phasorpy.datasets import DATA_ON_GITHUB, fetch
 
 # skip large downloads by default
 SKIP_LARGE = bool(int(os.environ.get('SKIP_LARGE', 1)))
+
+
+@pytest.mark.skipif(not DATA_ON_GITHUB, reason='not using GitHub Actions')
+def test_data_on_github():
+    """Test data files on GitHub."""
+    assert DATA_ON_GITHUB
 
 
 def test_fetch():


### PR DESCRIPTION
## Description

This PR enables GitHub Actions to use data files from the new [phasorpy-data](https://github.com/phasorpy/phasorpy-data) repository instead of [Zenodo](https://zenodo.org/communities/phasorpy).

This should make GitHub Actions a little faster and more reliable. 

Some third-party data files used during testing and in tutorials remain on Zenodo.

The "official" source of the data files remains on Zenodo.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Use phasorpy-data repo instead of Zenodo in GitHub Actions
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
