### PR TITLE
Add Anscombe transformation functions

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1809,3 +1809,49 @@ cdef (double, double, double) _phasor_threshold_nan(
         return <float_t> NAN, <float_t> NAN, <float_t> NAN
 
     return mean, real, imag
+
+
+###############################################################################
+# Unary ufuncs
+
+@cython.ufunc
+cdef float_t _anscombe(
+    float_t x,
+) noexcept nogil:
+    """Return anscombe variance stabilizing transformation."""
+    if isnan(x):
+        return <float_t> NAN
+
+    return <float_t> (2.0 * sqrt(<double> x + 0.375))
+
+
+@cython.ufunc
+cdef float_t _anscombe_inverse(
+    float_t x,
+) noexcept nogil:
+    """Return inverse anscombe transformation."""
+    if isnan(x):
+        return <float_t> NAN
+
+    return <float_t> (x * x / 4.0 - 0.375)  # 3/8
+
+
+@cython.ufunc
+cdef float_t _anscombe_inverse_approx(
+    float_t x,
+) noexcept nogil:
+    """Return inverse anscombe transformation.
+
+    Using approximation of exact unbiased inverse.
+
+    """
+    if isnan(x):
+        return <float_t> NAN
+
+    return <float_t> (
+        0.25 * x * x  # 1/4
+        + 0.30618621784789724 / x  # 1/4 * sqrt(3/2)
+        - 1.375 / (x * x)  # 11/8
+        + 0.7654655446197431 / (x * x * x)  # 5/8 * sqrt(3/2)
+        - 0.125  # 1/8
+    )

--- a/src/phasorpy/utils.py
+++ b/src/phasorpy/utils.py
@@ -7,9 +7,144 @@ that do not naturally fit into other modules.
 
 from __future__ import annotations
 
-__all__ = ['number_threads']
+__all__ = [
+    'anscombe_transformation',
+    'anscombe_transformation_inverse',
+    'number_threads',
+]
 
 import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ._typing import Any, NDArray, ArrayLike
+
+from ._phasorpy import _anscombe, _anscombe_inverse, _anscombe_inverse_approx
+
+
+def anscombe_transformation(
+    data: ArrayLike,
+    /,
+    **kwargs: Any,
+) -> NDArray[Any]:
+    r"""Return Anscombe variance-stabilizing transformation.
+
+    The Anscombe transformation normalizes the standard deviation of noisy,
+    Poisson-distributed data.
+    It can be used to transform un-normalized phasor coordinates to
+    approximate standard Gaussian distributions.
+
+    Parameters
+    ----------
+    data: array_like
+        Noisy Poisson-distributed data to be transformed.
+    **kwargs
+        Optional `arguments passed to numpy universal functions
+        <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Returns
+    -------
+    ndarray
+        Anscombe-transformed data with variance of approximately 1.
+
+    Notes
+    -----
+    The Anscombe transformation according to [1]_:
+
+    .. math::
+
+        z = 2 \cdot \sqrt{x + 3 / 8}
+
+    References
+    ----------
+
+    .. [1] Anscombe FJ.
+       `The transformation of Poisson, binomial and negative-binomial data
+       <https://doi.org/10.2307/2332343>`_.
+       *Biometrika*, 35(3-4): 246-254 (1948)
+
+    Examples
+    --------
+
+    >>> z = anscombe_transformation(numpy.random.poisson(10, 10000))
+    >>> numpy.allclose(numpy.std(z), 1.0, atol=0.1)
+    True
+
+    """
+    return _anscombe(data, **kwargs)  # type: ignore[no-any-return]
+
+
+def anscombe_transformation_inverse(
+    data: ArrayLike,
+    /,
+    *,
+    approx: bool = False,
+    **kwargs: Any,
+) -> NDArray[Any]:
+    r"""Return inverse Anscombe transformation.
+
+    Parameters
+    ----------
+    data: array_like
+        Anscombe-transformed data.
+    approx: bool, default: False
+        If true, return approximation of exact unbiased inverse.
+    **kwargs
+        Optional `arguments passed to numpy universal functions
+        <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Returns
+    -------
+    ndarray
+        Inverse Anscombe-transformed data.
+
+    Notes
+    -----
+    The inverse Anscombe transformation according to [1]_:
+
+    .. math::
+
+        x = (z / 2.0)^2 - 3 / 8
+
+    The approximate inverse Anscombe transformation according to [2]_ and [3]_:
+
+    .. math::
+
+        x = 1/4 \cdot z^2{2}
+          + 1/4 \cdot \sqrt{3/2} \cdot z^{-1}
+          - 11/8 \cdot z^{-2}
+          + 5/8 \cdot \sqrt(3/2) \cdot z^{-3}
+          - 1/8
+
+    References
+    ----------
+
+    .. [2] Makitalo M, and Foi A.
+       `A closed-form approximation of the exact unbiased inverse of the
+       Anscombe variance-stabilizing transformation
+       <https://doi.org/10.1109/TIP.2011.2121085>`_.
+       IEEE Trans Image Process, 20(9): 2697-8 (2011).
+
+    .. [3] Makitalo M, and Foi A
+       `Optimal inversion of the generalized Anscombe transformation for
+       Poisson-Gaussian noise
+       <https://doi.org/10.1109/TIP.2012.2202675>`_,
+       IEEE Trans Image Process, 22(1): 91-103 (2013)
+
+    Examples
+    --------
+
+    >>> x = numpy.random.poisson(10, 100)
+    >>> x2 = anscombe_transformation_inverse(anscombe_transformation(x))
+    >>> numpy.allclose(x, x2, atol=1e-3)
+    True
+
+    """
+    if approx:
+        return _anscombe_inverse_approx(  # type: ignore[no-any-return]
+            data, **kwargs
+        )
+    return _anscombe_inverse(data, **kwargs)  # type: ignore[no-any-return]
 
 
 def number_threads(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,16 @@
 
 import os
 
-from phasorpy.utils import number_threads
+import numpy
+import pytest
+
+from phasorpy.utils import (
+    anscombe_transformation,
+    anscombe_transformation_inverse,
+    number_threads,
+)
+
+numpy.random.seed(42)
 
 
 def test_number_threads():
@@ -23,6 +32,27 @@ def test_number_threads():
         assert number_threads(0) == 4
         assert number_threads(6) == 6
         del os.environ['PHASORPY_NUM_THREADS']
+
+
+@pytest.mark.parametrize('dtype', ['float32', 'uint16'])
+def test_anscombe_transformation(dtype):
+    """Test anscombe_transformation and inverse functions."""
+    x = numpy.random.poisson(10, 100000).astype(dtype)
+    if dtype == 'float32':
+        x[0] = numpy.nan
+    z = anscombe_transformation(x)
+    numpy.testing.assert_allclose(numpy.std(z[1:]), 1.0, atol=0.01)
+
+    x2 = anscombe_transformation_inverse(z)
+    numpy.testing.assert_allclose(x2[1:], x[1:], atol=0.01)
+
+    x3 = anscombe_transformation_inverse(z, approx=True)
+    numpy.testing.assert_allclose(x3[1:], x[1:], atol=1.0)
+
+    if dtype == 'float32':
+        assert numpy.isnan(z[0])
+        assert numpy.isnan(x2[0])
+        assert numpy.isnan(x3[0])
 
 
 # mypy: allow-untyped-defs, allow-untyped-calls


### PR DESCRIPTION
## Description

This PR adds the `anscombe_transformation` and `anscombe_transformation_inverse` functions to the public `utils` module.

The Anscombe transformation normalizes the standard deviation of noisy, Poisson-distributed data. It is [used by Leica](https://doi.org/10.1364/boe.420953) to transform un-normalized phasor coordinates to approximate standard Gaussian distributions before applying wavelet filters (see also #99).

We don't have any use for these functions yet, but they are easy to implement and might become useful when trying to understand/reproduce Leica's processing of phasor coordinates.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
