### PR TITLE
Add elliptic cursors

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1412,7 +1412,7 @@ cdef float _blend_overlay(
     float_t b,  # blend layer
 ) noexcept nogil:
     """Return blended layers using `overlay` mode."""
-    if isnan(b):
+    if isnan(b) or isnan(a):
         return <float> a
     if a < 0.5:
         return <float> (2.0 * a * b)
@@ -1425,7 +1425,7 @@ cdef float _blend_darken(
     float_t b,  # blend layer
 ) noexcept nogil:
     """Return blended layers using `darken` mode."""
-    if isnan(b):
+    if isnan(b) or isnan(a):
         return <float> a
     return <float> (min(a, b))
 
@@ -1436,6 +1436,6 @@ cdef float _blend_lighten(
     float_t b,  # blend layer
 ) noexcept nogil:
     """Return blended layers using `lighten` mode."""
-    if isnan(b):
+    if isnan(b) or isnan(a):
         return <float> a
     return <float> (max(a, b))

--- a/src/phasorpy/cursors.py
+++ b/src/phasorpy/cursors.py
@@ -5,6 +5,7 @@ The ``phasorpy.cursors`` module provides functions to:
 - create masks for regions of interests in the phasor space:
 
   - :py:func:`mask_from_circular_cursor`
+  - :py:func:`mask_from_elliptic_cursor`
   - :py:func:`mask_from_polar_cursor`
 
 - create pseudo-color image from average signal and cursor masks:

--- a/src/phasorpy/cursors.py
+++ b/src/phasorpy/cursors.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 __all__ = [
     'mask_from_circular_cursor',
+    'mask_from_elliptic_cursor',
     'mask_from_polar_cursor',
     'pseudo_color',
 ]
@@ -37,6 +38,7 @@ from ._phasorpy import (
     _blend_normal,
     _blend_overlay,
     _is_inside_circle,
+    _is_inside_ellipse_,
     _is_inside_polar_rectangle,
 )
 
