### PR TITLE
Add phasor_to_complex, phasor_multiply, and phasor_divide helper functions

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -815,7 +815,7 @@ cdef (double, double) _phasor_multiply(
     float_t imag1,
     float_t real2,
     float_t imag2,
-):
+) noexcept nogil:
     """Return multiplication of two phasors."""
     return real1 * real2 - imag1 * imag2, real1 * imag2 + imag1 * real2
 
@@ -826,7 +826,7 @@ cdef (double, double) _phasor_divide(
     float_t imag1,
     float_t real2,
     float_t imag2,
-):
+) noexcept nogil:
     """Return division of two phasors."""
     cdef:
         float_t denom = real2 * real2 + imag2 * imag2

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -809,8 +809,40 @@ cdef (double, double) _phasor_at_harmonic(
     return real, sqrt(real - real * real)
 
 
+@cython.ufunc
+cdef (double, double) _phasor_multiply(
+    float_t real1,
+    float_t imag1,
+    float_t real2,
+    float_t imag2,
+):
+    """Return multiplication of two phasors."""
+    return real1 * real2 - imag1 * imag2, real1 * imag2 + imag1 * real2
+
+
+@cython.ufunc
+cdef (double, double) _phasor_divide(
+    float_t real1,
+    float_t imag1,
+    float_t real2,
+    float_t imag2,
+):
+    """Return division of two phasors."""
+    cdef:
+        float_t denom = real2 * real2 + imag2 * imag2
+
+    if denom == 0.0:
+        return NAN, NAN
+
+    return (
+        (real1 * real2 + imag1 * imag2) / denom,
+        (imag1 * real2 - real1 * imag2) / denom
+    )
+
+
 ###############################################################################
 # Geometry ufuncs
+
 
 @cython.ufunc
 cdef short _is_inside_range(

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -30,6 +30,7 @@ from phasorpy.phasor import (
     phasor_at_harmonic,
     phasor_calibrate,
     phasor_center,
+    phasor_divide,
     phasor_filter,
     phasor_from_apparent_lifetime,
     phasor_from_fret_acceptor,
@@ -38,8 +39,10 @@ from phasorpy.phasor import (
     phasor_from_polar,
     phasor_from_signal,
     phasor_from_signal_fft,
+    phasor_multiply,
     phasor_semicircle,
     phasor_to_apparent_lifetime,
+    phasor_to_complex,
     phasor_to_polar,
     phasor_to_principal_plane,
     phasor_to_signal,
@@ -717,10 +720,81 @@ def test_polar_from_reference_functions():
     assert_allclose(mod0, mod1, atol=1e-3)
 
 
+def test_phasor_to_complex():
+    """Test phasor_to_complex function."""
+    real = [numpy.nan, 0.1, 0.2]
+    imag = [numpy.nan, 0.3, 0.4]
+    assert_allclose(phasor_to_complex(real, imag).real, real)
+    assert_allclose(phasor_to_complex(real, imag).imag, imag)
+    assert_allclose(phasor_to_complex(0, imag).real, 0)
+    assert_allclose(phasor_to_complex(real, 0).imag, 0)
+
+    assert (
+        phasor_to_complex(real, imag, dtype=numpy.complex64).dtype
+        == numpy.complex64
+    )
+
+    assert (
+        phasor_to_complex(
+            numpy.array(real, dtype=numpy.float32),
+            numpy.array(imag, dtype=numpy.float32),
+        ).dtype
+        == numpy.complex64
+    )
+
+    assert (
+        phasor_to_complex(
+            numpy.array(real, dtype=numpy.float64),
+            numpy.array(imag, dtype=numpy.float32),
+        ).dtype
+        == numpy.complex128
+    )
+
+    with pytest.raises(ValueError):
+        phasor_to_complex(0.0, 0.0, dtype=numpy.float64)
+
+
+def test_phasor_multiply():
+    """Test phasor_multiply function."""
+    real1 = [0.0, 0.1, 0.2]
+    imag1 = [0.0, 0.3, 0.4]
+    real2 = [0.0, 0.5, 0.6]
+    imag2 = [0.0, 0.7, 0.8]
+    real = [0.0, -0.16, -0.2]
+    imag = [0.0, 0.22, 0.4]
+
+    assert_allclose(
+        phasor_to_complex(*phasor_multiply(real1, imag1, real2, imag2)),
+        phasor_to_complex(real, imag),
+    )
+    assert_allclose(
+        phasor_to_complex(real1, imag1) * phasor_to_complex(real2, imag2),
+        phasor_to_complex(real, imag),
+    )
+
+
+def test_phasor_divide():
+    """Test phasor_divide function."""
+    real1 = [0.0, -0.16, -0.2]
+    imag1 = [0.0, 0.22, 0.4]
+    real2 = [0.0, 0.5, 0.6]
+    imag2 = [0.0, 0.7, 0.8]
+    real = [numpy.nan, 0.1, 0.2]
+    imag = [numpy.nan, 0.3, 0.4]
+
+    assert_allclose(
+        phasor_to_complex(*phasor_divide(real1, imag1, real2, imag2)),
+        phasor_to_complex(real, imag),
+    )
+    with pytest.warns(RuntimeWarning):
+        assert_allclose(
+            phasor_to_complex(real1, imag1) / phasor_to_complex(real2, imag2),
+            phasor_to_complex(real, imag),
+        )
+
+
 @pytest.mark.parametrize(
-    """real, imag,
-    phase_zero, modulation_zero,
-    expected_real, expected_imag""",
+    'real, imag, phase, modulation, expected_real, expected_imag',
     [
         (2, 2, None, None, 2, 2),
         (2, 2, 0, 1, 2, 2),
@@ -795,23 +869,23 @@ def test_polar_from_reference_functions():
             SYNTH_MOD,
             numpy.array([[39.81570233, 0.79631405], [0.79631405, 0.79631405]]),
             numpy.array([[135.70081005, 2.7140162], [2.7140162, 2.7140162]]),
-        ),  # test with phase_zero and modulation_zero as arrays
+        ),  # test with phase and modulation as arrays
     ],
 )
 def test_phasor_transform(
     real,
     imag,
-    phase_zero,
-    modulation_zero,
+    phase,
+    modulation,
     expected_real,
     expected_imag,
 ):
-    """Test `phasor_transform` function with various inputs."""
+    """Test phasor_transform function with various inputs."""
     real_copy = copy.deepcopy(real)
     imag_copy = copy.deepcopy(imag)
-    if phase_zero is not None and modulation_zero is not None:
+    if phase is not None and modulation is not None:
         calibrated_real, calibrated_imag = phasor_transform(
-            real_copy, imag_copy, phase_zero, modulation_zero
+            real_copy, imag_copy, phase, modulation
         )
     else:
         calibrated_real, calibrated_imag = phasor_transform(


### PR DESCRIPTION
## Description

This PR adds helper functions to convert phasor coordinates to numpy complex number arrays, and to complex-multiply or complex-divide phasor coordinates with other phasor coordinates. 

I have found myself repeatedly using such functionality while developing new features (almost regretting that we didn't base PhasorPy on complex numbers) and think these functions might be generally useful. 

The `phasor_transform` was re-classified from "calibration" to "transformation" together with `phasor_multiply` and `phasor_divide`. Let me know if that is not reasonable.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Add phasor_to_complex, phasor_multiply, and phasor_divide helper functions
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
