### PR TITLE
Improve handling of NaN values

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -628,7 +628,7 @@ cdef (float_t, float_t) _phasor_transform(
 ) noexcept nogil:
     """Return rotated and scaled phasor coordinates."""
     cdef:
-        double g, s = scale * sin(angle)
+        double g, s
 
     if isnan(real) or isnan(imag) or isnan(angle) or isnan(scale):
         return <float_t> NAN, <float_t> NAN

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -260,7 +260,6 @@ def graphical_component_analysis(
                         b_real + f * ab_real,  # cursor_real
                         b_imag + f * ab_imag,  # cursor_imag
                         radius,
-                        True,
                     )
                 else:
                     # num_components == 3
@@ -272,7 +271,6 @@ def graphical_component_analysis(
                         components_real[3 - i - j],  # c_real
                         components_imag[3 - i - j],  # c_imag
                         radius,
-                        True,
                     )
                 fraction_counts = numpy.sum(mask)
                 component_counts.append(fraction_counts)

--- a/src/phasorpy/cursors.py
+++ b/src/phasorpy/cursors.py
@@ -124,9 +124,7 @@ def mask_from_circular_cursor(
         real = numpy.expand_dims(real, axis=-1)
         imag = numpy.expand_dims(imag, axis=-1)
 
-    mask = _is_inside_circle(
-        real, imag, center_real, center_imag, radius, True
-    )
+    mask = _is_inside_circle(real, imag, center_real, center_imag, radius)
     if moveaxis:
         mask = numpy.moveaxis(mask, -1, 0)
     return mask.astype(numpy.bool_)
@@ -269,7 +267,6 @@ def mask_from_elliptic_cursor(
         radius_b,
         angle_sin,
         angle_cos,
-        True,
     )
     if moveaxis:
         mask = numpy.moveaxis(mask, -1, 0)
@@ -379,7 +376,7 @@ def mask_from_polar_cursor(
         imag = numpy.expand_dims(imag, axis=-1)
 
     mask = _is_inside_polar_rectangle(
-        real, imag, phase_min, phase_max, modulation_min, modulation_max, True
+        real, imag, phase_min, phase_max, modulation_min, modulation_max
     )
     if moveaxis:
         mask = numpy.moveaxis(mask, -1, 0)

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -2455,7 +2455,7 @@ def phasor_to_principal_plane(
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
     """Return multi-harmonic phasor coordinates projected onto principal plane.
 
-    The Principal Component Analysis (PCA) is used to project
+    Principal Component Analysis (PCA) is used to project
     multi-harmonic phasor coordinates onto a plane, along which
     coordinate axes the phasor coordinates have the largest variations.
 
@@ -2491,16 +2491,6 @@ def phasor_to_principal_plane(
     transformation_matrix : ndarray
         Affine transformation matrix used to project phasor coordinates.
         The shape is ``(2, 2 * real.shape[0])``.
-        The matrix can be used to project multi-harmonic phasor coordinates,
-        where the first axis is the frequency::
-
-            x, y = numpy.dot(
-                numpy.vstack(
-                    real.reshape(real.shape[0], -1),
-                    imag.reshape(imag.shape[0], -1),
-                ),
-                transformation_matrix,
-            ).reshape(2, *real.shape[1:])
 
     See Also
     --------
@@ -2508,6 +2498,22 @@ def phasor_to_principal_plane(
 
     Notes
     -----
+
+    This implementation does not work with coordinates containing
+    undefined `NaN` values.
+
+    The transformation matrix can be used to project multi-harmonic phasor
+    coordinates, where the first axis is the frequency:
+
+    .. code-block:: python
+
+        x, y = numpy.dot(
+            numpy.vstack(
+                real.reshape(real.shape[0], -1),
+                imag.reshape(imag.shape[0], -1),
+            ),
+            transformation_matrix,
+        ).reshape(2, *real.shape[1:])
 
     An application of PCA to full-harmonic phasor coordinates from MRI signals
     can be found in [1]_.
@@ -2550,7 +2556,7 @@ def phasor_to_principal_plane(
     coordinates = numpy.vstack((re, im))
 
     # vector of centered coordinates
-    center = coordinates.mean(1, keepdims=True)
+    center = numpy.nanmean(coordinates, axis=1, keepdims=True)
     coordinates -= center
 
     # covariance matrix (scatter matrix would also work)

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -329,6 +329,7 @@ def phasor_from_signal(
             real = numpy.moveaxis(real, axis, 0)
             imag = numpy.moveaxis(imag, axis, 0)
 
+        # complex division by mean signal
         with numpy.errstate(divide='ignore', invalid='ignore'):
             real /= dc
             imag /= dc
@@ -433,6 +434,11 @@ def phasor_to_signal(
     --------
     phasorpy.phasor.phasor_from_signal
 
+    Notes
+    -----
+    The reconstructed signal may be undefined if the input phasor coordinates
+    or signal mean contain `NaN` values.
+
     Examples
     --------
     Reconstruct exact signal from phasor coordinates at all harmonics:
@@ -501,6 +507,7 @@ def phasor_to_signal(
     if len(harmonic) != real.shape[0]:
         raise ValueError(f'{len(harmonic)=} != {real.shape[0]=}')
 
+    # complex multiplication by mean signal
     real *= mean
     imag *= mean
     numpy.negative(imag, out=imag)
@@ -2664,6 +2671,11 @@ def phasor_filter(
     -----
     For now, only the median filter method is implemented.
     Additional filtering methods may be added in the future.
+
+    The implementation of the median filter method is based on
+    :py:func:`scipy.ndimage.median_filter`,
+    which has undefined behavior if the input arrays contain `NaN` values.
+    See `issue #87 <https://github.com/phasorpy/phasorpy/issues/87>`_.
 
     Examples
     --------

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -43,12 +43,8 @@ def test_is_inside_circle():
     """Test _is_inside_circle function."""
     circle = 0.8, 0.4, 0.05
     assert_array_equal(
-        _is_inside_circle(*POINTS, *circle, True).astype(bool),
+        _is_inside_circle(*POINTS, *circle).astype(bool),
         [False, False, True],
-    )
-    assert_array_equal(
-        _is_inside_circle(*POINTS, *circle, False).astype(bool),
-        [False, False, False],
     )
 
 
@@ -57,23 +53,23 @@ def test_is_inside_ellipse():
     # compare to circle
     circle = 0.8, 0.4, 0.05
     assert_array_equal(
-        _is_inside_ellipse(*POINTS, *circle, 0.05, 1e-3, True),
-        _is_inside_circle(*POINTS, *circle, True),
+        _is_inside_ellipse(*POINTS, *circle, 0.05, 1e-3),
+        _is_inside_circle(*POINTS, *circle),
     )
     assert_array_equal(
-        _is_inside_ellipse_(*POINTS, *circle, 0.05, 1e-3, 1e-3, True),
-        _is_inside_circle(*POINTS, *circle, True),
+        _is_inside_ellipse_(*POINTS, *circle, 0.05, 1e-3, 1e-3),
+        _is_inside_circle(*POINTS, *circle),
     )
     # ellipse
     ellipse = 0.8, 0.4, 0.05, 0.1
     angle = math.pi / 4
     assert_array_equal(
-        _is_inside_ellipse(*POINTS, *ellipse, angle, True).astype(bool),
+        _is_inside_ellipse(*POINTS, *ellipse, angle).astype(bool),
         [False, True, True],
     )
     assert_array_equal(
         _is_inside_ellipse_(
-            *POINTS, *ellipse, math.sin(angle), math.cos(angle), True
+            *POINTS, *ellipse, math.sin(angle), math.cos(angle)
         ).astype(bool),
         [False, True, True],
     )
@@ -82,7 +78,7 @@ def test_is_inside_ellipse():
 def test_is_inside_range():
     """Test _is_inside_range function."""
     assert_array_equal(
-        _is_inside_range(*POINTS, 0.3, 0.5, 0.35, 0.5, True).astype(bool),
+        _is_inside_range(*POINTS, 0.3, 0.5, 0.35, 0.5).astype(bool),
         [True, False, False],
     )
 
@@ -90,9 +86,7 @@ def test_is_inside_range():
 def test_is_inside_rectangle():
     """Test _is_inside_rectangle function."""
     assert_array_equal(
-        _is_inside_rectangle(*POINTS, 0.4, 0.38, 0.83, 0.4, 0.1, True).astype(
-            bool
-        ),
+        _is_inside_rectangle(*POINTS, 0.4, 0.38, 0.83, 0.4, 0.1).astype(bool),
         [True, False, True],
     )
 
@@ -101,7 +95,7 @@ def test_is_inside_polar_rectangle():
     """Test _is_inside_polar_rectangle function."""
     assert_array_equal(
         _is_inside_polar_rectangle(
-            *POINTS, math.pi / 3, math.pi / 5, 0.5, 0.8, True
+            *POINTS, math.pi / 3, math.pi / 5, 0.5, 0.8
         ).astype(bool),
         [True, False, False],
     )
@@ -111,23 +105,19 @@ def test_is_inside_stadium():
     """Test _is_inside_stadium function."""
     stadium = 0.8, 0.4, 0.042, 0.2, 0.025
     assert_allclose(
-        _is_inside_stadium([0.4, 0.84], [0.38, 0.4], *stadium, True).astype(
-            bool
-        ),
+        _is_inside_stadium([0.4, 0.84], [0.38, 0.4], *stadium).astype(bool),
         [False, False],
     )
     assert_allclose(
-        _is_inside_stadium([0.4, 0.82], [0.38, 0.4], *stadium, True).astype(
-            bool
-        ),
+        _is_inside_stadium([0.4, 0.82], [0.38, 0.4], *stadium).astype(bool),
         [False, True],
     )
     assert_allclose(
-        _is_inside_stadium(0.8, 0.4, *stadium, True).astype(bool),
+        _is_inside_stadium(0.8, 0.4, *stadium).astype(bool),
         [True],
     )
     assert_allclose(
-        _is_inside_stadium(0.9, 0.4, *stadium, True).astype(bool),
+        _is_inside_stadium(0.9, 0.4, *stadium).astype(bool),
         [False],
     )
     assert _is_near_segment is _is_near_segment
@@ -136,7 +126,7 @@ def test_is_inside_stadium():
 def test_is_near_line():
     """Test _is_near_line function."""
     assert_array_equal(
-        _is_near_line(*POINTS, 0.4, 0.38, 0.83, 0.4, 0.001, True).astype(bool),
+        _is_near_line(*POINTS, 0.4, 0.38, 0.83, 0.4, 0.001).astype(bool),
         [True, False, True],
     )
 
@@ -339,29 +329,29 @@ def test_geometric_ufunc_on_grid():
     re, im = _point_on_segment(real, imag, *line)
     plot_points(re, im, title='_point_on_segment', ax=ax[3, 1])
 
-    mask = _is_near_line(real, imag, *line, 0.1, True)
+    mask = _is_near_line(real, imag, *line, 0.1)
     plot_mask(real, imag, mask, title='_is_near_line', ax=ax[4, 0])
 
-    mask = _is_inside_stadium(real, imag, *line, 0.1, True)
+    mask = _is_inside_stadium(real, imag, *line, 0.1)
     plot_mask(real, imag, mask, title='_is_inside_stadium', ax=ax[4, 1])
 
-    mask = _is_inside_circle(real, imag, 0.5, 0.5, 0.1, True)
+    mask = _is_inside_circle(real, imag, 0.5, 0.5, 0.1)
     plot_mask(real, imag, mask, title='_is_inside_circle', ax=ax[5, 0])
 
-    mask = _is_inside_ellipse(real, imag, 0.5, 0.5, 0.05, 0.15, pi / 4, True)
+    mask = _is_inside_ellipse(real, imag, 0.5, 0.5, 0.05, 0.15, pi / 4)
     plot_mask(real, imag, mask, title='_is_inside_ellipse', ax=ax[5, 1])
 
     mask = _is_inside_polar_rectangle(
-        real, imag, pi / 5, pi / 3 + 4 * pi, 0.6071, 0.8071, True
+        real, imag, pi / 5, pi / 3 + 4 * pi, 0.6071, 0.8071
     )
     plot_mask(
         real, imag, mask, title='_is_inside_polar_rectangle', ax=ax[6, 0]
     )
 
-    mask = _is_inside_rectangle(real, imag, *line, 0.1, True)
+    mask = _is_inside_rectangle(real, imag, *line, 0.1)
     plot_mask(real, imag, mask, title='_is_inside_rectangle', ax=ax[6, 1])
 
-    mask = _is_inside_range(real, imag, 0.4, 0.6, 0.45, 0.55, True)
+    mask = _is_inside_range(real, imag, 0.4, 0.6, 0.45, 0.55)
     plot_mask(real, imag, mask, title='_is_inside_range', ax=ax[7, 0])
 
     plot_points([], [], title='', ax=ax[7, 1])

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -1,0 +1,340 @@
+"""Tests handling NaN coordinates."""
+
+import warnings
+
+import numpy
+import pytest
+from matplotlib import pyplot
+from numpy import nan
+from numpy.testing import assert_allclose
+
+from phasorpy.cursors import (
+    mask_from_circular_cursor,
+    mask_from_elliptic_cursor,
+    mask_from_polar_cursor,
+)
+from phasorpy.phasor import (
+    phasor_at_harmonic,
+    phasor_calibrate,
+    phasor_center,
+    phasor_divide,
+    phasor_filter,
+    phasor_from_apparent_lifetime,
+    phasor_from_polar,
+    phasor_from_signal,
+    phasor_multiply,
+    phasor_threshold,
+    phasor_to_apparent_lifetime,
+    phasor_to_complex,
+    phasor_to_polar,
+    phasor_to_principal_plane,
+    phasor_to_signal,
+    phasor_transform,
+    polar_from_apparent_lifetime,
+    polar_from_reference,
+    polar_from_reference_phasor,
+    polar_to_apparent_lifetime,
+)
+from phasorpy.plot import PhasorPlot, plot_phasor_image
+
+VALUES_WITH_NAN = [0.5, nan, 0.1], [0.5, 0.5, 0.1]
+
+
+def test_phasorplot_nan():
+    """Test PhasorPlot methods with NaN values."""
+    plot = PhasorPlot()
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.plot(*VALUES_WITH_NAN)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.hist2d(*VALUES_WITH_NAN)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.contour(*VALUES_WITH_NAN)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.components(*VALUES_WITH_NAN)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.line(*VALUES_WITH_NAN)
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot.circle(nan, 0.5, radius=0.1)
+    with pytest.raises(ValueError):
+        plot.cursor(nan, 0.5, radius=0.1)
+    # pyplot.show()
+    pyplot.close()
+
+
+def test_plot_phasor_image_nan():
+    """Test plot_phasor_image function with NaN values."""
+    data = numpy.zeros((2, 3, 2))
+    data[0, 0, 0] = numpy.nan
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        plot_phasor_image(data[0], data, data, show=False)
+    pyplot.close()
+
+
+def test_mask_from_circular_cursor_nan():
+    """Test mask_from_circular_cursor function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        mask = mask_from_circular_cursor(
+            *VALUES_WITH_NAN, 0.55, 0.55, radius=0.1
+        )
+    assert_allclose(mask, [True, False, False])
+
+
+def test_mask_from_elliptic_cursor_nan():
+    """Test mask_from_elliptic_cursor function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        mask = mask_from_elliptic_cursor(
+            *VALUES_WITH_NAN, 0.55, 0.55, radius=0.1
+        )
+    assert_allclose(mask, [True, False, False])
+
+
+def test_mask_from_polar_cursor_nan():
+    """Test mask_from_polar_cursor function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        mask = mask_from_polar_cursor(*VALUES_WITH_NAN, 0, 1, 0.6, 0.8)
+    assert_allclose(mask, [True, False, False])
+
+
+def test_phasor_at_harmonic_nan():
+    """Test phasor_at_harmonic function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_at_harmonic(VALUES_WITH_NAN[0], 1, 2)
+    assert_allclose(
+        phasor, [[0.2, nan, 0.027027], [0.4, nan, 0.162162]], atol=1e-3
+    )
+
+
+def test_phasor_calibrate_nan():
+    """Test phasor_calibrate function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_calibrate(*VALUES_WITH_NAN, 0.0, 1.0, 80, 4.2)
+    assert_allclose(
+        phasor, [[0.28506, nan, 0.05701], [0.10181, nan, 0.02036]], atol=1e-3
+    )
+
+
+def test_phasor_center_nan():
+    """Test phasor_center function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        center = phasor_center(*VALUES_WITH_NAN)
+    assert_allclose(center, [0.3, 0.366667], atol=1e-3)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        center = phasor_center(*VALUES_WITH_NAN, method='median')
+    assert_allclose(center, [0.3, 0.5], atol=1e-3)
+
+
+def test_phasor_divide_nan():
+    """Test phasor_divide function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_divide(*VALUES_WITH_NAN, 1.0, 1.0)
+    assert_allclose(phasor, [[0.5, nan, 0.1], [0.0, nan, 0.0]], atol=1e-3)
+
+
+@pytest.mark.xfail
+def test_phasor_filter_nan():
+    """Test phasor_filter function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_filter(*VALUES_WITH_NAN)
+    # TODO: this is undefined. https://github.com/phasorpy/phasorpy/issues/87
+    assert_allclose(phasor, [0.5, nan, 0.1], [0.5, 0.5, 0.1], atol=1e-3)
+
+
+def test_phasor_from_apparent_lifetime_nan():
+    """Test phasor_from_apparent_lifetime function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_from_apparent_lifetime(*VALUES_WITH_NAN, 80)
+    assert_allclose(
+        phasor,
+        [[0.940587, nan, 0.99748], [0.236395, nan, 0.050139]],
+        atol=1e-3,
+    )
+
+
+def test_phasor_from_polar_nan():
+    """Test phasor_from_polar function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_from_polar(*VALUES_WITH_NAN)
+    assert_allclose(
+        phasor,
+        [[0.438791, nan, 0.0995], [0.239713, nan, 0.009983]],
+        atol=1e-3,
+    )
+
+
+def test_phasor_from_signal_nan():
+    """Test phasor_from_signal function with NaN values."""
+    sample_phase = numpy.linspace(0, 2 * numpy.pi, 4, endpoint=False)
+    signal = 1.1 * (numpy.cos(sample_phase - 0.4) * 0.8 + 1)
+    signal = numpy.stack((signal, signal))
+    signal[0, 2] = numpy.nan
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_from_signal(signal)
+    assert_allclose(
+        phasor,
+        [[nan, 1.1], [nan, 0.368424], [nan, 0.155767]],
+        atol=1e-3,
+    )
+
+
+def test_phasor_multiply_nan():
+    """Test phasor_multiply function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_multiply(*VALUES_WITH_NAN, 1.0, 1.0)
+    assert_allclose(phasor, [[0.0, nan, 0.0], [1.0, nan, 0.2]], atol=1e-3)
+
+
+def test_phasor_threshold_nan():
+    """Test phasor_threshold function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_threshold(1.0, *VALUES_WITH_NAN, real_min=0.2)
+    assert_allclose(
+        phasor, [[1.0, nan, nan], [0.5, nan, nan], [0.5, nan, nan]], atol=1e-3
+    )
+
+
+def test_phasor_to_apparent_lifetime_nan():
+    """Test phasor_to_apparent_lifetime function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        lifetimes = phasor_to_apparent_lifetime(*VALUES_WITH_NAN, 80)
+    assert_allclose(
+        lifetimes,
+        [[1.989437, nan, 1.989437], [1.989437, nan, 13.926058]],
+        atol=1e-3,
+    )
+
+
+def test_phasor_to_complex_nan():
+    """Test phasor_to_complex function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_to_complex(*VALUES_WITH_NAN)
+    assert_allclose(
+        phasor,
+        [0.5 + 0.5j, nan + 0.5j, 0.1 + 0.1j],
+        atol=1e-3,
+    )
+
+
+def test_phasor_to_polar_nan():
+    """Test phasor_to_polar function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        polar = phasor_to_polar(*VALUES_WITH_NAN)
+    assert_allclose(
+        polar,
+        [[0.785398, nan, 0.785398], [0.707107, nan, 0.141421]],
+        atol=1e-3,
+    )
+
+
+def test_phasor_to_principal_plane_nan():
+    """Test phasor_to_principal_plane function with NaN values."""
+    real = [[0.495, 0.35], [0.354, 0.304], [0.3, 0.37]]
+    imag = [[0.333, 0.33], [0.301, 0.349], [0.3, 0.36]]
+
+    x, y, transformation_matrix = phasor_to_principal_plane(real, imag)
+    assert_allclose(x, [0.458946, 0.202887], atol=1e-3)
+
+    real[0][0] = nan
+    with pytest.raises(ValueError):
+        # numpy.linalg.LinAlgError: Eigenvalues did not converge
+        x, y, transformation_matrix = phasor_to_principal_plane(real, imag)
+
+
+def test_phasor_to_signal_nan():
+    """Test phasor_to_signal function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        signal = phasor_to_signal(1.1, *VALUES_WITH_NAN, samples=16)
+    assert signal.shape == (3, 16)
+    assert_allclose(
+        signal[0][:9],
+        [2.2, 2.5, 2.6, 2.5, 2.2, 1.69, 1.1, 0.5, 0.0],
+        atol=1e-1,
+    )
+    # TODO: this might be dependent on FFT implementation?
+    assert_allclose(signal[1][:4], [nan, nan, nan, nan], atol=1e-3)
+
+
+def test_phasor_transform_nan():
+    """Test phasor_transform function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        phasor = phasor_transform(*VALUES_WITH_NAN, 1, 0.9)
+    assert_allclose(
+        phasor,
+        [[-0.135526, nan, -0.027105], [0.621798, nan, 0.12436]],
+        atol=1e-3,
+    )
+
+
+def test_polar_from_apparent_lifetime_nan():
+    """Test polar_from_apparent_lifetime function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        polar = polar_from_apparent_lifetime(*VALUES_WITH_NAN, 80)
+    assert_allclose(
+        polar,
+        [[0.246228, nan, 0.050223], [0.969839, nan, 0.998739]],
+        atol=1e-3,
+    )
+
+
+def test_polar_from_reference_nan():
+    """Test polar_from_reference function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        polar = polar_from_reference(*VALUES_WITH_NAN, 0.5, 0.5)
+    assert_allclose(
+        polar,
+        [[0.0, nan, 0.4], [1.0, nan, 5.0]],
+        atol=1e-3,
+    )
+
+
+def test_polar_from_reference_phasor_nan():
+    """Test polar_from_reference_phasor function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        polar = polar_from_reference_phasor(*VALUES_WITH_NAN, 0.5, 0.5)
+    assert_allclose(
+        polar,
+        [[0.0, nan, 0.0], [1.0, nan, 5.0]],
+        atol=1e-3,
+    )
+
+
+def test_polar_to_apparent_lifetime_nan():
+    """Test polar_to_apparent_lifetime function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        lifetime = polar_to_apparent_lifetime(*VALUES_WITH_NAN, 80)
+    assert_allclose(
+        lifetime,
+        [[1.086834, nan, 0.199609], [3.445806, nan, 19.794646]],
+        atol=1e-3,
+    )

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -260,7 +260,7 @@ def test_phasor_to_principal_plane_nan():
     # assert_allclose(x, [0.458946, 0.202887], atol=1e-3)
 
     real[0][0] = nan
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         # numpy.linalg.LinAlgError: Eigenvalues did not converge
         x, y, transformation_matrix = phasor_to_principal_plane(real, imag)
 

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -257,7 +257,7 @@ def test_phasor_to_principal_plane_nan():
     imag = [[0.333, 0.33], [0.301, 0.349], [0.3, 0.36]]
 
     x, y, transformation_matrix = phasor_to_principal_plane(real, imag)
-    assert_allclose(x, [0.458946, 0.202887], atol=1e-3)
+    # assert_allclose(x, [0.458946, 0.202887], atol=1e-3)
 
     real[0][0] = nan
     with pytest.raises(ValueError):

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -8,6 +8,10 @@ from matplotlib import pyplot
 from numpy import nan
 from numpy.testing import assert_allclose
 
+from phasorpy.components import (
+    graphical_component_analysis,
+    two_fractions_from_phasor,
+)
 from phasorpy.cursors import (
     mask_from_circular_cursor,
     mask_from_elliptic_cursor,
@@ -337,4 +341,31 @@ def test_polar_to_apparent_lifetime_nan():
         lifetime,
         [[1.086834, nan, 0.199609], [3.445806, nan, 19.794646]],
         atol=1e-3,
+    )
+
+
+def test_two_fractions_from_phasor_nan():
+    """Test two_fractions_from_phasor function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        fractions = two_fractions_from_phasor(
+            *VALUES_WITH_NAN, [0.5, 1.0], [0.5, 1.0]
+        )
+    assert_allclose(fractions, [1.0, nan, 1.0])
+
+
+def test_graphical_component_analysis_nan():
+    """Test graphical_component_analysis function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        counts = graphical_component_analysis(
+            *VALUES_WITH_NAN, [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], fractions=10
+        )
+    assert_allclose(
+        counts,
+        (
+            [1, 1, 0, 0, 0, 0, 0, 0, 1, 0],
+            [1, 1, 0, 0, 0, 0, 0, 0, 1, 0],
+            [0, 0, 0, 1, 1, 1, 1, 0, 0, 0],
+        ),
     )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -522,13 +522,3 @@ def test_plot_phasor_image():
         # percentile out of range
         plot_phasor_image(d, d, d, percentile=50, show=False)
     pyplot.close()
-
-
-def test_plot_phasor_image_runtimewarning():
-    """Test 'RuntimeWarning: Mean of empty slice' is not raised."""
-    data = numpy.zeros((3, 4, 5))
-    data[0, 0, 0] = numpy.nan
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
-        plot_phasor_image(data[0], data, data, show=False)
-    pyplot.close()

--- a/tutorials/phasorpy_lfd_workshop.py
+++ b/tutorials/phasorpy_lfd_workshop.py
@@ -14,7 +14,7 @@ and Excel software.
 
 .. note::
 
-    This tutorial is work in progress. Not all of SimFCS's functionality is
+    This tutorial is work in progress. Not all of SimFCS' functionality is
     available in the PhasorPy library yet.
 
 """
@@ -223,10 +223,10 @@ real2, imag2 = phasor_filter(real2, imag2, method='median', repeat=2)
 # zero modulation depth). This can be eliminated by setting a threshold.
 
 _, real1, imag1 = phasor_threshold(
-    mean, real1, imag1, 20, real_min=0, imag_min=0
+    mean, real1, imag1, mean_min=20, real_min=0, imag_min=0, open_interval=True
 )
 _, real2, imag2 = phasor_threshold(
-    mean, real2, imag2, 20, real_min=0, imag_min=0
+    mean, real2, imag2, mean_min=20, real_min=0, imag_min=0, open_interval=True
 )
 # %%
 plot_phasor(
@@ -418,18 +418,18 @@ real1, imag1 = phasor_filter(real1, imag1, method='median', repeat=2)
 real2, imag2 = phasor_filter(real2, imag2, method='median', repeat=2)
 
 _, real1, imag1 = phasor_threshold(
-    mean, real1, imag1, 32, real_min=0, imag_min=0
+    mean, real1, imag1, mean_min=32, real_min=0, imag_min=0, open_interval=True
 )
 _, real2, imag2 = phasor_threshold(
-    mean, real2, imag2, 32, real_min=0, imag_min=0
+    mean, real2, imag2, mean_min=32, real_min=0, imag_min=0, open_interval=True
 )
 
 plot = PhasorPlot(
     frequency=frequency,
     title='Filtered CFPpax8651866 (blue) and 1011rac1002 (red)',
 )
-plot.hist2d(real1, imag1, cmap='Blues', cmin=4)  # label='CFPpax8651866'
-plot.hist2d(real2, imag2, cmap='Reds', cmin=4)  # label='1011rac1002'
+plot.hist2d(real2, imag2, cmap='Reds', cmin=20)  # label='1011rac1002'
+plot.hist2d(real1, imag1, cmap='Blues', cmin=20)  # label='CFPpax8651866'
 plot.show()
 
 # %%
@@ -469,7 +469,7 @@ imag = numpy.vstack((imag1, imag2))
 real, imag = phasor_filter(real, imag, method='median', repeat=2)
 
 _, real, imag = phasor_threshold(
-    mean, real, imag, 6202, real_min=0, imag_min=0
+    mean, real, imag, mean_min=6202, real_min=0, imag_min=0, open_interval=True
 )
 
 plot = PhasorPlot(


### PR DESCRIPTION
## Description

This PR is following up on #88, which settled on representing invalid or threshold-ed phasor coordinates as `NaN` (a special floating point number):

- Many Cython ufuncs now return NaN if certain input values (such as phasor or polar coordinates, or apparent single lifetimes)  are NaN. 
- The unused `mask` parameter was removed from `_is_` functions. 
- The behavior of `phasor_filter` is currently undefined (#87). 
- The `phasor_to_principal_plane` function does not work with NaNs.
- The behavior of `phasor_to_signal` likely depends on the FFT implementation. 
- The `phasor_from_signal` and `phasor_from_lifetime` functions remain unchanged. 

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Improve handling of NaN values
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
