### PR TITLE
Enable code coverage via codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+codecov:
+  notify:
+    require_ci_to_pass: false
+    after_n_builds: 1
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1%
+        informational: true
+comment: off

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Code coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  code_coverage:
+    name: Code coverage
+    runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Editable install
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --editable .
+        python -m pip install -r requirements_dev.txt
+        python -m pip install -r requirements_numpy.txt
+    - name: Generate coverage report
+      run: |
+        pytest --cov=phasorpy --cov-report=xml tests
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        env_vars: OS,PYTHON
+        fail_ci_if_error: false
+        token: ${{ secrets.PHASORPY_CODECOV_TOKEN }}
+        verbose: true

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -175,12 +175,12 @@ thorougly.
 
 Run the unit tests in the development environment::
 
-    $ python -m pytest -v
+    $ python -m pytest -v --cov=phasorpy --cov-report=html tests
 
 All tests must pass.
 
-PhasorPy strives to maintain near complete test coverage. The coverage report
-is automatically generated during testing in the ``_htmlcov`` folder.
+PhasorPy strives to maintain near complete code coverage. A coverage report
+is generated during testing in the ``_htmlcov`` folder.
 
 Configuration settings for pytest and other tools are in the
 ``pyproject.toml`` file.
@@ -232,7 +232,7 @@ standard.
 Examples in docstrings must run and pass as
 `doctests <https://docs.python.org/3/library/doctest.html>`_ ::
 
-    $ python -m pytest -v phasorpy
+    $ python -m pytest -v src/phasorpy
 
 Examples in docstrings are meant to illustrate mere usage, not to
 provide a testing framework.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ directory = "_htmlcov"
 minversion = "7"
 log_cli_level = "INFO"
 xfail_strict = true
-addopts = "-rfEXs --strict-config --strict-markers --cov=phasorpy --cov-report html --doctest-modules --doctest-glob=*.py --doctest-glob=*.rst"
+addopts = "-rfEXs --strict-config --strict-markers --doctest-modules --doctest-glob=*.py --doctest-glob=*.rst"
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "ELLIPSIS",


### PR DESCRIPTION
## Description

This PR enables [code coverage](https://en.wikipedia.org/wiki/Code_coverage) reports via [Codecov](https://about.codecov.io/) for all pull requests and pushes to the main branch. 

Code coverage reports were previously generated automatically during pytest runs, but I don't think they got much attention.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Enable code coverage via codecov.io
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
