### PR TITLE
Test minimum runtime requirements

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   CIBW_TEST_SKIP: "cp313*"
+  MPLBACKEND: agg
 
 jobs:
   build:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --editable .
         python -m pip install -r requirements_dev.txt
-        python -m pip install -r requirements_numpy.txt
     - name: Generate coverage report
       run: |
         pytest --cov=phasorpy --cov-report=xml tests

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,6 +11,9 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  MPLBACKEND: agg
+
 jobs:
   build:
 
@@ -18,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -30,7 +33,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements_dev.txt
-        python -m pip install -r requirements_numpy.txt
         python -m pip install --no-build-isolation --no-deps --verbose --editable .
     - name: Build docs
       run: |

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install PyBuild
         run: |
           python -m pip install build
@@ -49,7 +49,7 @@ jobs:
           path: dist
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - run: |
           ls
           ls dist

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  MPLBACKEND: agg
+
 jobs:
   test:
     name: Test library and docs
@@ -34,7 +37,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --editable .
         python -m pip install -r requirements_dev.txt
-        python -m pip install -r requirements_numpy.txt
+        python -m pip install -r requirements_min.txt
     - name: Print dependency versions
       run: |
         phasorpy versions
@@ -66,7 +69,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --editable .
         python -m pip install -r requirements_dev.txt
-        python -m pip install -r requirements_numpy.txt
+        python -m pip install -r requirements_min.txt
     - name: Test with pytest
       run: |
         python -X dev -m pytest
@@ -76,7 +79,7 @@ jobs:
         make html
 
   build_wheels:
-    name: Test cibuildwheel and numpy 2
+    name: Test cibuildwheel
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -113,7 +116,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --editable .
         python -m pip install -r requirements_dev.txt
-        python -m pip install -r requirements_numpy.txt
+        python -m pip install -r requirements_min.txt
     - name: Test with black
       run: |
         python -m black --check src/phasorpy tutorials docs

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -125,7 +125,6 @@ following from within the local phasorpy repository::
     $ python -m venv ~/pyenv/phasorpy-dev
     $ source ~/pyenv/phasorpy-dev/bin/activate
     $ pip install -r requirements_dev.txt
-    $ pip install -r requirements_numpy.txt
     $ pip install -e .
 
 Verify that the development environment is working by running the tests::

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
+set MPLBACKEND=agg
 
 rd /S /Q %BUILDDIR%
 rd /S /Q tutorials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,17 +12,19 @@ description = "Analysis of fluorescence lifetime and hyperspectral images using 
 readme = { file = "README.md", content-type = "text/markdown" }
 dynamic = ["version"]
 dependencies = [
-    "numpy",
-    "matplotlib",
+    # sync with requirements_min.txt
+    # https://scientific-python.org/specs/spec-0000/
+    "numpy>=1.24.0",
+    "matplotlib>=3.7.0",
+    "scipy>=1.11.0",
     "click",
     "pooch",
     "tqdm",
-    "xarray",
-    "scipy",
-    # "scikit-image",
-    # "scikit-learn",
-    # "pandas",
-    "tifffile>=2024.8.24",
+    # "scikit-image>=0.20.0",
+    # "scikit-learn>=1.2.2",
+    # "pandas>=2.0.0",
+    "xarray>=2023.4.0",
+    "tifffile>=2024.8.30",
 ]
 requires-python = ">=3.10"
 classifiers = [
@@ -67,22 +69,10 @@ test = [
     "pytest-doctestplus",
     "coverage",
 ]
-io = ["lfdfiles", "sdtfile", "ptufile"]
 all = [
-    "numpy",
-    "matplotlib",
-    "click",
-    "pooch",
-    "tqdm",
-    "xarray",
-    "scipy",
-    # "scikit-image",
-    # "scikit-learn",
-    # "pandas",
-    "tifffile>=2024.8.24",
-    "lfdfiles",
-    "sdtfile",
-    "ptufile",
+    "lfdfiles>=2024.5.24",
+    "sdtfile>=2024.5.24",
+    "ptufile>=2024.7.13",
 ]
 
 [tool.setuptools]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,12 +1,14 @@
 # Requirements for developing the PhasorPy library
 #
 # runtime requirements
+numpy
+scipy
 matplotlib
 click
 pooch
 tqdm
 xarray
-tifffile
+tifffile>=2024.8.30
 #
 # build requirements
 setuptools
@@ -47,7 +49,6 @@ cython_lint
 # pre-commit
 #
 # optional requirements
-scipy
 scikit-image
 # scikit-learn
 # pandas

--- a/requirements_min.txt
+++ b/requirements_min.txt
@@ -1,0 +1,13 @@
+# Minimum version requirements for the PhasorPy library
+#
+numpy==1.24.4; python_version == "3.10"
+matplotlib==3.7.5; python_version == "3.10"
+pandas==2.0.3; python_version == "3.10"
+scipy==1.11.4; python_version == "3.10"
+scikit-image==0.20.0; python_version == "3.10"
+scikit-learn==1.2.2; python_version == "3.10"
+xarray==2023.4.0; python_version == "3.10"
+tifffile==2024.8.30; python_version == "3.10"
+lfdfiles==2024.5.24; python_version == "3.10"
+sdtfile==2024.5.24; python_version == "3.10"
+ptufile==2024.7.13; python_version == "3.10"

--- a/requirements_numpy.txt
+++ b/requirements_numpy.txt
@@ -1,6 +1,0 @@
-# Numpy requirements for developing the PhasorPy library
-#
-# use NEP29 minimum on Python 3.10
-numpy == 1.23.5; python_version == "3.10"
-# use recent
-numpy >= 1.25; python_version > "3.10"


### PR DESCRIPTION
## Description

Currently only numpy==1.23.5 is tested, while other requirements are always the latest versions.

This PR defines, and enables testing with, the following minimum runtime dependencies:

- Python 3.10
- numpy==1.24.4
- matplotlib==3.7.5
- pandas==2.0.3
- scipy==1.11.4
- scikit-image==0.20.0
- scikit-learn==1.2.2
- xarray==2023.4.0
- tifffile==2024.8.30
- lfdfiles==2024.5.24
- sdtfile==2024.5.24
- ptufile==2024.7.13

This list is roughly following the recommendation of [SPEC 0 — Minimum Supported Dependencies](https://scientific-python.org/specs/spec-0000/). 

The file reader libraries are all pinned to the currently latest versions. 

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Test minimum runtime requirements
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