@@ -123,6 +125,141 @@ def mask_from_circular_cursor(
 
     mask = _is_inside_circle(
         real, imag, center_real, center_imag, radius, True
+    )
+    if moveaxis:
+        mask = numpy.moveaxis(mask, -1, 0)
+    return mask.astype(numpy.bool_)
+
+
+def mask_from_elliptic_cursor(
+    real: ArrayLike,
+    imag: ArrayLike,
+    center_real: ArrayLike,
+    center_imag: ArrayLike,
+    /,
+    *,
+    radius: ArrayLike = 0.05,
+    radius_b: ArrayLike | None = None,
+    angle: ArrayLike | None = None,
+) -> NDArray[numpy.bool_]:
+    """Return masks for elliptic cursors of phasor coordinates.
+
+    Parameters
+    ----------
+    real : array_like
+        Real component of phasor coordinates.
+    imag : array_like
+        Imaginary component of phasor coordinates.
+    center_real : array_like, shape (n,)
+        Real coordinates of ellipses centers.
+    center_imag : array_like, shape (n,)
+        Imaginary coordinates of ellipses centers.
+    radius : array_like, optional, shape (n,)
+        Radii of ellipses along semi-major axis.
+    radius_b : array_like, optional, shape (n,)
+        Radii of ellipses along semi-major axis.
+        By default, `radius_b` is equal to `radius` (the ellipse is circular).
+    angle : array_like, optional, shape (n,)
+        Rotation angles of semi-major axis of ellipses in radians.
+        If None, the angle defined by `center_real` and `center_imag` is used.
+
+    Returns
+    -------
+    masks : ndarray
+        Boolean array of shape `(n, *real.shape)`.
+        The first dimension is omitted if `center*`, `radius*`, and `angle`
+        are scalars.
+        Values are True if phasor coordinates are inside elliptic cursor,
+        else False.
+
+    Raises
+    ------
+    ValueError
+        The array shapes of `real` and `imag` do not match.
+        The array shapes of `center*`, `radius*`, or `angle` have more than
+        one dimension.
+
+    See Also
+    --------
+    :ref:`sphx_glr_tutorials_phasorpy_cursors.py`
+
+    Examples
+    --------
+    Create mask for a single elliptic cursor:
+
+    >>> mask_from_elliptic_cursor([0.2, 0.5], [0.4, 0.5], 0.2, 0.4, radius=0.1)
+    array([ True, False])
+
+    Create masks for two elliptic cursors with different radii:
+
+    >>> mask_from_elliptic_cursor(
+    ...     [0.2, 0.5],
+    ...     [0.4, 0.5],
+    ...     [0.2, 0.5],
+    ...     [0.4, 0.5],
+    ...     radius=[0.1, 0.05],
+    ...     radius_b=[0.15, 0.1],
+    ...     angle=[math.pi, math.pi / 2],
+    ... )
+    array([[ True, False],
+           [False,  True]])
+
+    """
+    real = numpy.asarray(real)
+    imag = numpy.asarray(imag)
+    center_real = numpy.asarray(center_real)
+    center_imag = numpy.asarray(center_imag)
+    radius_a = numpy.asarray(radius)
+    if radius_b is None:
+        # circular by default
+        radius_b = radius_a
+        angle = 0.0
+    else:
+        radius_b = numpy.asarray(radius_b)
+    if angle is None:
+        # TODO: add option for semicircle
+        # angle = numpy.arctan2(center_real - 0.5, center_imag)
+        angle = numpy.arctan2(center_real, center_imag)
+    angle_sin = numpy.sin(angle)
+    angle_cos = numpy.cos(angle)
+
+    if real.shape != imag.shape:
+        raise ValueError(f'{real.shape=} != {imag.shape=}')
+    if (
+        center_real.ndim > 1
+        or center_imag.ndim > 1
+        or radius_a.ndim > 1
+        or radius_b.ndim > 1
+        or angle_sin.ndim > 1
+    ):
+        raise ValueError(
+            f'{center_real.ndim=}, {center_imag.ndim=}, '
+            f'radius.ndim={radius_a.ndim}, {radius_b.ndim=} or '
+            f'angle.ndim={angle_sin.ndim}, > 1'
+        )
+
+    moveaxis = False
+    if real.ndim > 0 and (
+        center_real.ndim > 0
+        or center_imag.ndim > 0
+        or radius_a.ndim > 0
+        or radius_b.ndim > 0
+        or angle_sin.ndim > 0
+    ):
+        moveaxis = True
+        real = numpy.expand_dims(real, axis=-1)
+        imag = numpy.expand_dims(imag, axis=-1)
+
+    mask = _is_inside_ellipse_(
+        real,
+        imag,
+        center_real,
+        center_imag,
+        radius_a,
+        radius_b,
+        angle_sin,
+        angle_cos,
+        True,
     )
     if moveaxis:
         mask = numpy.moveaxis(mask, -1, 0)

--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -571,8 +571,9 @@ class PhasorPlot:
         real_limit: float | None = None,
         imag_limit: float | None = None,
         radius: float | None = None,
-        radius_b: float | None = None,
+        radius_minor: float | None = None,
         angle: float | None = None,
+        align_semicircle: bool = False,
         **kwargs: Any,
     ) -> None:
         """Plot phase and modulation grid lines and arcs at phasor coordinates.
@@ -589,18 +590,23 @@ class PhasorPlot:
             Imaginary component of limiting phasor coordinate.
         radius : float, optional
             Radius of circle limiting phase and modulation grid lines and arcs.
-        radius_b : float, optional
-            Radius of ellipse along semi-major axis.
-            limiting phase and modulation grid lines and arcs.
-            By default, the cursor is circular (`radius_b` == `radius`).
+        radius_minor : float, optional
+            Radius of elliptic cursor along semi-minor axis.
+            By default, `radius_minor` is equal to `radius`, that is,
+            the ellipse is circular.
         angle : float, optional
-            Rotation angle of semi-major axis of ellipse in radians.
-            If None (default), the angle is defined by `real` and `imag`,
-            depending on `allquadrants` used to initialize the plot.
+            Rotation angle of semi-major axis of elliptic cursor in radians.
+            If None (default), orient ellipse cursor according to
+            `align_semicircle`.
+        align_semicircle : bool, optional
+            Determines elliptic cursor orientation if `angle` is not provided.
+            If true, align the minor axis of the ellipse with the closest
+            tangent on the universal semicircle, else align to the unit circle.
         **kwargs
             Additional parameters passed to
             :py:class:`matplotlib.lines.Line2D`,
-            :py:class:`matplotlib.patches.Circle`, and
+            :py:class:`matplotlib.patches.Circle`,
+            :py:class:`matplotlib.patches.Ellipse`, or
             :py:class:`matplotlib.patches.Arc`.
 
         See Also
@@ -613,15 +619,17 @@ class PhasorPlot:
                 *phasor_to_polar_scalar(real, imag),
                 *phasor_to_polar_scalar(real_limit, imag_limit),
                 radius=radius,
-                radius_b=radius_b,
+                radius_minor=radius_minor,
                 angle=angle,
+                align_semicircle=align_semicircle,
                 **kwargs,
             )
         return self.polar_cursor(
             *phasor_to_polar_scalar(real, imag),
             radius=radius,
-            radius_b=radius_b,
+            radius_minor=radius_minor,
             angle=angle,
+            align_semicircle=align_semicircle,
             # _circle_only=True,
             **kwargs,
         )
@@ -633,8 +641,9 @@ class PhasorPlot:
         phase_limit: float | None = None,
         modulation_limit: float | None = None,
         radius: float | None = None,
-        radius_b: float | None = None,
+        radius_minor: float | None = None,
         angle: float | None = None,
+        align_semicircle: bool = False,
         **kwargs: Any,
     ) -> None:
         """Plot phase and modulation grid lines and arcs.
