### PR TITLE
Change release-pypi to build_sdist workflow

### DIFF
--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPI
+name: Build sdist
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build_artifacts:
-    name: Build sdist and wheel
+    name: Build sdist
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -28,23 +28,23 @@ jobs:
           python-version: "3.12"
       - name: Install PyBuild
         run: |
-          python -m pip install build
-      - name: Build wheel and sdist
+          python -m pip install -U build
+      - name: Build sdist
         run: |
-          python -m build .
+          python -m build --sdist .
       - uses: actions/upload-artifact@v4
         with:
-          name: releases
+          name: sdist
           path: dist
 
   test_artifacts:
-    name: Test sdist and wheel
+    name: Test sdist
     needs: [build_artifacts]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: releases
+          name: sdist
           path: dist
       - uses: actions/setup-python@v5
         with:
@@ -57,19 +57,21 @@ jobs:
           python -m pip install --upgrade --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
           python -c"from phasorpy import __version__;print(__version__)"
 
-  upload_artifacts:
-    name: Upload release to PyPI
-    needs: [build_artifacts]
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/phasorpy
-    permissions:
-      id-token: write
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: releases
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+# Upload sdist and wheels manually for now
+#
+#  upload_artifacts:
+#    name: Upload release to PyPI
+#    needs: [test_artifacts]
+#    runs-on: ubuntu-latest
+#    environment:
+#      name: pypi
+#      url: https://pypi.org/p/phasorpy
+#    permissions:
+#      id-token: write
+#    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+#    steps:
+#      - uses: actions/download-artifact@v4
+#        with:
+#          name: releases
+#          path: dist
+#      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -52,9 +52,9 @@ jobs:
       - run: |
           ls
           ls dist
-          python -m pip install -U twine setuptools
+          python -m pip install -U twine setuptools build wheel numpy Cython
           python -m twine check dist/*
-          python -m pip install --upgrade --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
+          python -m pip install --upgrade --no-build-isolation --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
           python -c"from phasorpy import __version__;print(__version__)"
 
 # Upload sdist and wheels manually for now

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -52,7 +52,7 @@ jobs:
       - run: |
           ls
           ls dist
-          python -m pip install -U twine
+          python -m pip install -U twine setuptools
           python -m twine check dist/*
           python -m pip install --upgrade --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
           python -c"from phasorpy import __version__;print(__version__)"


### PR DESCRIPTION
## Description

- Rename the `release-pypi.yml` GitHub Action workflow to `build_sdist.yml`.
- Remove building wheel with sdist (wheels are built in `build_wheels.yml`).
- Disable automatic upload to PyPI on tag (sdist and wheels will be uploaded manually for the first releases). 

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
