### PR TITLE
Add documentation version switcher dropdown

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,13 +1,13 @@
 [
-    {
-        "name": "dev",
-        "version": "0.2",
-        "url": "https://www.phasorpy.org/docs/dev/"
-    },
-    {
-        "name": "0.1 (stable)",
-        "version": "0.1",
-        "url": "https://www.phasorpy.org/docs/stable/",
-        "preferred": true
-    }
+  {
+    "name": "dev",
+    "version": "0.2",
+    "url": "https://www.phasorpy.org/docs/dev/"
+  },
+  {
+    "name": "0.1 (stable)",
+    "version": "0.1",
+    "url": "https://www.phasorpy.org/docs/stable/",
+    "preferred": true
+  }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,6 +25,7 @@ import phasorpy
 
 version = phasorpy.__version__
 release = phasorpy.__version__
+version_match = version.replace('.dev', '').replace('.rc', '')
 
 # general configuration
 
@@ -72,6 +73,7 @@ napoleon_use_param = True
 
 html_theme_options = {
     'logo': {
+        # 'text': f'PhasorPy {version}',
         'text': 'PhasorPy',
         'alt_text': 'PhasorPy',
         # 'image_dark': '_static/logo-dark.svg',
@@ -79,17 +81,38 @@ html_theme_options = {
     'header_links_before_dropdown': 4,
     'show_nav_level': 2,
     'navigation_with_keys': False,
+    # 'collapse_navigation': True,
+    'navbar_align': 'content',  # [left, content, right]
+    'navbar_persistent': [],
+    # 'navbar_center': [],  # , 'version-switcher', 'navbar-nav'
+    'navbar_end': [
+        'search-button',
+        'version-switcher',
+        'theme-switcher',
+        'navbar-icon-links',
+    ],
+    'switcher': {
+        'version_match': version_match,
+        'json_url': 'https://www.phasorpy.org/docs/dev/_static/switcher.json',
+    },
+    # 'check_switcher': False,
+    'show_version_warning_banner': True,
     'icon_links': [
         {
-            'name': 'GitHub',
-            'url': 'https://github.com/phasorpy/phasorpy',
-            'icon': 'fa-brands fa-github',
+            'name': 'Home',
+            'url': 'https://www.phasorpy.org',
+            'icon': 'fa fa-home',
         },
         {
             'name': 'PyPI',
             'url': 'https://pypi.org/project/phasorpy/',
             'icon': 'fa-custom fa-pypi',
             'type': 'fontawesome',
+        },
+        {
+            'name': 'GitHub',
+            'url': 'https://github.com/phasorpy/phasorpy',
+            'icon': 'fa-brands fa-github',
         },
     ],
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,7 +59,7 @@ Contents
 ========
 
 .. toctree::
-    :maxdepth: 1
+    :maxdepth: 2
 
     phasor_approach
     tutorials/index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ docs = [
     "sphinx_gallery",
     "sphinx-copybutton",
     "sphinx_click",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.16.0",
     "numpydoc",
 ]
 test = [

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -29,7 +29,7 @@ sphinx-copybutton
 sphinx_click
 sphinx-inline-tabs
 numpydoc
-pydata-sphinx-theme
+pydata-sphinx-theme>=0.16.0
 #
 # test requirements
 pytest


### PR DESCRIPTION
## Description

This PR adds [version switcher dropdowns](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html) to the documentation. Unfortunately there is an [issue with the PyData Sphinx theme](https://github.com/pydata/pydata-sphinx-theme/issues/2002), which prevents this from being merged at this time.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
