### PR TITLE
Enable testing wheels on Python 3.13

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -12,7 +12,6 @@ on:
   workflow_dispatch:
 
 env:
-  CIBW_TEST_SKIP: "cp313*"
   MPLBACKEND: agg
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.10", "3.12", "3.13"]
+        python-version: ["3.10", "3.12"]
         # 3.11 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.12", "3.13"]
         # 3.11 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -52,7 +52,7 @@ pre-commit
 pre-commit-hooks
 #
 # optional requirements
-scikit-image
+# scikit-image
 # scikit-learn
 # pandas
 # zarr


### PR DESCRIPTION
## Description

This PR enables testing wheels on Python 3.13.  Also disable scikit-image as a development dependency since wheels are not yet available for Python 3.13.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
