### PR TITLE
Improve private parse_harmonic function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -115,7 +115,7 @@ def _phasor_from_signal(
     # https://numpy.org/devdocs/reference/c-api/iterator.html
 
     if (
-        samples < 3
+        samples < 2
         or harmonics > samples // 2
         or phasor.shape[0] != harmonics * 2 + 1
         or phasor.shape[1] != signal.shape[0]

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -130,37 +130,42 @@ def test_dilate_coordinates():
 
 def test_parse_harmonic():
     """Test parse_harmonic function."""
-    assert parse_harmonic(None, 3) == ([1], False)
-    assert parse_harmonic(1, 3) == ([1], False)
-    assert parse_harmonic(numpy.int32(1), 3) == ([1], False)
-    assert parse_harmonic([1], 3) == ([1], True)
-    assert parse_harmonic([numpy.int32(1)], 3) == (  # type: ignore[list-item]
+    assert parse_harmonic(None) == ([1], False)
+    assert parse_harmonic(None, 1) == ([1], False)
+    assert parse_harmonic(1) == ([1], False)
+    assert parse_harmonic(1, 1) == ([1], False)
+    assert parse_harmonic(numpy.int32(1), 1) == ([1], False)
+    assert parse_harmonic([1], 1) == ([1], True)
+    assert parse_harmonic([numpy.int32(1)], 1) == (  # type: ignore[list-item]
         [1],
         True,
     )
-    assert parse_harmonic([1, 2], 5) == ([1, 2], True)
-    assert parse_harmonic([2, 1], 5) == ([2, 1], True)
-    assert parse_harmonic(numpy.array([1, 2]), 5) == ([1, 2], True)
-    assert parse_harmonic('all', 5) == ([1, 2], True)
+    assert parse_harmonic([1, 2], 2) == ([1, 2], True)
+    assert parse_harmonic([2, 1], 2) == ([2, 1], True)
+    assert parse_harmonic(numpy.array([1, 2]), 2) == ([1, 2], True)
+    assert parse_harmonic('all', 1) == ([1], True)
+    assert parse_harmonic('all', 2) == ([1, 2], True)
 
     with pytest.raises(ValueError):
-        parse_harmonic(1, 2)
+        parse_harmonic(1, 0)
     with pytest.raises(IndexError):
-        parse_harmonic(0, 3)
+        parse_harmonic(0, 1)
     with pytest.raises(IndexError):
-        parse_harmonic(2, 3)
+        parse_harmonic(2, 1)
     with pytest.raises(IndexError):
-        parse_harmonic([1, 2], 3)
+        parse_harmonic([1, 2], 1)
     with pytest.raises(TypeError):
-        parse_harmonic([[1]], 3)  # type: ignore[list-item]
+        parse_harmonic([[1]], 1)  # type: ignore[list-item]
     with pytest.raises(ValueError):
-        parse_harmonic([], 3)
+        parse_harmonic([], 1)
     with pytest.raises(ValueError):
-        parse_harmonic([1, 1], 3)
+        parse_harmonic([1, 1], 1)
     with pytest.raises(ValueError):
-        parse_harmonic('alles', 3)
+        parse_harmonic('alles', 1)
     with pytest.raises(TypeError):
-        parse_harmonic(1.0, 3)
+        parse_harmonic(1.0, 1)
+    with pytest.raises(TypeError):
+        parse_harmonic('all')
 
 
 def test_chunk_iter():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -536,8 +536,8 @@ def test_phasor_to_ometiff_exceptions():
         with pytest.raises(ValueError):
             phasor_to_ometiff(filename, data[:1], data, data)
 
-        # invalid harmonic
-        with pytest.raises(ValueError):
+        # invalid harmonic, not an integer
+        with pytest.raises(TypeError):
             phasor_to_ometiff(
                 filename, *data, harmonic=[[1]]  # type: ignore[list-item]
             )

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -67,11 +67,12 @@ numpy.random.seed(42)
 @pytest.mark.parametrize('use_fft', (True, False))
 def test_phasor_from_signal(use_fft):
     """Test phasor_from_signal function."""
-    sample_phase = numpy.linspace(0, 2 * math.pi, 7, endpoint=False)
+    samples = 7
+    sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
     signal = 1.1 * (numpy.cos(sample_phase - 0.46364761) * 2 * 0.44721359 + 1)
     signal_copy = signal.copy()
 
-    # test scalar type
+    # scalar type
     mean, real, imag = phasor_from_signal(signal, use_fft=use_fft)
     assert mean.ndim == 0
     assert real.ndim == 0
@@ -202,6 +203,22 @@ def test_phasor_from_signal(use_fft):
             phasor_from_signal(
                 signal, sample_phase=sample_phase, use_fft=use_fft
             )
+
+
+@pytest.mark.parametrize('use_fft', (True, False))
+@pytest.mark.parametrize('samples', [2, 3])
+def test_phasor_from_signal_min_samples(samples, use_fft):
+    """Test phasor_from_signal function with two and three samples."""
+    sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
+    signal = 1.1 * (numpy.cos(sample_phase - 0.46364761) * 2 * 0.44721359 + 1)
+
+    # a minimum of three samples is required to calculate correct 1st harmonic
+    if samples < 3:
+        with pytest.raises(ValueError):
+            phasor = phasor_from_signal(signal, use_fft=use_fft)
+    else:
+        phasor = phasor_from_signal(signal, use_fft=use_fft)
+        assert_allclose(phasor, (1.1, 0.4, 0.2), atol=1e-3)
 
 
 @pytest.mark.parametrize('use_fft', (True, False))


### PR DESCRIPTION
## Description

This PR proposes the following changes to the private `_utils.parse_harmonic` function:

1. Replace `samples` with `harmonic_max` parameter to make the function more consistent and easier to understand.
2. Make `harmonic_max` parameter optional to allow for cases where the upper harmonics limit is unknown (as in #124).

This simplifies existing code a little.

Also added a note to the  `phasor_from_signal` function that "A minimum of `harmonic * 2 + 1` samples are required along `axis` to calculate correct phasor coordinates at `harmonic`". This is actually not verified in `parse_harmonic` and Fourier transform does return second harmonic numbers for 4 samples even though they are not correct phasor coordinates (as far as I understand). There is however a verified requirement for an absolute minimum of three signal samples.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
