### PR TITLE
Fix type of harmonic parameter in phasor_to_signal

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -408,7 +408,7 @@ def phasor_to_signal(
     /,
     *,
     samples: int = 64,
-    harmonic: int | Sequence[int] | None = None,
+    harmonic: int | Sequence[int] | Literal['all'] | None = None,
     axis: int = -1,
     irfft_func: Callable[..., NDArray[Any]] | None = None,
 ) -> NDArray[numpy.float64]:


### PR DESCRIPTION
## Description

Fix type of harmonic parameter in phasor_to_signal.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Fix type of harmonic parameter in phasor_to_signal
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
