### PR TITLE
Sort fractions in PhasorPlot.components

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -430,6 +430,7 @@ class PhasorPlot:
         # TODO: catch more annotate properties?
         real, imag, indices = sort_coordinates(real, imag)
 
+        label = kwargs.pop('label', None)
         marker = kwargs.pop('marker', None)
         color = kwargs.pop('color', None)
         fontsize = kwargs.pop('fontsize', 12)
@@ -476,9 +477,13 @@ class PhasorPlot:
                     marker=marker,
                     linestyle='',
                     color=color,
+                    label=label,
                 )
+                if label is not None:
+                    self._ax.legend()
             return
 
+        fraction = numpy.asarray(fraction)[indices]
         update_kwargs(
             kwargs,
             color=GRID_COLOR if color is None else color,
@@ -495,8 +500,15 @@ class PhasorPlot:
         if marker is not None:
             self._ax.plot(real, imag, marker=marker, linestyle='', color=color)
             self._ax.plot(
-                center_re, center_im, marker=marker, linestyle='', color=color
+                center_re,
+                center_im,
+                marker=marker,
+                linestyle='',
+                color=color,
+                label=label,
             )
+            if label is not None:
+                self._ax.legend()
 
     def line(
         self,


### PR DESCRIPTION
## Description

The `fractions` values in `PhasorPlot.components` are currently not sorted like the coordinates, which can lead to wrong average being displayed. The PR fixes this issue and also passes through the `label` parameter to plot functions. This is needed for #63.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Sort fractions in PhasorPlot.components
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
