### PR TITLE
Support Linux on AArch64

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,11 +23,11 @@ jobs:
         os: [ubuntu-22.04, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
+      # - name: Set up QEMU
+      #   if: runner.os == 'Linux'
+      #   uses: docker/setup-qemu-action@v3
+      #   with:
+      #     platforms: all
       - uses: pypa/cibuildwheel@v2.21.1
         env:
           # Building and testing manylinux2014_aarch64 too is slow.

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,11 +30,13 @@ jobs:
           platforms: all
       - uses: pypa/cibuildwheel@v2.21.1
         env:
-          # CIBW_ENVIRONMENT: "PIP_PRE=1"
-          CIBW_BUILD_VERBOSITY: 2
-          CIBW_ARCHS_LINUX: x86_64 aarch64
+          # Building and testing manylinux2014_aarch64 too is slow.
+          # See https://github.com/phasorpy/phasorpy/pull/135
+          # CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
+          CIBW_BUILD_VERBOSITY: 2
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -23,11 +23,16 @@ jobs:
         os: [ubuntu-22.04, macos-12, windows-2019]
     steps:
       - uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
       - uses: pypa/cibuildwheel@v2.21.1
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 2
-          CIBW_ARCHS_LINUX: auto
+          CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -98,30 +98,33 @@ jobs:
           path: ./wheelhouse/*.whl
           name: wheels-${{ matrix.os }}
 
-  build_wheels_arm64:
-    name: Test Linux on AArch64
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-      - uses: pypa/cibuildwheel@v2.21.1
-        env:
-          CIBW_ARCHS_LINUX: aarch64
-          CIBW_BUILD_VERBOSITY: 2
-          CIBW_BUILD: "cp311*"
-          CIBW_SKIP: "*musllinux*"
-      - uses: actions/upload-artifact@v4
-        with:
-          path: ./wheelhouse/*.whl
-          name: wheels-aarch64
+  # Building and testing manylinux2014_aarch64 too is slow.
+  # See https://github.com/phasorpy/phasorpy/pull/135
+  #
+  #  build_wheels_arm64:
+  #    name: Test Linux on AArch64
+  #    runs-on: ${{ matrix.os }}
+  #    strategy:
+  #      fail-fast: false
+  #      matrix:
+  #        os: ["ubuntu-latest"]
+  #    steps:
+  #      - uses: actions/checkout@v4
+  #      - name: Set up QEMU
+  #        if: runner.os == 'Linux'
+  #        uses: docker/setup-qemu-action@v3
+  #        with:
+  #          platforms: all
+  #      - uses: pypa/cibuildwheel@v2.21.1
+  #        env:
+  #          CIBW_ARCHS_LINUX: aarch64
+  #          CIBW_BUILD_VERBOSITY: 2
+  #          CIBW_BUILD: "cp311*"
+  #          CIBW_SKIP: "*musllinux*"
+  #      - uses: actions/upload-artifact@v4
+  #        with:
+  #          path: ./wheelhouse/*.whl
+  #          name: wheels-aarch64
 
   static_analysis:
     name: Static code analysis

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         python-version: ["3.10", "3.12"]
-        # 3.11, 3.13 tested with cibuildwheel
+        # 3.11 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -91,7 +91,7 @@ jobs:
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_BUILD: "cp313-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
+          CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: ["ubuntu-20.04"]
         python-version: ["3.10", "3.12"]
-        # 3.11 tested with cibuildwheel
+        # 3.11, 3.13 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -91,12 +91,37 @@ jobs:
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
           CIBW_BUILD_VERBOSITY: 3
-          CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
+          CIBW_BUILD: "cp313-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
           name: wheels-${{ matrix.os }}
+
+  build_wheels_arm64:
+    name: Test cibuildwheel on arm64
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+      - uses: pypa/cibuildwheel@v2.21.1
+        env:
+          CIBW_ARCHS_LINUX: aarch64
+          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD: "cp311*"
+          CIBW_SKIP: "*musllinux*"
+      - uses: actions/upload-artifact@v4
+        with:
+          path: ./wheelhouse/*.whl
+          name: wheels-aarch64
 
   static_analysis:
     name: Static code analysis

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -99,7 +99,7 @@ jobs:
           name: wheels-${{ matrix.os }}
 
   build_wheels_arm64:
-    name: Test cibuildwheel on arm64
+    name: Test Linux on AArch64
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -115,7 +115,7 @@ jobs:
       - uses: pypa/cibuildwheel@v2.21.1
         env:
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_BUILD_VERBOSITY: 3
+          CIBW_BUILD_VERBOSITY: 2
           CIBW_BUILD: "cp311*"
           CIBW_SKIP: "*musllinux*"
       - uses: actions/upload-artifact@v4

--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,13 +1,13 @@
 [
-    {
-        "name": "dev",
-        "version": "0.2",
-        "url": "https://www.phasorpy.org/docs/dev/"
-    },
-    {
-        "name": "0.1 (stable)",
-        "version": "0.1",
-        "url": "https://www.phasorpy.org/docs/stable/",
-        "preferred": true
-    }
+  {
+    "name": "dev",
+    "version": "0.2",
+    "url": "https://www.phasorpy.org/docs/dev/"
+  },
+  {
+    "name": "0.1 (stable)",
+    "version": "0.1",
+    "url": "https://www.phasorpy.org/docs/stable/",
+    "preferred": true
+  }
 ]

--- a/tools/build_manylinux2014.cmd
+++ b/tools/build_manylinux2014.cmd
@@ -1,0 +1,13 @@
+:: Build PhasorPy manylinux2014 wheels on Windows using Docker
+
+setlocal
+set PATH=C:\Windows;C:\Windows\System32;C:\Program Files\Docker\Docker\resources\bin
+set CIBW_ARCHS_LINUX=auto
+set CIBW_SKIP=pp* cp37* cp38* cp39* *musllinux*
+:: set CIBW_TEST_SKIP=*
+set CIBW_TEST_COMMAND=python -m pytest {project}/tests
+set CIBW_BUILD_VERBOSITY=3
+
+docker version
+py -m cibuildwheel --platform linux
+endlocal

--- a/tools/build_manylinux2014.sh
+++ b/tools/build_manylinux2014.sh
@@ -1,0 +1,10 @@
+# Build PhasorPy manylinux2014 wheels on Linux or macOS using Docker
+
+export CIBW_ARCHS_LINUX=auto
+export CIBW_SKIP="pp* cp37* cp38* cp39* *musllinux*"
+# export CIBW_TEST_SKIP="*"
+export CIBW_TEST_COMMAND="pytest {project}/tests"
+export CIBW_BUILD_VERBOSITY=3
+
+docker version
+python3 -m cibuildwheel --platform linux


### PR DESCRIPTION
## Description

This PR enables testing and building wheels on AArch64 Linux [via QEMU](https://cibuildwheel.pypa.io/en/stable/faq/#emulation). Wheels for macOS and Windows are already built for ARM64. Not all dependencies are available on AArch64 Linux, so tests may be slow or fail.

Update: disabled building and testing in GitHub Actions because it is too slow and instead added scripts to locally build and test manylinux2014_aarch64 (or x86_64) wheels using Docker.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
