### PR TITLE
Unify phasor_from_signal functions

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -254,12 +254,12 @@ def phasor_from_signal(
     >>> sample_phase = numpy.linspace(0, 2 * math.pi, 5, endpoint=False)
     >>> signal = 1.1 * (numpy.cos(sample_phase - 0.785398) * 2 * 0.707107 + 1)
     >>> phasor_from_signal(signal)  # doctest: +NUMBER
-    (1.1, 0.5, 0.5)
+    (array(1.1), array(0.5), array(0.5))
 
     The sinusoidal signal does not have a second harmonic component:
 
     >>> phasor_from_signal(signal, harmonic=2)  # doctest: +NUMBER
-    (1.1, 0.0, 0.0)
+    (array(1.1), array(0.0), array(0.0))
 
     """
     # TODO: C-order not required by rfft?
@@ -329,7 +329,7 @@ def phasor_from_signal(
         numpy.negative(imag, out=imag)
 
         if not keepdims and real.ndim == 0:
-            return mean, real.item(), imag.item()
+            return mean.squeeze(), real.squeeze(), imag.squeeze()
 
         return mean, real, imag
 
@@ -370,7 +370,7 @@ def phasor_from_signal(
     imag = phasor[1 + num_harmonics :].reshape(shape)
     if shape:
         return mean, real, imag
-    return mean.item(), real.item(), imag.item()
+    return mean.squeeze(), real.squeeze(), imag.squeeze()
 
 
 def phasor_to_signal(

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -4,6 +4,7 @@ import copy
 import math
 
 import numpy
+import numpy.fft as numpy_fft
 import pytest
 from numpy.testing import (
     assert_allclose,
@@ -39,7 +40,6 @@ from phasorpy.phasor import (
     phasor_from_lifetime,
     phasor_from_polar,
     phasor_from_signal,
-    phasor_from_signal_fft,
     phasor_multiply,
     phasor_semicircle,
     phasor_to_apparent_lifetime,
@@ -62,98 +62,145 @@ SYNTH_MOD = numpy.array([[2, 2], [2, 2]])
 numpy.random.seed(42)
 
 
-@pytest.mark.parametrize('fft', (True, False))
-def test_phasor_from_signal(fft):
-    """Test phasor_from_signal functions."""
-    func = phasor_from_signal_fft if fft else phasor_from_signal
+@pytest.mark.parametrize('use_fft', (True, False))
+def test_phasor_from_signal(use_fft):
+    """Test phasor_from_signal function."""
     sample_phase = numpy.linspace(0, 2 * math.pi, 7, endpoint=False)
     signal = 1.1 * (numpy.cos(sample_phase - 0.46364761) * 2 * 0.44721359 + 1)
     signal_copy = signal.copy()
 
+    # test scalar type
+    mean, real, imag = phasor_from_signal(signal, use_fft=use_fft)
+    assert isinstance(mean, float)
+    assert isinstance(real, float)
+    assert isinstance(imag, float)
+
     # default is first harmonic
-    assert_allclose(func(signal), (1.1, 0.4, 0.2), atol=1e-6)
+    assert_allclose(
+        phasor_from_signal(signal, use_fft=use_fft), (1.1, 0.4, 0.2), atol=1e-6
+    )
     assert_array_equal(signal, signal_copy)
 
     # specify first harmonic
-    assert_allclose(func(signal, harmonic=1), (1.1, 0.4, 0.2), atol=1e-6)
+    assert_allclose(
+        phasor_from_signal(signal, harmonic=1, use_fft=use_fft),
+        (1.1, 0.4, 0.2),
+        atol=1e-6,
+    )
     assert_array_equal(signal, signal_copy)
 
     # keep harmonic axis
-    dc, re, im = func(signal, harmonic=[1])
+    dc, re, im = phasor_from_signal(signal, harmonic=[1], use_fft=use_fft)
     assert_array_equal(signal, signal_copy)
     assert_allclose(dc, 1.1, atol=1e-6)
     assert_allclose(re, [0.4], atol=1e-6)
     assert_allclose(im, [0.2], atol=1e-6)
 
     # specific harmonic
-    assert_allclose(func(signal, harmonic=2), (1.1, 0.0, 0.0), atol=1e-6)
+    assert_allclose(
+        phasor_from_signal(signal, harmonic=2, use_fft=use_fft),
+        (1.1, 0.0, 0.0),
+        atol=1e-6,
+    )
 
     # list harmonics
-    dc, re, im = func(signal, harmonic=[1, 2])
+    dc, re, im = phasor_from_signal(signal, harmonic=[1, 2], use_fft=use_fft)
     assert_array_equal(signal, signal_copy)
     assert_allclose(dc, 1.1, atol=1e-6)
     assert_allclose(re, [0.4, 0.0], atol=1e-6)
     assert_allclose(im, [0.2, 0.0], atol=1e-6)
 
     # all harmonics
-    dc, re, im = func(signal, harmonic='all')
+    dc, re, im = phasor_from_signal(signal, harmonic='all', use_fft=use_fft)
     assert_array_equal(signal, signal_copy)
     assert_allclose(dc, 1.1, atol=1e-6)
     assert_allclose(re, (0.4, 0.0, 0.0), atol=1e-6)
     assert_allclose(im, (0.2, 0.0, 0.0), atol=1e-6)
 
-    if not fft:
-        assert_allclose(
-            func(signal[::-1], sample_phase=sample_phase[::-1], num_threads=0),
-            (1.1, 0.4, 0.2),
-            atol=1e-6,
-        )
-        assert_allclose(
-            func(signal[::-1], sample_phase=sample_phase[::-1], harmonic=1),
-            (1.1, 0.4, 0.2),
-            atol=1e-6,
-        )
-        assert_allclose(
-            func(numpy.cos(sample_phase)), [0.0, 0.0, 0.0], atol=1e-6
-        )
+    # zero signal
     assert_allclose(
-        func(numpy.zeros(256)),
-        (0.0, numpy.nan, numpy.nan) if fft else (0.0, 0.0, 0.0),
+        phasor_from_signal(numpy.zeros(256), use_fft=use_fft),
+        (0.0, numpy.nan, numpy.nan),
         atol=1e-6,
     )
 
+    # no modulation
+    assert_allclose(
+        phasor_from_signal(numpy.ones(256), use_fft=use_fft),
+        (1.0, 0.0, 0.0),
+        atol=1e-6,
+    )
+
+    # numerically unstable?
+    # assert_allclose(
+    #     phasor_from_signal(numpy.cos(sample_phase), use_fft=use_fft),
+    #     [0.0, 0.0, 0.0],
+    #     atol=1e-6,
+    # )
+
+    if not use_fft:
+        assert_allclose(
+            phasor_from_signal(
+                signal[::-1],
+                sample_phase=sample_phase[::-1],
+                num_threads=0,
+                use_fft=use_fft,
+            ),
+            (1.1, 0.4, 0.2),
+            atol=1e-6,
+        )
+        assert_allclose(
+            phasor_from_signal(
+                signal[::-1],
+                sample_phase=sample_phase[::-1],
+                harmonic=1,
+                use_fft=use_fft,
+            ),
+            (1.1, 0.4, 0.2),
+            atol=1e-6,
+        )
+
     with pytest.raises(ValueError):
-        func(signal[:2])
+        phasor_from_signal(signal[:2], use_fft=use_fft)
     with pytest.raises(TypeError):
-        func(signal, harmonic=1.0)
+        phasor_from_signal(signal, harmonic=1.0, use_fft=use_fft)
     with pytest.raises(TypeError):
-        func(signal, harmonic=[])
+        phasor_from_signal(signal, harmonic=[], use_fft=use_fft)
     with pytest.raises(TypeError):
-        func(signal, harmonic=[1.0])
+        phasor_from_signal(signal, harmonic=[1.0], use_fft=use_fft)
     with pytest.raises(IndexError):
-        func(signal, harmonic=0)
+        phasor_from_signal(signal, harmonic=0, use_fft=use_fft)
     with pytest.raises(ValueError):
-        func(signal, harmonic='none')
+        phasor_from_signal(signal, harmonic='none', use_fft=use_fft)
     with pytest.raises(IndexError):
-        func(signal, harmonic=[0])
+        phasor_from_signal(signal, harmonic=[0], use_fft=use_fft)
     with pytest.raises(IndexError):
-        func(signal, harmonic=[4])
+        phasor_from_signal(signal, harmonic=[4], use_fft=use_fft)
     with pytest.raises(IndexError):
-        func(signal, harmonic=4)
+        phasor_from_signal(signal, harmonic=4, use_fft=use_fft)
     with pytest.raises(ValueError):
-        func(signal, harmonic=[1, 1])
+        phasor_from_signal(signal, harmonic=[1, 1], use_fft=use_fft)
     with pytest.raises(TypeError):
-        func(signal.astype('complex64'))
-    if not fft:
+        phasor_from_signal(signal.astype('complex64'), use_fft=use_fft)
+    if not use_fft:
         with pytest.raises(ValueError):
-            func(signal, sample_phase=sample_phase, harmonic=2)
+            phasor_from_signal(
+                signal, sample_phase=sample_phase, harmonic=2, use_fft=use_fft
+            )
         with pytest.raises(ValueError):
-            func(signal, sample_phase=sample_phase[::-2])
+            phasor_from_signal(
+                signal, sample_phase=sample_phase[::-2], use_fft=use_fft
+            )
         with pytest.raises(TypeError):
-            func(signal, dtype='int8')
+            phasor_from_signal(signal, dtype='int8', use_fft=use_fft)
+    else:
+        with pytest.raises(ValueError):
+            phasor_from_signal(
+                signal, sample_phase=sample_phase, use_fft=use_fft
+            )
 
 
-@pytest.mark.parametrize('fft', (True, False))
+@pytest.mark.parametrize('use_fft', (True, False))
 @pytest.mark.parametrize(
     'shape, axis, dtype, dtype_out',
     [
@@ -174,13 +221,13 @@ def test_phasor_from_signal(fft):
         # TODO: can't test uint with this
     ],
 )
-def test_phasor_from_signal_param(fft, shape, axis, dtype, dtype_out):
-    """Test phasor_from_signal functions parameters."""
+def test_phasor_from_signal_param(use_fft, shape, axis, dtype, dtype_out):
+    """Test phasor_from_signal function parameters."""
     samples = shape[axis]
     dtype = numpy.dtype(dtype)
     signal = numpy.empty(shape, dtype)
     sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
-    if not fft:
+    if not use_fft:
         sample_phase[0] = sample_phase[-1]  # out of order
         sample_phase[-1] = 0.0
     sig = 2.1 * (numpy.cos(sample_phase - 0.46364761) * 2 * 0.44721359 + 1)
@@ -190,8 +237,10 @@ def test_phasor_from_signal_param(fft, shape, axis, dtype, dtype_out):
     reshape = [1] * len(shape)
     reshape[axis] = samples
     signal[:] = sig.reshape(reshape)
-    if fft:
-        mean, real, imag = phasor_from_signal_fft(signal, axis=axis)
+    if use_fft:
+        mean, real, imag = phasor_from_signal(
+            signal, axis=axis, use_fft=True, dtype=dtype_out
+        )
     else:
         num_threads = 4 if signal.size > 4096 else 1
         mean, real, imag = phasor_from_signal(
@@ -200,10 +249,10 @@ def test_phasor_from_signal_param(fft, shape, axis, dtype, dtype_out):
             sample_phase=sample_phase,
             dtype=dtype_out,
             num_threads=num_threads,
+            use_fft=False,
         )
     if isinstance(mean, numpy.ndarray):
-        if not fft:
-            assert mean.dtype == dtype_out
+        assert mean.dtype == dtype_out
         assert mean.shape == shape[:axis] + shape[axis + 1 :]
     if dtype.kind == 'f':
         assert_allclose(numpy.mean(mean), 2.1, 1e-3)
@@ -213,10 +262,11 @@ def test_phasor_from_signal_param(fft, shape, axis, dtype, dtype_out):
     assert_allclose(numpy.mean(imag), 0.2, 1e-3)
 
 
-@pytest.mark.parametrize('fft', (True, False))
-def test_phasor_from_signal_noncontig(fft):
+@pytest.mark.parametrize('use_fft', (True, False))
+@pytest.mark.parametrize('dtype', ('float32', 'float64'))
+def test_phasor_from_signal_noncontig(use_fft, dtype):
     """Test phasor_from_signal functions with non-contiguous input."""
-    dtype = numpy.float64
+    dtype = numpy.dtype(dtype)
     samples = 31
     signal = numpy.empty((7, 19, samples, 11), dtype)
     sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
@@ -229,11 +279,12 @@ def test_phasor_from_signal_noncontig(fft):
     assert signal.shape == (7, samples, 19, 11)
     assert not signal.flags['C_CONTIGUOUS']
     signal_copy = signal.copy()
-    if fft:
-        mean, real, imag = phasor_from_signal_fft(signal, axis=-3)
-    else:
-        mean, real, imag = phasor_from_signal(signal, axis=-3, dtype=dtype)
+    mean, real, imag = phasor_from_signal(
+        signal, axis=-3, dtype=dtype, use_fft=use_fft
+    )
     assert_array_equal(signal, signal_copy)
+    assert real.dtype == dtype
+    assert mean.dtype == dtype
     assert mean.shape == signal.shape[:1] + signal.shape[1 + 1 :]
     assert_allclose(numpy.mean(mean), 2.1, 1e-3)
     assert_allclose(numpy.mean(real), 0.4, 1e-3)
@@ -243,32 +294,32 @@ def test_phasor_from_signal_noncontig(fft):
 @pytest.mark.parametrize('scalar', (True, False))
 @pytest.mark.parametrize('harmonic', ('all', 1, 2, 8, [1], [1, 2, 8]))
 def test_phasor_from_signal_harmonic(scalar, harmonic):
-    """Test phasor_from_signal functions harmonic parameter."""
+    """Test phasor_from_signal function harmonic parameter."""
     rng = numpy.random.default_rng(1)
     signal = rng.random((33,) if scalar else (3, 33, 61, 63))
     signal += 1.1
     kwargs = dict(axis=0 if scalar else 1, harmonic=harmonic)
-    mean0, real0, imag0 = phasor_from_signal(signal, **kwargs)
-    mean1, real1, imag1 = phasor_from_signal_fft(signal, **kwargs)
+    mean0, real0, imag0 = phasor_from_signal(signal, use_fft=False, **kwargs)
+    mean1, real1, imag1 = phasor_from_signal(signal, use_fft=True, **kwargs)
     assert_allclose(mean0, mean1, 1e-8)
     assert_allclose(real0, real1, 1e-8)
     assert_allclose(imag0, imag1, 1e-8)
 
 
-@pytest.mark.parametrize('fft', (scipy_fft, mkl_fft))
+@pytest.mark.parametrize('fft', (numpy_fft, scipy_fft, mkl_fft))
 @pytest.mark.parametrize('scalar', (True, False))
 @pytest.mark.parametrize('harmonic', (1, [4], [1, 4]))
 def test_phasor_from_signal_fft_func(fft, scalar, harmonic):
-    """Test phasor_from_signal_fft functions rfft_func parameter."""
+    """Test phasor_from_signal_fft function rfft parameter."""
     if fft is None:
         pytest.skip('rfft function could not be imported')
     rng = numpy.random.default_rng(1)
     signal = rng.random((33,) if scalar else (3, 33, 61, 63))
     signal += 1.1
     kwargs = dict(axis=0 if scalar else 1, harmonic=harmonic)
-    mean0, real0, imag0 = phasor_from_signal_fft(signal, **kwargs)
-    mean1, real1, imag1 = phasor_from_signal_fft(
-        signal, rfft_func=fft.rfft, **kwargs
+    mean0, real0, imag0 = phasor_from_signal(signal, use_fft=True, **kwargs)
+    mean1, real1, imag1 = phasor_from_signal(
+        signal, rfft=fft.rfft, use_fft=True, **kwargs
     )
     assert_allclose(mean0, mean1, 1e-8)
     assert_allclose(real0, real1, 1e-8)
@@ -369,7 +420,7 @@ def test_phasor_to_signal():
     """Test phasor_to_signal function."""
     sample_phase = numpy.linspace(0, 2 * math.pi, 5, endpoint=False)
     signal = 1.1 * (numpy.cos(sample_phase - 0.78539816) * 2 * 0.70710678 + 1)
-    assert_allclose(phasor_from_signal_fft(signal), (1.1, 0.5, 0.5))
+    assert_allclose(phasor_from_signal(signal, use_fft=True), (1.1, 0.5, 0.5))
 
     assert_allclose(
         phasor_to_signal(1.1, 0.5, 0.5, samples=5), signal, atol=1e-4

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -72,9 +72,9 @@ def test_phasor_from_signal(use_fft):
 
     # test scalar type
     mean, real, imag = phasor_from_signal(signal, use_fft=use_fft)
-    assert isinstance(mean, float)
-    assert isinstance(real, float)
-    assert isinstance(imag, float)
+    assert mean.ndim == 0
+    assert real.ndim == 0
+    assert imag.ndim == 0
 
     # default is first harmonic
     assert_allclose(

--- a/tutorials/benchmarks/phasorpy_phasor_from_signal.py
+++ b/tutorials/benchmarks/phasorpy_phasor_from_signal.py
@@ -4,24 +4,26 @@ Benchmark phasor_from_signal
 
 Benchmark the ``phasor_from_signal`` function.
 
-The :doc:`/api/phasor` module provides two functions to calculate phasor
-coordinates from time-resolved or spectral signals:
+The :py:func:`phasorpy.phasor.phasor_from_signal` function to calculate phasor
+coordinates from time-resolved or spectral signals can operate in two modes:
 
-- :py:func:`phasorpy.phasor.phasor_from_signal`,
-  implemented mostly in Cython for efficiency.
+- using an internal Cython function optimized for calculating a small number
+  of harmonics, optionally using multiple threads.
 
-- :py:func:`phasorpy.phasor.phasor_from_signal_fft`,
-  a pure Python reference implementation based on ``numpy.fft.rfft``.
+- using a real forward Fast Fourier Transform (FFT), ``numpy.fft.rfft`` or
+  a drop-in replacement function like ``scipy.fft.rfft``
+  or ``mkl_fft._numpy_fft.rfft``.
 
-This tutorial compares the performance of the two implementations.
+This tutorial compares the performance of the two modes.
 
 """
 
 from timeit import timeit
 
 import numpy
+from numpy.fft import rfft as numpy_fft
 
-from phasorpy.phasor import phasor_from_signal, phasor_from_signal_fft
+from phasorpy.phasor import phasor_from_signal
 from phasorpy.utils import number_threads
 
 try:
@@ -44,107 +46,104 @@ signal = numpy.random.default_rng(1).random((384, 384, 384))
 signal += 1.1
 signal *= 3723  # ~12 bit
 signal = signal.astype(numpy.uint16)  # 108 MB
+signal[signal < 0.05] = 0.0  # 5% no signal
 
 # %%
 # Print execution times depending on function, axis, number of harmonics,
 # and number of threads:
 
 
-statement = 'func(signal, axis=axis, harmonic=harmonic, **kwargs)'
+statement = """
+phasor_from_signal(signal, axis=axis, harmonic=harmonic, **kwargs)
+"""
 number = 1  # how many times to execute statement
 ref = None  # reference duration
 
 
 def print_(descr, t):
-    print(f'    {descr:24s}{t / number:>6.3f}s {t / ref:>6.2f}')
+    print(f'    {descr:20s}{t / number:>6.3f}s {t / ref:>6.2f}')
 
 
 for harmonic in ([1], [1, 2, 3, 4, 5, 6, 7, 8]):
     print(f'harmonics {len(harmonic)}')
     for axis in (-1, 0, 2):
         print(f'  axis {axis}')
-        func = phasor_from_signal  # type: ignore
-        kwargs = {}
+        kwargs = {'use_fft': False, 'num_threads': 1}
         t = timeit(statement, number=number, globals=globals())
         if ref is None:
             ref = t
-        print_(func.__name__, t)
+        print_('not_fft', t)
 
         num_threads = number_threads(0, 6)
         if num_threads > 1:
-            kwargs = {'num_threads': num_threads}
+            kwargs = {'use_fft': False, 'num_threads': num_threads}
             t = timeit(statement, number=number, globals=globals())
-            print_(f'  threads {num_threads}', t)
+            print_(f'not_fft ({num_threads} threads)', t)
 
-        func = phasor_from_signal_fft  # type: ignore
-        kwargs = {}
-        t = timeit(statement, number=number, globals=globals())
-        print_(func.__name__, t)
-
-        for fft_name in ('scipy_fft', 'mkl_fft'):
+        for fft_name in ('numpy_fft', 'scipy_fft', 'mkl_fft'):
             fft_func = globals()[fft_name]
             if fft_func is None:
                 continue
-            kwargs = {'rfft_func': fft_func}
+            kwargs = {'use_fft': True, 'rfft': fft_func}
             t = timeit(statement, number=number, globals=globals())
-            print_(f'  {fft_name}', t)
+            print_(f'{fft_name}', t)
 
 # %%
-# For reference, the results on a Core i7-14700K CPU::
+# For reference, the results on a Core i7-14700K CPU, Windows 11::
 #
-#      harmonics 1
-#        axis -1
-#          phasor_from_signal       0.035s   1.00
-#            threads 6              0.008s   0.24
-#          phasor_from_signal_fft   0.270s   7.72
-#            scipy_fft              0.236s   6.74
-#            mkl_fft                0.128s   3.67
-#        axis 0
-#          phasor_from_signal       0.158s   4.50
-#            threads 6              0.036s   1.02
-#          phasor_from_signal_fft   0.724s  20.66
-#            scipy_fft              0.516s  14.72
-#            mkl_fft                0.177s   5.04
-#        axis 2
-#          phasor_from_signal       0.035s   1.01
-#            threads 6              0.007s   0.19
-#          phasor_from_signal_fft   0.273s   7.79
-#            scipy_fft              0.243s   6.93
-#            mkl_fft                0.131s   3.73
-#      harmonics 8
-#        axis -1
-#          phasor_from_signal       0.268s   7.65
-#            threads 6              0.040s   1.15
-#          phasor_from_signal_fft   0.289s   8.26
-#            scipy_fft              0.252s   7.19
-#            mkl_fft                0.148s   4.21
-#        axis 0
-#          phasor_from_signal       1.260s  35.96
-#            threads 6              0.308s   8.78
-#          phasor_from_signal_fft   0.718s  20.49
-#            scipy_fft              0.528s  15.06
-#            mkl_fft                0.172s   4.91
-#        axis 2
-#          phasor_from_signal       0.274s   7.82
-#            threads 6              0.041s   1.18
-#          phasor_from_signal_fft   0.283s   8.06
-#            scipy_fft              0.253s   7.21
-#            mkl_fft                0.143s   4.08
+#     harmonics 1
+#       axis -1
+#         not_fft              0.036s   1.00
+#         not_fft (6 threads)  0.008s   0.21
+#         numpy_fft            0.285s   7.89
+#         scipy_fft            0.247s   6.84
+#         mkl_fft              0.124s   3.43
+#       axis 0
+#         not_fft              0.156s   4.32
+#         not_fft (6 threads)  0.041s   1.14
+#         numpy_fft            0.743s  20.60
+#         scipy_fft            0.583s  16.16
+#         mkl_fft              0.182s   5.03
+#       axis 2
+#         not_fft              0.037s   1.02
+#         not_fft (6 threads)  0.009s   0.25
+#         numpy_fft            0.282s   7.81
+#         scipy_fft            0.244s   6.78
+#         mkl_fft              0.125s   3.47
+#     harmonics 8
+#       axis -1
+#         not_fft              0.275s   7.62
+#         not_fft (6 threads)  0.041s   1.13
+#         numpy_fft            0.295s   8.18
+#         scipy_fft            0.267s   7.39
+#         mkl_fft              0.145s   4.02
+#       axis 0
+#         not_fft              1.250s  34.66
+#         not_fft (6 threads)  0.325s   9.01
+#         numpy_fft            0.732s  20.28
+#         scipy_fft            0.546s  15.13
+#         mkl_fft              0.168s   4.67
+#       axis 2
+#         not_fft              0.278s   7.72
+#         not_fft (6 threads)  0.040s   1.11
+#         numpy_fft            0.298s   8.25
+#         scipy_fft            0.270s   7.48
+#         mkl_fft              0.143s   3.98
 
 # %%
 # Results
 # -------
 #
-# - The ``phasor_from_signal`` implementation is significantly faster than
-#   the ``numpy.fft`` based reference implementation for single harmonics.
+# - Using the Cython implementation is significantly faster than using the
+#   ``numpy.fft`` based implementation for single harmonics.
+# - Using multiple threads can significantly speed up the Cython mode.
 # - The FFT functions from ``scipy`` and ``mkl_fft`` outperform numpy.fft.
-#   ``mkl_fft`` is very performant.
+#   Specifically, ``mkl_fft`` is very performant.
 # - Using FFT becomes more competitive when calculating larger number of
 #   harmonics.
 # - Computing over the last axis is significantly faster compared to the first
 #   axis. That is because the samples in the last dimension are contiguous,
 #   closer together in memory.
-# - Using multiple threads can significantly speed up the calculation.
 #
 # Note that these results were obtained on a single dataset of random numbers.
 
@@ -152,6 +151,6 @@ for harmonic in ([1], [1, 2, 3, 4, 5, 6, 7, 8]):
 # Conclusions
 # -----------
 #
-# The ``phasor_from_signal`` implementation is a reasonable default.
-# The ``phasor_from_signal_fft`` function may be a better choice, for example,
+# Using the Cython implementation is a reasonable default when calculating
+# a few harmonics. Using FFT may be a better choice, for example,
 # when computing large number of harmonics with an optimized FFT function.


### PR DESCRIPTION
## Description

This PR merges the `phasor_from_signal` and `phasor_from_signal_fft` functions into one:

- Remove `phasor_from_signal_fft` function.
- Add two parameters to `phasor_from_signal`: `use_fft` and `rfft` (used to be `rfft_func`). By default, FFT is automatically used when all or at least 8 harmonics are calculated, or a `rfft` function is specified.
- Change `irfft_func` parameter to `irfft` in `phasor_to_signal`.
- Change Cython implementation to return `NaN` or `Inf` instead of 0.0 in case of zero DC.
- Document that zero phasor coordinates are legit and phasor coordinates are undefined for zero DC.
- Update tests.
- Update benchmark tutorial.

The introduction tutorial is currently failing due to #96 and #97

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Unify phasor_from_signal functions
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
