### PR TITLE
Add default fractions to graphical_component_analysis

### DIFF
--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -151,11 +151,14 @@ def graphical_component_analysis(
         Imaginary coordinates for two or three components.
     radius: float, optional, default: 0.05
         Radius of the cursor in phasor coordinates.
-    fractions: array_like or int, optional, default: 100
+    fractions: array_like or int, optional
         Number of equidistant fractions, or 1D array of fraction values.
         Fraction values must be in range [0.0, 1.0].
         If an integer, ``numpy.linspace(0.0, 1.0, fractions)`` fraction values
         are used.
+        If None (default), the number of fractions is determined from the
+        longest distance between any pair of components and the radius of
+        the cursor (see Notes below).
 
     Returns
     -------
@@ -183,16 +186,19 @@ def graphical_component_analysis(
 
     The graphical method was first introduced in [1]_.
 
-    If no `fractions` are provided, the number of fractions (N) used is
-    determined by the longest distance between any pair of components (D)
-    and by the radius of the cursor (R):
+    If no `fractions` are provided, the number of fractions (:math:`N`) used
+    is determined from the longest distance between any pair of components
+    (:math:`D`) and the radius of the cursor (:math:`R`):
 
     .. math::
-        N = \frac{2*D}{R} + 1
+
+        N = \frac{2 \cdot D}{R} + 1
 
     The fractions can be retrieved by:
 
-    ``fractions = numpy.linspace(0.0, 1.0, len(counts[0]))``
+    .. code-block:: python
+
+        fractions = numpy.linspace(0.0, 1.0, len(counts[0]))
 
     References
     ----------
@@ -257,7 +263,7 @@ def graphical_component_analysis(
                 )
                 longest_distance = max(longest_distance, length)
         fractions = numpy.linspace(
-            0.0, 1.0, int(longest_distance / (radius / 2) + 1)
+            0.0, 1.0, int(round(longest_distance / (radius / 2) + 1))
         )
     elif isinstance(fractions, numbers.Integral):
         fractions = numpy.linspace(0.0, 1.0, fractions)

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -42,6 +42,7 @@ from ._phasorpy import (
     _fraction_on_segment,
     _is_inside_circle,
     _is_inside_stadium,
+    _segment_direction_and_length,
 )
 
 
@@ -132,7 +133,7 @@ def graphical_component_analysis(
     radius: float = 0.05,
     fractions: ArrayLike | None = None,
 ) -> tuple[NDArray[Any], ...]:
-    """Return fractions of two or three components from phasor coordinates.
+    r"""Return fractions of two or three components from phasor coordinates.
 
     The graphical method is based on moving circular cursors along the line
     between pairs of components, and quantifying the phasors for each
@@ -181,6 +182,17 @@ def graphical_component_analysis(
     be analyzed and will be broadcasted to all channels/frequencies.
 
     The graphical method was first introduced in [1]_.
+
+    If no `fractions` are provided, the number of fractions (N) used is
+    determined by the longest distance between any pair of components (D)
+    and by the radius of the cursor (R):
+
+    .. math::
+        N = \frac{2*D}{R} + 1
+
+    The fractions can be retrieved by:
+
+    ``fractions = numpy.linspace(0.0, 1.0, len(counts[0]))``
 
     References
     ----------
@@ -232,7 +244,22 @@ def graphical_component_analysis(
     if num_components not in {2, 3}:
         raise ValueError('number of components must be 2 or 3')
 
-    if isinstance(fractions, numbers.Integral):
+    if fractions is None:
+        longest_distance = 0
+        for i in range(num_components):
+            a_real = components_real[i]
+            a_imag = components_imag[i]
+            for j in range(i + 1, num_components):
+                b_real = components_real[j]
+                b_imag = components_imag[j]
+                _, _, length = _segment_direction_and_length(
+                    a_real, a_imag, b_real, b_imag
+                )
+                longest_distance = max(longest_distance, length)
+        fractions = numpy.linspace(
+            0.0, 1.0, int(longest_distance / (radius / 2) + 1)
+        )
+    elif isinstance(fractions, numbers.Integral):
         fractions = numpy.linspace(0.0, 1.0, fractions)
     else:
         fractions = numpy.asarray(fractions)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -77,6 +77,7 @@ def test_two_fractions_from_phasor_channels():
     radius, fractions,
     expected_counts""",
     [
+        # Two components, phasor as scalar
         (
             0.6,
             0.35,
@@ -85,7 +86,8 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             6,
             ([0, 0, 1, 0, 0, 0],),
-        ),  # Two components, phasor as scalar
+        ),
+        # Two components, phasors as list. Increase cursor radius.
         (
             [0.6, 0.4],
             [0.35, 0.38],
@@ -94,7 +96,8 @@ def test_two_fractions_from_phasor_channels():
             0.15,
             [0, 0.2, 0.4, 0.6, 0.8, 1],
             ([0, 0, 1, 2, 1, 0],),
-        ),  # Two components, phasors as list. Increase cursor radius.
+        ),
+        # Two components, phasors as list. Increase number of steps.
         (
             [0.6, 0.4],
             [0.35, 0.38],
@@ -103,7 +106,8 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             11,
             ([0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],),
-        ),  # Two components, phasors as list. Increase number of steps.
+        ),
+        # Three components, phasor as scalar
         (
             0.3,
             0.2,
@@ -112,7 +116,8 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             [0, 0.2, 0.4, 0.6, 0.8, 1],
             ([0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0], [0, 0, 1, 1, 0, 0]),
-        ),  # Three components, phasor as scalar
+        ),
+        # Three components, phasors as list
         (
             [0.3, 0.5],
             [0.2, 0.3],
@@ -121,7 +126,8 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             6,
             ([0, 1, 1, 1, 0, 0], [0, 1, 0, 1, 0, 0], [0, 0, 2, 1, 0, 0]),
-        ),  # Three components, phasors as list
+        ),
+        # Phasor outside semicircle but inside cursor of component 1
         (
             [0.4, 0.82],
             [0.38, 0.4],
@@ -130,7 +136,8 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             5,
             ([0, 0, 1, 0, 1], [0, 0, 0, 1, 2], [1, 1, 2, 2, 2]),
-        ),  # Phasor outside semicircle but inside cursor of component 1
+        ),
+        # Phasor outside semicircle and outside cursor of component 1
         (
             [0.4, 0.86],
             [0.38, 0.4],
@@ -139,7 +146,31 @@ def test_two_fractions_from_phasor_channels():
             0.05,
             [0, 0.25, 0.5, 0.75, 1],
             ([0, 0, 1, 0, 0], [0, 0, 0, 1, 1], [0, 0, 1, 1, 1]),
-        ),  # Phasor outside semicircle and outside cursor of component 1
+        ),
+        # Two components no fractions provided
+        (
+            0,
+            0,
+            [0, 0],
+            [0, 0.2],
+            0.05,
+            None,
+            ([0, 0, 0, 0, 0, 0, 1, 1, 1],),
+        ),
+        # Three components no fractions provided
+        (
+            0,
+            0,
+            [0, 0.1, 0],
+            [0, 0.1, 0.2],
+            0.05,
+            None,
+            (
+                [0, 0, 0, 0, 0, 0, 1, 1, 1],
+                [0, 0, 0, 0, 0, 0, 1, 1, 1],
+                [1, 1, 1, 1, 1, 1, 1, 1, 1],
+            ),
+        ),
     ],
 )
 def test_graphical_component_analysis(
@@ -170,41 +201,50 @@ def test_graphical_component_analysis(
     fractions
     """,
     [
-        ([0], [0, 0], [0, 1], [0, 1], 10),  # imag.shape != real.shape
-        ([0, 0], [0], [0, 1], [0, 1], 10),  # real.shape != imag.shape
+        # imag.shape != real.shape
+        ([0], [0, 0], [0, 1], [0, 1], 10),
+        # real.shape != imag.shape
+        ([0, 0], [0], [0, 1], [0, 1], 10),
+        # components_imag.shape != components_real.shape
         (
             0,
             0,
             [0, 1, 2],
             [0, 1],
             10,
-        ),  # components_imag.shape != components_real.shape
+        ),
+        # components_real.shape != components_imag.shape
         (
             0,
             0,
             [0, 1],
             [0, 1, 2],
             10,
-        ),  # components_real.shape != components_imag.shape
-        ([0], [0], [0], [0], 10),  # Number of components is 1
+        ),
+        # Number of components is 1
+        ([0], [0], [0], [0], 10),
+        # number of components is more than 3
         (
             0,
             0,
             [0, 1, 2, 3],
             [0, 1, 2, 3],
             10,
-        ),  # number of components is more than 3
-        # ([0], [0], [0, 0], [0, 0], 10),  # components have same coordinates
+        ),
+        # components are not one dimensional
         (
             0,
             0,
             [[0], [1]],
             [[0], [1]],
             10,
-        ),  # components are not one dimensional
-        ([0, 0], [0, 0], [0, 1], [0, 1], -10),  # negative fraction
-        ([0, 0], [0, 0], [0, 1], [0, 1], [0.5, -0.5]),  # negative fraction
-        ([0, 0], [0, 0], [0, 1], [0, 1], [[0.5], [-0.5]]),  # fraction not 1D
+        ),
+        # negative fraction
+        ([0, 0], [0, 0], [0, 1], [0, 1], -10),
+        # negative fraction
+        ([0, 0], [0, 0], [0, 1], [0, 1], [0.5, -0.5]),
+        # fraction not 1D
+        ([0, 0], [0, 0], [0, 1], [0, 1], [[0.5], [-0.5]]),
     ],
 )
 def test_errors_graphical_component_analysis(


### PR DESCRIPTION
## Description

This PR proposes the addition of default values for `fractions` in the `graphical_component_analysis` function in the `components` module. This was further discussed in #83, where the reasons for the proposed changes are stated. 

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```Add default fractions to graphical_component_analysis
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
