### PR TITLE
Revise phasor_from_ometiff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ directory = "_htmlcov"
 [tool.pytest.ini_options]
 minversion = "7"
 log_cli_level = "INFO"
-filterwarnings = ["error"]
+# filterwarnings = ["error"]  # breaks debugging tests in VSCode (Sept. 2024)
 xfail_strict = true
 addopts = "-rfEXs --strict-config --strict-markers --doctest-modules --doctest-glob=*.py --doctest-glob=*.rst"
 doctest_optionflags = [

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -285,13 +285,13 @@ phasor_to_ometiff(
 # %%
 # Read the phasor coordinates and metadata back from the OME-TIFF file:
 
-mean_, real_, imag_ = phasor_from_ometiff('phasors.ome.tif')
+mean_, real_, imag_, attrs = phasor_from_ometiff('phasors.ome.tif')
 
 numpy.allclose(real_, real)
 assert real_.dtype == numpy.float32
-assert real_.attrs['frequency'] == frequency
-assert real_.attrs['harmonic'] == 1
-assert mean_.attrs['description'].startswith('Phasor coordinates of')
+assert attrs['frequency'] == frequency
+assert attrs['harmonic'] == 1
+assert attrs['description'].startswith('Phasor coordinates of')
 
 # %%
 # The functions also transparently work with multi-harmonic phasor coordinates.


### PR DESCRIPTION
## Description

This PR makes the following changes to the `phasor_from_ometiff` function to improve overall consistency of the API:

- Return phasor coordinate images as numpy ndarrays, not xarrays. 
- Return an additional dict with metadata. 
- Return only the first harmonic stored in the file by default.
- Add option to return specific harmonic(s) from file.

The changes make the function more alike `phasor_from_signal` or `phasor_from_simfcs_referenced`, which return numpy arrays and the first harmonic by default. Metadata keys are matching the optional parameters of the `phasor_to_ometiff` function.

Another objective is to avoid using xarray since it is a large dependency and the metadata returned are trivial and repetitive for all returned arrays.

## Release note

Summarize the changes in the code block below to be included in the
[release notes](https://www.phasorpy.org/stable/release.html):

```release-note
Revise phasor_from_ometiff
```

## Checklist

- [x] The pull request title, summary, and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/stable/license.html).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/stable/contributing.html#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/stable/contributing.html#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/stable/contributing.html#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
