### PR TITLE
Do not test wheels on Python 3.13 for now

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -11,6 +11,9 @@ on:
   #     - main
   workflow_dispatch:
 
+env:
+  CIBW_TEST_SKIP: "cp313*"
+
 jobs:
   build:
     name: Build wheels on ${{ matrix.os }}
@@ -23,7 +26,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.20.0
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
-          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD_VERBOSITY: 2
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64


### PR DESCRIPTION
## Description

Not all dependencies are available or compatible yet.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Do not test wheels on Python 3.13 for now
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