@@ -653,14 +662,18 @@ class PhasorPlot:
             Phase grid lines are drawn from `modulation` to `modulation_limit`.
         radius : float, optional
             Radius of circle limiting phase and modulation grid lines and arcs.
-        radius_b : float, optional
-            Radius of ellipse along semi-major axis.
-            limiting phase and modulation grid lines and arcs.
-            By default, the cursor is circular (`radius_b` == `radius`).
+        radius_minor : float, optional
+            Radius of elliptic cursor along semi-minor axis.
+            By default, `radius_minor` is equal to `radius`, that is,
+            the ellipse is circular.
         angle : float, optional
-            Rotation angle of semi-major axis of ellipse in radians.
-            If None (default), the angle is defined by `real` and `imag`,
-            depending on `allquadrants` used to initialize the plot.
+            Rotation angle of semi-major axis of elliptic cursor in radians.
+            If None (default), orient ellipse cursor according to
+            `align_semicircle`.
+        align_semicircle : bool, optional
+            Determines elliptic cursor orientation if `angle` is not provided.
+            If true, align the minor axis of the ellipse with the closest
+            tangent on the universal semicircle, else align to the unit circle.
         **kwargs
             Additional parameters passed to
             :py:class:`matplotlib.lines.Line2D`,
@@ -685,14 +698,20 @@ class PhasorPlot:
         if radius is not None and phase is not None and modulation is not None:
             x = modulation * math.cos(phase)
             y = modulation * math.sin(phase)
-            if radius_b is not None and radius_b != radius:
+            if radius_minor is not None and radius_minor != radius:
                 if angle is None:
-                    # orient ellipse along semicircle or full circle
-                    angle = phase if self._full else math.atan2(y, x - 0.5)
+                    if align_semicircle:
+                        angle = math.atan2(y, x - 0.5)
+                    else:
+                        angle = phase
                 angle = math.degrees(angle)
                 ax.add_patch(
                     Ellipse(
-                        (x, y), radius * 2, radius_b * 2, angle=angle, **kwargs
+                        (x, y),
+                        radius * 2,
+                        radius_minor * 2,
+                        angle=angle,
+                        **kwargs,
                     )
                 )
                 # TODO: implement gridlines intersecting with ellipse

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -183,6 +183,7 @@ class TestPhasorPlot:
         plot.cursor(0.4, 0.3, color='tab:blue', linestyle='-')
         plot.cursor(0.52, 0.3, 0.78, 0.16, color='tab:orange')
         plot.cursor(0.9, 0.3, radius=0.05, color='tab:green')
