### PR TITLE
Fix phasor_center with NaN input

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -2751,8 +2751,8 @@ def phasor_center(
         - ``'median'``: Spatial median of phasor coordinates.
 
     **kwargs
-        Optional arguments passed to :py:func:`numpy.mean` or
-        :py:func:`numpy.median`.
+        Optional arguments passed to :py:func:`numpy.nanmean` or
+        :py:func:`numpy.nanmedian`.
 
     Returns
     -------
@@ -2811,7 +2811,7 @@ def _mean(
     imag : numpy.ndarray
         Imaginary components of phasor coordinates.
     **kwargs
-        Optional arguments passed to :py:func:`numpy.mean`.
+        Optional arguments passed to :py:func:`numpy.nanmean`.
 
     Returns
     -------
@@ -2826,7 +2826,7 @@ def _mean(
     (2.0, 5.0)
 
     """
-    return numpy.mean(real, **kwargs), numpy.mean(imag, **kwargs)
+    return numpy.nanmean(real, **kwargs), numpy.nanmean(imag, **kwargs)
 
 
 def _median(
@@ -2841,7 +2841,7 @@ def _median(
     imag : numpy.ndarray
         Imaginary components of the phasor coordinates.
     **kwargs
-        Optional arguments passed to :py:func:`numpy.median`.
+        Optional arguments passed to :py:func:`numpy.nanmedian`.
 
     Returns
     -------
@@ -2856,7 +2856,7 @@ def _median(
     (2.0, 5.0)
 
     """
-    return numpy.median(real, **kwargs), numpy.median(imag, **kwargs)
+    return numpy.nanmedian(real, **kwargs), numpy.nanmedian(imag, **kwargs)
 
 
 def _median_filter(
@@ -2881,7 +2881,7 @@ def _median_filter(
     size : int or tuple of int, optional
         The size of the median filter kernel. Default is 3.
     **kwargs
-        Optional arguments passed to :py:func:`numpy.median`.
+        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`.
 
     Returns
     -------

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -55,6 +55,7 @@ from phasorpy.phasor import (
 )
 
 SYNTH_DATA_ARRAY = numpy.array([[50, 1], [1, 1]])
+SYNTH_DATA_NAN = numpy.array([[50, numpy.nan], [1, 1]])
 SYNTH_DATA_LIST = [1, 2, 4]
 SYNTH_PHI = numpy.array([[0.5, 0.5], [0.5, 0.5]])
 SYNTH_MOD = numpy.array([[2, 2], [2, 2]])
@@ -1013,8 +1014,7 @@ def test_phasor_transform_more():
 
 
 @pytest.mark.parametrize(
-    """real, imag, kwargs,
-    expected_real_center, expected_imag_center""",
+    'real, imag, kwargs, expected_real_center, expected_imag_center',
     [
         (1.0, 4.0, {'skip_axis': None, 'method': 'mean'}, 1.0, 4.0),
         (1.0, -4.0, {'skip_axis': None, 'method': 'median'}, 1.0, -4.0),
@@ -1068,6 +1068,20 @@ def test_phasor_transform_more():
             [[13.25]],
             [[13.25]],
         ),  # with kwargs for numpy functions
+        (
+            SYNTH_DATA_NAN,
+            SYNTH_DATA_NAN,
+            {'skip_axis': None, 'method': 'median'},
+            1.0,
+            1.0,
+        ),
+        (
+            SYNTH_DATA_NAN,
+            SYNTH_DATA_NAN,
+            {'skip_axis': None, 'method': 'mean'},
+            52 / 3,
+            52 / 3,
+        ),
     ],
 )
 def test_phasor_center(
@@ -1077,7 +1091,7 @@ def test_phasor_center(
     expected_real_center,
     expected_imag_center,
 ):
-    """Test `phasor_center` function with various inputs and methods."""
+    """Test phasor_center function with various inputs and methods."""
     real_copy = copy.deepcopy(real)
     imag_copy = copy.deepcopy(imag)
     real_center, imag_center = phasor_center(real_copy, imag_copy, **kwargs)
@@ -1088,7 +1102,7 @@ def test_phasor_center(
 
 
 def test_phasor_center_exceptions():
-    """Test exceptions in `phasor_center` function."""
+    """Test exceptions in phasor_center function."""
     with pytest.raises(ValueError):
         phasor_center(0, 0, method='method_not_supported')
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Description

While unifying the `phasor_from_signal` and `phasor_from_signal_fft` functions, I noticed that the introduction tutorial failed to calibrate phasor coordinates. `phasor_from_signal_fft` returns `NaN` when DC values are zero, which could not be handled correctly by `phasor_calibrate`. This PR changes the `phasor_center` functions to use `numpy.nanmean` and `numpy.nanmedian` instead of `numpy.mean` and `numpy.median`. I do not know if/how much slower the NaN handling is.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Fix phasor_center with NaN input
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
