### PR TITLE
Improve io module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tutorials/data/*
 *.sdt
 *.b64
 *.r64
+*.ref
 *.npy
 *.flif
 *.lif

--- a/docs/api/_private/_phasorpy.rst
+++ b/docs/api/_private/_phasorpy.rst
@@ -1,5 +1,12 @@
 phasorpy._phasorpy
 ------------------
 
+.. note::
+    This module and its functions are not part of the public interface.
+    They are intended to facilitate the development of the PhasorPy library.
+
 .. automodule:: phasorpy._phasorpy
     :members:
+    :undoc-members:
+    :private-members:
+    :special-members:

--- a/docs/api/_private/_phasorpy.rst
+++ b/docs/api/_private/_phasorpy.rst
@@ -1,0 +1,5 @@
+phasorpy._phasorpy
+------------------
+
+.. automodule:: phasorpy._phasorpy
+    :members:

--- a/docs/api/_private/_utils.rst
+++ b/docs/api/_private/_utils.rst
@@ -1,0 +1,5 @@
+phasorpy._utils
+---------------
+
+.. automodule:: phasorpy._utils
+    :members:

--- a/docs/api/_private/_utils.rst
+++ b/docs/api/_private/_utils.rst
@@ -1,5 +1,9 @@
 phasorpy._utils
 ---------------
 
+.. note::
+    This module and its functions are not part of the public interface.
+    They are intended to facilitate the development of the PhasorPy library.
+
 .. automodule:: phasorpy._utils
     :members:

--- a/docs/api/_private/index.rst
+++ b/docs/api/_private/index.rst
@@ -5,7 +5,6 @@ Private modules
     These modules and their functions are not part of the public interface.
     They are intended to facilitate the development of the PhasorPy library.
 
-
 .. toctree::
     :maxdepth: 2
 

--- a/docs/api/_private/index.rst
+++ b/docs/api/_private/index.rst
@@ -1,0 +1,13 @@
+Private modules
+===============
+
+.. note::
+    These modules and their functions are not part of the public interface.
+    They are intended to facilitate the development of the PhasorPy library.
+
+
+.. toctree::
+    :maxdepth: 2
+
+    _utils
+    _phasorpy

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -22,3 +22,4 @@ PhasorPy library version |version|.
     datasets
     utils
     cli
+    _private/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ profile = "black"
 line_length = 79
 
 [tool.codespell]
-skip = "*.html,*.css,*.js,*.map,./.git,./data,./docs/_build,./docs/tutorials,PKG-INFO,_htmlcov,pyproject.toml"
+skip = "*.html,*.css,*.js,*.r64,*.map,./.git,./data,./docs/_build,./docs/tutorials,PKG-INFO,_htmlcov,pyproject.toml"
 ignore-words-list = "ba,compiletime,hist,nd,unparseable,HSI"
 
 [tool.mypy]

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -4,6 +4,7 @@
 # cython: wraparound = False
 # cython: cdivision = True
 # cython: nonecheck = False
+# cython: embedsignature = True
 
 """Cython implementation of low-level functions for the PhasorPy package."""
 

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -4,9 +4,8 @@
 # cython: wraparound = False
 # cython: cdivision = True
 # cython: nonecheck = False
-# cython: embedsignature = True
 
-"""Cython implementation of low-level functions for the PhasorPy package."""
+"""Cython implementation of low-level functions for the PhasorPy library."""
 
 # TODO: replace short with unsigned char when Cython supports it
 # https://github.com/cython/cython/pull/6196#issuecomment-2209509572
@@ -71,32 +70,37 @@ def _phasor_from_signal(
 ):
     """Return phasor coordinates from signal along middle axis.
 
-    This implementation requires contiguous input arrays.
-
-    TODO: use Numpy iterator API?
-    https://numpy.org/devdocs/reference/c-api/iterator.html
-
     Parameters
     ----------
-    phasor:
-        Writable buffer of three-dimensions where calculated phasor
+    phasor : 3D memoryview of float32 or float64
+        Writable buffer of three dimensions where calculated phasor
         coordinates are stored:
-            0. mean, real, and imaginary components
-            1. lower dimensions flat
-            2. upper dimensions flat
-    signal:
-        Buffer of three-dimensions containing signal:
-            0. lower dimensions flat
-            1. dimension over which to compute FFT, number samples
-            2. upper dimensions flat
-    sincos:
-        Buffer of two dimensions containing sin and cos terms to be multiplied
-        with signal:
-            0. number harmonics
-            1. number samples
-            2. cos and sin
-    num_threads:
+
+        0. mean, real, and imaginary components
+        1. lower dimensions flat
+        2. upper dimensions flat
+
+    signal : 3D memoryview of float32 or float64
+        Buffer of three dimensions containing signal:
+
+        0. lower dimensions flat
+        1. dimension over which to compute FFT, number samples
+        2. upper dimensions flat
+
+    sincos : 3D memoryview of float64
+        Buffer of three dimensions containing sine and cosine terms to be
+        multiplied with signal:
+
+        0. number harmonics
+        1. number samples
+        2. cos and sin
+
+    num_threads : int
         Number of OpenMP threads to use for parallelization.
+
+    Notes
+    -----
+    This implementation requires contiguous input arrays.
 
     """
     cdef:
@@ -106,6 +110,9 @@ def _phasor_from_signal(
         ssize_t harmonics = sincos.shape[0]
         ssize_t i, j, k, h
         double dc, re, im, sample
+
+    # TODO: use Numpy iterator API?
+    # https://numpy.org/devdocs/reference/c-api/iterator.html
 
     if (
         samples < 3
@@ -218,26 +225,32 @@ def _phasor_from_lifetime(
 
     Parameters
     ----------
-    phasor:
-        Writable buffer of three-dimensions where calculated phasor
+    phasor : 3D memoryview of float32 or float64
+        Writable buffer of three dimensions where calculated phasor
         coordinates are stored:
-            0. real and imaginary components
-            1. frequencies
-            2. lifetimes or fractions
-    frequency:
+
+        0. real and imaginary components
+        1. frequencies
+        2. lifetimes or fractions
+
+    frequency : 2D memoryview of float64
         One-dimensional sequence of laser-pulse or modulation frequencies.
-    lifetime:
+    lifetime : 2D memoryview of float64
         Buffer of two dimensions:
-            0. lifetimes
-            1. components of lifetimes
-    fraction:
+
+        0. lifetimes
+        1. components of lifetimes
+
+    fraction : 2D memoryview of float64
         Buffer of two dimensions:
-            0. fractions
-            1. fractions of lifetime components
-    unit_conversion:
+
+        0. fractions
+        1. fractions of lifetime components
+
+    unit_conversion : float
         Product of `frequency` and `lifetime` units' prefix factors.
         1e-3 for MHz and ns. 1.0 for Hz and s.
-    preexponential:
+    preexponential : bool
         If true, fractions are pre-exponential amplitudes, else fractional
         intensities.
 
@@ -379,7 +392,18 @@ def _gaussian_signal(
     const double mean,
     const double stdev,
 ):
-    """Return normal distribution, wrapped around at borders."""
+    """Return normal distribution, wrapped around at borders.
+
+    Parameters
+    ----------
+    signal : memoryview of float32 or float64
+        Writable buffer where calculated signal samples are stored.
+    mean : float
+        Mean of normal distribution.
+    stdev : float
+        Standard deviation of normal distribution.
+
+    """
     cdef:
         ssize_t samples = signal.shape[0]
         ssize_t folds = 1  # TODO: calculate from stddev and samples

--- a/src/phasorpy/_typing.py
+++ b/src/phasorpy/_typing.py
@@ -31,8 +31,8 @@ from collections.abc import (
 from os import PathLike
 from types import EllipsisType
 from typing import (
+    IO,
     Any,
-    BinaryIO,
     Literal,
     Optional,
     TextIO,

--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -1,7 +1,4 @@
-"""Private utility functions.
-
-The ``phasorpy._utils`` module provides private auxiliary and convenience
-functions.
+"""Private auxiliary and convenience functions.
 
 """
 

--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -23,7 +23,7 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._typing import Any, ArrayLike, NDArray, Literal, BinaryIO
+    from ._typing import Any, ArrayLike, NDArray, Literal, IO
 
     from matplotlib.axes import Axes
     from matplotlib.image import AxesImage
@@ -187,7 +187,7 @@ class PhasorPlot:
 
     def save(
         self,
-        file: str | os.PathLike[Any] | BinaryIO | None,
+        file: str | os.PathLike[Any] | IO[bytes] | None,
         /,
         **kwargs: Any,
     ) -> None:

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -166,7 +166,7 @@ def test_phasor_from_signal(use_fft):
         phasor_from_signal(signal[:2], use_fft=use_fft)
     with pytest.raises(TypeError):
         phasor_from_signal(signal, harmonic=1.0, use_fft=use_fft)
-    with pytest.raises(TypeError):
+    with pytest.raises(ValueError):
         phasor_from_signal(signal, harmonic=[], use_fft=use_fft)
     with pytest.raises(TypeError):
         phasor_from_signal(signal, harmonic=[1.0], use_fft=use_fft)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,8 +2,6 @@
 
 import os
 
-import pytest
-
 from phasorpy.utils import number_threads
 
 

--- a/tutorials/phasorpy_lfd_workshop.py
+++ b/tutorials/phasorpy_lfd_workshop.py
@@ -26,14 +26,13 @@ import numpy
 from matplotlib import pyplot
 
 from phasorpy.datasets import fetch
-from phasorpy.io import read_ref
+from phasorpy.io import phasor_from_simfcs_referenced
 from phasorpy.phasor import (
     lifetime_fraction_from_amplitude,
     lifetime_to_signal,
     phasor_filter,
     phasor_from_fret_donor,
     phasor_from_lifetime,
-    phasor_from_polar,
     phasor_threshold,
     phasor_to_apparent_lifetime,
     phasor_to_polar,
@@ -170,18 +169,15 @@ plot_phasor(real, imag, fmt='o-', frequency=frequency)
 # display the images, and plot the phasor coordinates of first and second
 # harmonics:
 
-filename = fetch('capillaries1001.ref')
-data = read_ref(filename)
 frequency = 80.0  # MHz
-
-mean = data[0].values
-real1, imag1 = phasor_from_polar(numpy.deg2rad(data[1]), data[2])  # harmonic 1
-real2, imag2 = phasor_from_polar(numpy.deg2rad(data[3]), data[4])  # harmonic 2
+mean, real, imag = phasor_from_simfcs_referenced(
+    fetch('capillaries1001.ref'), harmonic=[1, 2]
+)
+real1, real2 = real
+imag1, imag2 = imag
 
 # %%
-plot_phasor_image(
-    mean, [real1, real2], [imag1, imag2], title='capillaries1001.ref'
-)
+plot_phasor_image(mean, real, imag, title='capillaries1001.ref')
 # %%
 plot_phasor(
     real1,
@@ -383,10 +379,7 @@ plot.show()
 # Open the file ``CFPpax8651866.ref``, which contains referenced FLIM data
 # for a cell transfected with a CFP paxillin construct.
 
-data = read_ref(fetch('CFPpax8651866.ref'))
-
-mean1 = data[0].values
-real1, imag1 = phasor_from_polar(numpy.deg2rad(data[1]), data[2])
+mean1, real1, imag1 = phasor_from_simfcs_referenced(fetch('CFPpax8651866.ref'))
 
 plot_phasor_image(mean1, real1, imag1, title='CFPpax8651866.ref')
 
@@ -394,10 +387,7 @@ plot_phasor_image(mean1, real1, imag1, title='CFPpax8651866.ref')
 # Open the file ``1011rac1002.ref``, which contains referenced FLIM data
 # for a cell transfected with a CFP-YFP fusion protein:
 
-data = read_ref(fetch('1011rac1002.ref'))
-
-mean2 = data[0].values
-real2, imag2 = phasor_from_polar(numpy.deg2rad(data[1]), data[2])
+mean2, real2, imag2 = phasor_from_simfcs_referenced(fetch('1011rac1002.ref'))
 
 plot_phasor_image(mean2, real2, imag2, title='1011rac1002.ref')
 
@@ -442,19 +432,17 @@ plot.show()
 # is visible.
 
 frequency = 80.0  # MHz
-data = read_ref(fetch('CFP and CFP-YFp.ref'))
-
-mean1 = data[0].values
-real1, imag1 = phasor_from_polar(numpy.deg2rad(data[1]), data[2])
+mean1, real1, imag1 = phasor_from_simfcs_referenced(
+    fetch('CFP and CFP-YFp.ref')
+)
 
 plot_phasor_image(mean1, real1, imag1, title='CFP and CFP-YFp.ref')
 
 # %%
 
-data = read_ref(fetch('CFP-YFP many cells with background.ref'))
-
-mean2 = data[0].values
-real2, imag2 = phasor_from_polar(numpy.deg2rad(data[1]), data[2])
+mean2, real2, imag2 = phasor_from_simfcs_referenced(
+    fetch('CFP-YFP many cells with background.ref')
+)
 
 plot_phasor_image(
     mean2, real2, imag2, title='CFP-YFP many cells with background.ref'


### PR DESCRIPTION
## Description

This PR proposes several improvements mainly to the `io` module:

- Add option to specify dataset description in `phasor_to_ometiff`. Requires tifffile>=2024.8.30.

- Add a note to `phasor_to_ometiff` that the format is experimental and not meant for long-term storage.

- Add `phasor_to_simfcs_referenced` function to store phasor coordinates in SimFCS R64 format. The function writes chunked and/or padded files for dimensions not supported by the R64 format.

- Add `phasor_from_simfcs_referenced` function to directly read phasor coordinates from SimFCS REF or R64 files.

- Remove redundant `read_ref` and `read_r64` functions, which are replaced by `phasor_from_simfcs_referenced`.

- Delay import of xarray since not all functions are using xarray.

- Add private `_utils.chunk_iter` function to iterate over chunk indices of ndarrays.

- Move `phasor._parse_harmonic` function to `_utils.parse_harmonic` since it is used in more than one module.

- Add tests for `parse_harmonic` function.

- Update tutorials with new functionality.

- Add private `_utils` module to API documentation to make sure docstrings are rendered correctly.


Things postponed from this PR to another PR:

- Add `read_imspector_tiff` function to read FLUTE dataset files (#105).

- Add option to return specific harmonics from `phasor_from_ometiff`.

- Consider changing `phasor_from_ometiff` function to return numpy instead of xarray arrays. Attributes would be returned as a separate dict.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Improve io module
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