+        plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1, fill=True, alpha=0.5)
         self.show(plot)
 
     def test_cursor_allquadrants(self):
@@ -191,6 +192,8 @@ class TestPhasorPlot:
         plot.cursor(-0.4, -0.3, color='tab:blue', linestyle='-')
         plot.cursor(-0.52, -0.3, -0.78, -0.16, color='tab:orange')
         plot.cursor(-0.9, -0.3, radius=0.1, color='tab:green')
+        plot.cursor(-0.3, -0.6, radius=0.1, radius_b=0.2, fill=True, alpha=0.5)
+        plot.cursor(-0.5, 0.5, radius=0.1, radius_b=0.2, angle=math.pi / 4)
         self.show(plot)
 
     def test_polar_cursor(self):

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -183,7 +183,12 @@ class TestPhasorPlot:
         plot.cursor(0.4, 0.3, color='tab:blue', linestyle='-')
         plot.cursor(0.52, 0.3, 0.78, 0.16, color='tab:orange')
         plot.cursor(0.9, 0.3, radius=0.05, color='tab:green')
-        plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1, fill=True, alpha=0.5)
+        plot.cursor(
+            0.4, 0.3, radius=0.05, radius_minor=0.1, fill=True, alpha=0.5
+        )
+        plot.cursor(
+            0.11, 0.3, radius=0.05, radius_minor=0.1, align_semicircle=True
+        )
         self.show(plot)
 
     def test_cursor_allquadrants(self):
@@ -192,8 +197,10 @@ class TestPhasorPlot:
         plot.cursor(-0.4, -0.3, color='tab:blue', linestyle='-')
         plot.cursor(-0.52, -0.3, -0.78, -0.16, color='tab:orange')
         plot.cursor(-0.9, -0.3, radius=0.1, color='tab:green')
-        plot.cursor(-0.3, -0.6, radius=0.1, radius_b=0.2, fill=True, alpha=0.5)
-        plot.cursor(-0.5, 0.5, radius=0.1, radius_b=0.2, angle=math.pi / 4)
+        plot.cursor(
+            -0.3, -0.6, radius=0.1, radius_minor=0.2, fill=True, alpha=0.5
+        )
+        plot.cursor(-0.6, 0.6, radius=0.1, radius_minor=0.2, angle=2.36)
         self.show(plot)
 
     def test_polar_cursor(self):

--- a/tutorials/phasorpy_cursors.py
+++ b/tutorials/phasorpy_cursors.py
@@ -75,7 +75,7 @@ plt.show()
 # Elliptic cursors
 # ----------------
 #
-# Use elliptic cursors to mask morde defined regions of interest in the
+# Use elliptic cursors to mask more defined regions of interest in the
 # phasor space:
 
 radius = [0.1, 0.06]

--- a/tutorials/phasorpy_cursors.py
+++ b/tutorials/phasorpy_cursors.py
@@ -14,6 +14,7 @@ import matplotlib.pyplot as plt
 from phasorpy.color import CATEGORICAL
 from phasorpy.cursors import (
     mask_from_circular_cursor,
+    mask_from_elliptic_cursor,
     mask_from_polar_cursor,
     pseudo_color,
 )
@@ -28,35 +29,89 @@ from phasorpy.plot import PhasorPlot
 signal = read_lsm(fetch('paramecium.lsm'))
 mean, real, imag = phasor_from_signal(signal, axis=0)
 
+threshold = mean > 1
+
 # %%
 # Circular cursors
 # ----------------
 #
 # Use circular cursors to mask regions of interest in the phasor space:
 
-cursors_real = [-0.33, 0.55]
-cursors_imag = [-0.72, -0.72]
+cursors_real = [-0.33, 0.54]
+cursors_imag = [-0.72, -0.74]
+radius = [0.2, 0.22]
 
 circular_mask = mask_from_circular_cursor(
-    real, imag, cursors_real, cursors_imag, radius=0.2
+    real, imag, cursors_real, cursors_imag, radius=radius
 )
 
 # %%
 # Show the circular cursors in a phasor plot:
 
-threshold = mean > 1
-
 plot = PhasorPlot(allquadrants=True, title='Circular cursors')
