### PR TITLE
Configure mypy enable_error_code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
 #     args: []
 
 ci:
-  autofix_commit_msg: |
-    [pre-commit.ci] auto fixes from pre-commit.com hooks
+  autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autofix_prs: false
   autoupdate_schedule: weekly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ ignore-words-list = "ba,compiletime,hist,nd,unparseable,HSI"
 packages = ["phasorpy"]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 plugins = ["numpy.typing.mypy_plugin"]
+enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
 warn_unreachable = true
 

--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -120,7 +120,9 @@ class PhasorPlot:
     ) -> None:
         # initialize empty phasor plot
         self._ax = pyplot.subplots()[1] if ax is None else ax
-        self._ax.format_coord = self._on_format_coord  # type: ignore
+        self._ax.format_coord = (  # type: ignore[method-assign]
+            self._on_format_coord
+        )
 
         self._semicircle_ticks = None
 
@@ -934,7 +936,7 @@ class PhasorPlot:
         self._reset_limits()
         return lines
 
-    def _on_format_coord(self, x: float, y: float, /) -> str:
+    def _on_format_coord(self, x: float, y: float) -> str:
         """Callback function to update coordinates displayed in toolbar."""
         phi, mod = phasor_to_polar_scalar(x, y)
         ret = [
@@ -1541,8 +1543,9 @@ class SemicircleTicks(AbstractPathEffect):
         gc0.copy_properties(gc)
 
         # TODO: this uses private methods of the base class
-        gc0 = self._update_gc(gc0, self._gc)  # type: ignore
-        trans = affine + self._offset_transform(renderer)  # type: ignore
+        gc0 = self._update_gc(gc0, self._gc)  # type: ignore[attr-defined]
+        trans = affine
+        trans += self._offset_transform(renderer)  # type: ignore[attr-defined]
 
         font = FontProperties()
         # approximate half size of 'x'


### PR DESCRIPTION
## Description

This PR sets `enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]` for mypy (suggested by [Repo-Review](https://learn.scientific-python.org/development/guides/repo-review/?repo=phasorpy%2Fphasorpy&branch=main)) and fixes a few new failures.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Configure mypy enable_error_code
```

## Checklist

- [ ] The pull request title, summary, and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
