### PR TITLE
Fix RuntimeWarning in plot_phasor_image

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -1,7 +1,8 @@
 """Plot phasor coordinates and related data.
 
 The ``phasorpy.plot`` module provides functions and classes to visualize
-phasor coordinates and related data using the matplotlib library.
+phasor coordinates and related data using the
+`matplotlib <https://matplotlib.org/>`_ library.
 
 """
 
@@ -1727,7 +1728,11 @@ def plot_phasor_image(
         if mean.ndim < 2:
             raise ValueError(f'not an image {mean.ndim=} < 2')
         shape = mean.shape
-        mean = numpy.nanmean(mean.reshape(-1, *mean.shape[-2:]), axis=0)
+        mean = mean.reshape(-1, *mean.shape[-2:])
+        if mean.shape[0] == 1:
+            mean = mean[0]
+        else:
+            mean = numpy.nanmean(mean, axis=0)
 
     real = numpy.asarray(real)
     imag = numpy.asarray(imag)
@@ -1749,9 +1754,14 @@ def plot_phasor_image(
     else:
         raise ValueError(f'shape mismatch {real.shape[1:]=} != {shape}')
 
-    # average extra image dimensions, but not harmonics
-    real = numpy.nanmean(real.reshape(nh, -1, *real.shape[-2:]), axis=1)
-    imag = numpy.nanmean(imag.reshape(nh, -1, *imag.shape[-2:]), axis=1)
+    real = real.reshape(nh, -1, *real.shape[-2:])
+    imag = imag.reshape(nh, -1, *imag.shape[-2:])
+    if real.shape[1] == 1:
+        real = real[:, 0]
+        imag = imag[:, 0]
+    else:
+        real = numpy.nanmean(real, axis=1)
+        imag = numpy.nanmean(imag, axis=1)
 
     # for MyPy
     assert isinstance(mean, numpy.ndarray) or mean is None

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -2,6 +2,7 @@
 
 import io
 import math
+import warnings
 
 import numpy
 import pytest
@@ -520,4 +521,14 @@ def test_plot_phasor_image():
     with pytest.raises(ValueError):
         # percentile out of range
         plot_phasor_image(d, d, d, percentile=50, show=False)
+    pyplot.close()
+
+
+def test_plot_phasor_image_runtimewarning():
+    """Test 'RuntimeWarning: Mean of empty slice' is not raised."""
+    data = numpy.zeros((3, 4, 5))
+    data[0, 0, 0] = numpy.nan
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot_phasor_image(data[0], data, data, show=False)
     pyplot.close()


### PR DESCRIPTION
## Description

This PR fixes two RuntimeWarning when using `plot_phasor_image` with images containing `NaN`:

```
phasorpy\plot.py:1753: RuntimeWarning: Mean of empty slice
  real = numpy.nanmean(real.reshape(nh, -1, *real.shape[-2:]), axis=1)
phasorpy\plot.py:1754: RuntimeWarning: Mean of empty slice
  imag = numpy.nanmean(imag.reshape(nh, -1, *imag.shape[-2:]), axis=1)
```
## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Fix RuntimeWarning in plot_phasor_image
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