-plot.hist2d(real[threshold], imag[threshold])
+plot.hist2d(real[threshold], imag[threshold], cmap='Greys')
 for i in range(len(cursors_real)):
     plot.cursor(
         cursors_real[i],
         cursors_imag[i],
-        radius=0.2,
+        radius=radius[i],
         color=CATEGORICAL[i],
         linestyle='-',
     )
 plot.show()
+
+# %%
+#
+# The cursor masks can be blended to produce a pseudo-colored image:
+
+pseudo_color_image = pseudo_color(*circular_mask)
+
+fig, ax = plt.subplots()
+ax.set_title('Pseudo-color image from circular cursors')
+ax.imshow(pseudo_color_image)
+plt.show()
+
+# %%
+# Elliptic cursors
+# ----------------
+#
+# Use elliptic cursors to mask morde defined regions of interest in the
+# phasor space:
+
+radius = [0.1, 0.06]
+radius_b = [0.3, 0.25]
+
+elliptic_mask = mask_from_elliptic_cursor(
+    real, imag, cursors_real, cursors_imag, radius=radius, radius_b=radius_b
+)
+
+# %%
+# Show the elliptic cursors in a phasor plot:
+
+plot = PhasorPlot(allquadrants=True, title='Elliptic cursors')
+plot.hist2d(real[threshold], imag[threshold], cmap='Greys')
+for i in range(len(cursors_real)):
+    plot.cursor(
+        cursors_real[i],
+        cursors_imag[i],
+        radius=radius[i],
+        radius_b=radius_b[i],
+        color=CATEGORICAL[i],
+        linestyle='-',
+    )
+plot.show()
+
+# %%
+#
+# The mean intensity image can be used as a base layer to overlay
+# the masks from the elliptic cursors:
+
+pseudo_color_image = pseudo_color(*elliptic_mask, intensity=mean)
+
+fig, ax = plt.subplots()
+ax.set_title('Pseudo-color image from elliptic cursors and intensity')
+ax.imshow(pseudo_color_image)
+plt.show()
 
 # %%
 # Polar cursors
@@ -77,7 +132,7 @@ polar_mask = mask_from_polar_cursor(
 # Show the polar cursors in a phasor plot:
 
 plot = PhasorPlot(allquadrants=True, title='Polar cursors')
-plot.hist2d(real[threshold], imag[threshold])
+plot.hist2d(real[threshold], imag[threshold], cmap='Greys')
 for i in range(len(phase_min)):
     plot.polar_cursor(
         phase=phase_min[i],
@@ -90,23 +145,8 @@ for i in range(len(phase_min)):
 plot.show()
 
 # %%
-# Pseudo-color images
-# -------------------
-#
-# The cursor masks and optionally the intensity image can be
-# blended to produce pseudo-colored images.
-# Blending the masks from the circular cursors:
-
-pseudo_color_image = pseudo_color(*circular_mask)
-
-fig, ax = plt.subplots()
-ax.set_title('Pseudo-color image from circular cursors')
-ax.imshow(pseudo_color_image)
-plt.show()
-
-# %%
-# Using the mean intensity image as a base layer to overlay the masks from
-# the polar cursors:
+# The mean intensity image can be used as a base layer to overlay
+# the masks from the polar cursors:
 
 pseudo_color_image = pseudo_color(
     *polar_mask, intensity=mean, colors=CATEGORICAL[2:]

--- a/tutorials/phasorpy_cursors.py
+++ b/tutorials/phasorpy_cursors.py
@@ -79,10 +79,15 @@ plt.show()
 # phasor space:
 
 radius = [0.1, 0.06]
-radius_b = [0.3, 0.25]
+radius_minor = [0.3, 0.25]
 
 elliptic_mask = mask_from_elliptic_cursor(
-    real, imag, cursors_real, cursors_imag, radius=radius, radius_b=radius_b
+    real,
+    imag,
+    cursors_real,
+    cursors_imag,
+    radius=radius,
+    radius_minor=radius_minor,
 )
 
 # %%
@@ -95,7 +100,7 @@ for i in range(len(cursors_real)):
         cursors_real[i],
         cursors_imag[i],
         radius=radius[i],
-        radius_b=radius_b[i],
+        radius_minor=radius_minor[i],
         color=CATEGORICAL[i],
         linestyle='-',
     )

--- a/tutorials/phasorpy_phasorplot.py
+++ b/tutorials/phasorpy_phasorplot.py
@@ -66,6 +66,7 @@ plot = PhasorPlot(frequency=80.0, title='Cursors')
 plot.cursor(0.4, 0.3)
 plot.cursor(0.5, 0.3, 0.8, 0.15)
 plot.cursor(0.9, 0.3, radius=0.05)
+plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1)
 plot.show()
 
 # %%
@@ -75,6 +76,7 @@ plot = PhasorPlot(frequency=80.0, title='Polar cursors')
 plot.polar_cursor(0.6435, 0.5, linestyle='-')
 plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8, linewidth=2)
 plot.polar_cursor(0.3233, 0.9482, radius=0.05, color='tab:red')
+plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1, fill=True, alpha=0.5)
 plot.show()
 
 # %%

--- a/tutorials/phasorpy_phasorplot.py
+++ b/tutorials/phasorpy_phasorplot.py
@@ -66,17 +66,36 @@ plot = PhasorPlot(frequency=80.0, title='Cursors')
 plot.cursor(0.4, 0.3)
 plot.cursor(0.5, 0.3, 0.8, 0.15)
 plot.cursor(0.9, 0.3, radius=0.05)
-plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1)
+plot.cursor(0.4, 0.3, radius=0.05, radius_minor=0.1)
+plot.cursor(0.1, 0.3, radius=0.05, radius_minor=0.1, align_semicircle=True)
 plot.show()
 
 # %%
-# Alternatively, use polar coordinates:
+# Alternatively, use polar coordinates, here demonstrated with various options:
 
 plot = PhasorPlot(frequency=80.0, title='Polar cursors')
 plot.polar_cursor(0.6435, 0.5, linestyle='-')
 plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8, linewidth=2)
 plot.polar_cursor(0.3233, 0.9482, radius=0.05, color='tab:red')
-plot.cursor(0.9, 0.1, radius=0.05, radius_b=0.1, fill=True, alpha=0.5)
+plot.polar_cursor(
+    0.6435,
+    0.5,
+    radius=0.05,
+    radius_minor=0.1,
+    color='tab:blue',
+    fill=True,
+    alpha=0.5,
+)
+plot.polar_cursor(
+    0.6435,
+    0.5,
+    radius=0.1,
+    radius_minor=0.05,
+    angle=0.0,
+    color='tab:green',
+    fill=True,
+    alpha=0.5,
+)
 plot.show()
 
 # %%


### PR DESCRIPTION
## Description

This PR adds support for elliptic cursors to the `plot.PhasorPlot.cursor` method and the `cursors` module. Tests and tutorials are updated.

Items to discuss:

- [ ] The new `mask_from_elliptic_cursor` function behaves exactly like `mask_from_circular_cursor` by default. Removing `mask_from_circular_cursor` would simplify implementation and testing.
- [x] The `radius_b` parameter of the `mask_from_elliptic_cursor` function sets the ellipse radius along the minor axis. Is the name `radius_b` appropriate?
- [x] The default `angle` of the ellipse in the `plot.PhasorPlot.cursor` method aligns with a circle around the origin or the universal semicircle depending on the `allquadrants` mode of the plot. There is no option in the `mask_from_elliptic_cursor` function to align with the universal semicircle. Is it worth adding? The `angle` can always be set explicitly.
- [ ] Phase and modulation lines are not drawn inside ellipses in the `plot.PhasorPlot.cursor` method. This would require implementing `_intersection_ellipse_circle` and  `_intersection_ellipse_line` ufuncs. Is it worth implementing this functionality?
- [ ] I am really not sure that handling multiple cursors in the `mask_from_*_cursor` is the right approach. It makes implementation, documentation, and testing more complicated than necessary, and the user has to keep track of the dimensions returned. Is there a significant use case where this simplifies things for users as compared to calling the functions in a loop or list comprehension?

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add elliptic cursors
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
