### PR TITLE
Replace median filter implementation for NaN handling consistency

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -2093,48 +2093,53 @@ cdef inline float_t _median(float_t *values, const ssize_t n) noexcept nogil:
 def _apply_2d_median_filter(
     const float_t[:, ::1] image,
     float_t[:, ::1] filtered_image,
-    const ssize_t kernel_size
+    const ssize_t kernel_size,
+    const int num_threads=1,
 ):
     """Apply a 2D median filter ignoring NaN."""
     cdef:
         ssize_t rows = image.shape[0]
         ssize_t cols = image.shape[1]
         ssize_t k = kernel_size // 2
-        ssize_t i, j, di, dj
-        ssize_t ki, kj
-        ssize_t valid_count
+        ssize_t i, j, di, dj, ki, kj, valid_count
         float_t element
-        float_t *kernel = <float_t *>malloc(
-            kernel_size * kernel_size * sizeof(float_t)
-        )
+        float_t *kernel
 
     if kernel_size <= 0:
         raise ValueError("kernel_size must be greater than 0")
-    if kernel == NULL:
-        raise MemoryError("Unable to allocate memory for kernel")
 
-    with nogil:
-        for i in range(rows):
+    with nogil, parallel(num_threads=num_threads):
+
+        kernel = <float_t *> malloc(
+            kernel_size * kernel_size * sizeof(float_t)
+        )
+        if kernel == NULL:
+            with gil:
+                raise MemoryError("Unable to allocate memory for kernel")
+
+        for i in prange(rows):
             for j in range(cols):
-                if not isnan(image[i, j]):
-                    valid_count = 0
-                    for di in range(kernel_size):
-                        ki = i - k + di
-                        if ki < 0:
-                            ki = 0
-                        elif ki >= rows:
-                            ki = rows - 1
-                        for dj in range(kernel_size):
-                            kj = j - k + dj
-                            if kj < 0:
-                                kj = 0
-                            elif kj >= cols:
-                                kj = cols - 1
-                            element = image[ki, kj]
-                            if not isnan(element):
-                                kernel[valid_count] = element
-                                valid_count += 1
-                    if valid_count > 0:
-                        filtered_image[i, j] = _median(kernel, valid_count)
+                if isnan(image[i, j]):
+                    filtered_image[i, j] = <float_t> NAN
+                    continue
+                valid_count = 0
+                for di in range(kernel_size):
+                    ki = i - k + di
+                    if ki < 0:
+                        ki = 0
+                    elif ki >= rows:
+                        ki = rows - 1
+                    for dj in range(kernel_size):
+                        kj = j - k + dj
+                        if kj < 0:
+                            kj = 0
+                        elif kj >= cols:
+                            kj = cols - 1
+                        element = image[ki, kj]
+                        if not isnan(element):
+                            kernel[valid_count] = element
+                            valid_count = valid_count + 1
+                if valid_count > 0:
+                    filtered_image[i, j] = _median(kernel, valid_count)
 
-    free(kernel)
+        free(kernel)

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1866,7 +1866,7 @@ cdef float_t _quickselect(
     float_t *arr,
     ssize_t left,
     ssize_t right,
-    ssize_t k
+    const ssize_t k
 ) noexcept nogil:
     """Quickselect algorithm to find the k-th smallest element."""
     cdef:

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -2086,12 +2086,12 @@ cdef float_t _median(const float_t *values, const ssize_t n) noexcept nogil:
             (_quickselect(values, 0, n - 1, n // 2 - 1) +
              _quickselect(values, 0, n - 1, n // 2)) / 2
         )
-    
+
     return _quickselect(values, 0, n - 1, n // 2)
 
 
 def _apply_2d_median_filter(
-    const float_t[:, :] image, 
+    const float_t[:, :] image,
     float_t[:, :] filtered_image,
     const ssize_t kernel_size
 ):
@@ -2103,7 +2103,7 @@ def _apply_2d_median_filter(
         int rows = image.shape[0]
         int cols = image.shape[1]
         int k = kernel_size // 2
-        int i, j, di, dj, iter
+        int i, j, di, dj
         int ki, kj
         int valid_count
         float_t element
@@ -2113,7 +2113,7 @@ def _apply_2d_median_filter(
 
     if kernel == NULL:
         raise MemoryError("Unable to allocate memory for kernel")
-    
+
     with nogil:
         for i in range(rows):
             for j in range(cols):

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1940,7 +1940,5 @@ def _median_filter_2d(float_t[:, :] image, float_t[:, :] filtered_image,
                             valid_count += 1
                 if valid_count > 0:
                     filtered_image[i, j] = _median(kernel, valid_count)
-            else:
-                print(image[i, j])
 
     free(kernel)

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1921,28 +1921,26 @@ def _median_filter_2d(float_t[:, :] image, float_t[:, :] filtered_image,
 
     for i in range(rows):
         for j in range(cols):
-            if isnan(image[i, j]):
-                filtered_image[i, j] = <float_t>NAN
-                continue
-            valid_count = 0
-            for di in range(kernel_size):
-                for dj in range(kernel_size):
-                    ki = i - k + di
-                    kj = j - k + dj
-                    if ki < 0:
-                        ki = 0
-                    elif ki >= rows:
-                        ki = rows - 1
-                    if kj < 0:
-                        kj = 0
-                    elif kj >= cols:
-                        kj = cols - 1
-                    if not isnan(image[ki, kj]):
-                        kernel[valid_count] = image[ki, kj]
-                        valid_count += 1
-            if valid_count > 0:
-                filtered_image[i, j] = _median(kernel, valid_count)
+            if not isnan(image[i, j]):
+                valid_count = 0
+                for di in range(kernel_size):
+                    for dj in range(kernel_size):
+                        ki = i - k + di
+                        kj = j - k + dj
+                        if ki < 0:
+                            ki = 0
+                        elif ki >= rows:
+                            ki = rows - 1
+                        if kj < 0:
+                            kj = 0
+                        elif kj >= cols:
+                            kj = cols - 1
+                        if not isnan(image[ki, kj]):
+                            kernel[valid_count] = image[ki, kj]
+                            valid_count += 1
+                if valid_count > 0:
+                    filtered_image[i, j] = _median(kernel, valid_count)
             else:
-                filtered_image[i, j] = <float_t>NAN
+                print(image[i, j])
 
     free(kernel)

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -2091,7 +2091,7 @@ cdef inline float_t _median(float_t *values, const ssize_t n) noexcept nogil:
 
 
 def _apply_2d_median_filter(
-    const float_t[:, ::1] image,
+    float_t[:, :] image,
     float_t[:, ::1] filtered_image,
     const ssize_t kernel_size,
     const int num_threads=1,
@@ -2142,3 +2142,7 @@ def _apply_2d_median_filter(
                 filtered_image[i, j] = _median(kernel, valid_count)
 
         free(kernel)
+
+        for i in prange(rows):
+            for j in range(cols):
+                image[i, j] = filtered_image[i, j]

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -2139,7 +2139,6 @@ def _apply_2d_median_filter(
                         if not isnan(element):
                             kernel[valid_count] = element
                             valid_count = valid_count + 1
-                if valid_count > 0:
-                    filtered_image[i, j] = _median(kernel, valid_count)
+                filtered_image[i, j] = _median(kernel, valid_count)
 
         free(kernel)

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1862,52 +1862,64 @@ cdef float_t _anscombe_inverse_approx(
 ###############################################################################
 # Filtering functions
 
-cdef float_t _quickselect(float_t *arr, int left, int right, int k) nogil:
+cdef float_t _quickselect(
+    float_t *arr,
+    ssize_t left,
+    ssize_t right,
+    ssize_t k
+) noexcept nogil:
     """Quickselect algorithm to find the k-th smallest element."""
-    cdef int i, j, pivotIndex, pivotNewIndex
-    cdef float_t pivotValue, temp
+    cdef:
+        ssize_t i, pivot_index, pivot_new_index
+        float_t pivot_value, temp
 
     while left <= right:
-        pivotIndex = left + (right - left) // 2
-        pivotValue = arr[pivotIndex]
-        temp = arr[pivotIndex]
-        arr[pivotIndex] = arr[right]
+        pivot_index = left + (right - left) // 2
+        pivot_value = arr[pivot_index]
+        temp = arr[pivot_index]
+        arr[pivot_index] = arr[right]
         arr[right] = temp
-        pivotNewIndex = left
+        pivot_new_index = left
         for i in range(left, right):
-            if arr[i] < pivotValue:
+            if arr[i] < pivot_value:
                 temp = arr[i]
-                arr[i] = arr[pivotNewIndex]
-                arr[pivotNewIndex] = temp
-                pivotNewIndex += 1
+                arr[i] = arr[pivot_new_index]
+                arr[pivot_new_index] = temp
+                pivot_new_index += 1
         temp = arr[right]
-        arr[right] = arr[pivotNewIndex]
-        arr[pivotNewIndex] = temp
+        arr[right] = arr[pivot_new_index]
+        arr[pivot_new_index] = temp
 
-        if pivotNewIndex == k:
+        if pivot_new_index == k:
             return arr[k]
-        elif pivotNewIndex < k:
-            left = pivotNewIndex + 1
+        if pivot_new_index < k:
+            left = pivot_new_index + 1
         else:
-            right = pivotNewIndex - 1
+            right = pivot_new_index - 1
 
     return arr[k]
 
 
-cdef float_t _median(float_t *values, int n) nogil:
+cdef float_t _median(const float_t *values, const ssize_t n) noexcept nogil:
     """Calculate the median of an array of values."""
     if n % 2 == 0:
         return (
             (_quickselect(values, 0, n - 1, n // 2 - 1) +
              _quickselect(values, 0, n - 1, n // 2)) / 2
         )
-    else:
-        return _quickselect(values, 0, n - 1, n // 2)
+    
+    return _quickselect(values, 0, n - 1, n // 2)
 
 
-def _median_filter_2d(float_t[:, :] image, float_t[:, :] filtered_image,
-                      const ssize_t kernel_size):
+def _apply_2d_median_filter(
+    const float_t[:, :] image, 
+    float_t[:, :] filtered_image,
+    const ssize_t kernel_size
+):
     """Apply a 2D median filter ignoring NaN."""
+    if kernel_size <= 0:
+        raise ValueError("kernel_size must be greater than 0")
+
     cdef:
         int rows = image.shape[0]
         int cols = image.shape[1]
@@ -1915,30 +1927,36 @@ def _median_filter_2d(float_t[:, :] image, float_t[:, :] filtered_image,
         int i, j, di, dj, iter
         int ki, kj
         int valid_count
+        float_t element
         float_t *kernel = <float_t *>malloc(
             kernel_size * kernel_size * sizeof(float_t)
         )
 
-    for i in range(rows):
-        for j in range(cols):
-            if not isnan(image[i, j]):
-                valid_count = 0
-                for di in range(kernel_size):
-                    for dj in range(kernel_size):
+    if kernel == NULL:
+        raise MemoryError("Unable to allocate memory for kernel")
+    
+    with nogil:
+        for i in range(rows):
+            for j in range(cols):
+                if not isnan(image[i, j]):
+                    valid_count = 0
+                    for di in range(kernel_size):
                         ki = i - k + di
-                        kj = j - k + dj
                         if ki < 0:
                             ki = 0
                         elif ki >= rows:
                             ki = rows - 1
-                        if kj < 0:
-                            kj = 0
-                        elif kj >= cols:
-                            kj = cols - 1
-                        if not isnan(image[ki, kj]):
-                            kernel[valid_count] = image[ki, kj]
-                            valid_count += 1
-                if valid_count > 0:
-                    filtered_image[i, j] = _median(kernel, valid_count)
+                        for dj in range(kernel_size):
+                            kj = j - k + dj
+                            if kj < 0:
+                                kj = 0
+                            elif kj >= cols:
+                                kj = cols - 1
+                            element = image[ki, kj]
+                            if not isnan(element):
+                                kernel[valid_count] = element
+                                valid_count += 1
+                    if valid_count > 0:
+                        filtered_image[i, j] = _median(kernel, valid_count)
 
     free(kernel)

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -3165,6 +3165,10 @@ def _median_filter_2d(
 
     num_threads = number_threads(num_threads)
 
+    filtered_slice = numpy.empty(
+        tuple(real.shape[axis] for axis in axes), dtype=real.dtype
+    )
+
     for _ in range(repeat):
         for index in numpy.ndindex(
             *[real.shape[ax] for ax in range(real.ndim) if ax not in axes]
@@ -3177,18 +3181,17 @@ def _median_filter_2d(
             real_slice = real[full_index]
             imag_slice = imag[full_index]
 
-            filtered_real_slice = numpy.empty_like(real_slice)
-            filtered_imag_slice = numpy.empty_like(imag_slice)
-
             _apply_2d_median_filter(
-                real_slice, filtered_real_slice, size, num_threads
+                real_slice, filtered_slice, size, num_threads
             )
+            # numpy.copyto(real_slice, filtered_slice)
             _apply_2d_median_filter(
-                imag_slice, filtered_imag_slice, size, num_threads
+                imag_slice, filtered_slice, size, num_threads
             )
+            # numpy.copyto(imag_slice, filtered_slice)
 
-            real[full_index] = filtered_real_slice
-            imag[full_index] = filtered_imag_slice
+            real[full_index] = real_slice
+            imag[full_index] = imag_slice
 
     return numpy.asarray(real), numpy.asarray(imag)
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -2782,7 +2782,7 @@ def phasor_filter(
         axes = kwargs.pop('axes')
 
     return methods[method](  # type: ignore[no-any-return]
-        real, imag, repeat=repeat, size=size, axes=axes, **kwargs
+        real, imag, axes, repeat=repeat, size=size, **kwargs
     )
 
 
@@ -3100,13 +3100,13 @@ def _median(
 
 
 def _median_filter_2d(
-    real: ArrayLike,
-    imag: ArrayLike,
+    real: NDArray[Any],
+    imag: NDArray[Any],
+    axes: Sequence[int],
     /,
     *,
     repeat: int = 1,
     size: int = 3,
-    axes: Sequence[int],
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """Return the phasor coordinates after applying a 2D median filter.
 
@@ -3116,12 +3116,11 @@ def _median_filter_2d(
         Real components of the phasor coordinates.
     imag : ndarray
         Imaginary components of the phasor coordinates.
-    axes : int or sequence of int
-        Axes along which to apply the filter. By default, filtering is
-        applied to all axes.
+    axes : sequence of int
+        Axes along which to apply the filter.
     repeat : int, optional
         Number of times to apply filter. The default is 1.
-    size : int or tuple of int, optional
+    size : int, optional
         The size of the median filter kernel. Default is 3.
 
     Returns
@@ -3145,9 +3144,7 @@ def _median_filter_2d(
         imag = imag.astype(float)
 
     if len(axes) != 2:
-        return _median_filter_nd(
-            real, imag, repeat=repeat, size=size, axes=axes
-        )
+        return _median_filter_nd(real, imag, axes, repeat=repeat, size=size)
 
     for _ in range(repeat):
         for index in numpy.ndindex(
@@ -3171,13 +3168,13 @@ def _median_filter_2d(
 
 
 def _median_filter_nd(
-    real: ArrayLike,
-    imag: ArrayLike,
+    real: NDArray[Any],
+    imag: NDArray[Any],
+    axes: Sequence[int],
     /,
     *,
     repeat: int = 1,
     size: int = 3,
-    axes: Sequence[int],
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """Return the phasor coordinates after applying a median filter.
 
@@ -3187,12 +3184,11 @@ def _median_filter_nd(
         Real components of the phasor coordinates.
     imag : numpy.ndarray
         Imaginary components of the phasor coordinates.
-    axes : int or sequence of int
-        Axes along which to apply the filter. By default, filtering is
-        applied to all axes.
+    axes : sequence of int
+        Axes along which to apply the filter.
     repeat : int, optional
         Number of times to apply filter. The default is 1.
-    size : int or tuple of int, optional
+    size : int, optional
         The size of the median filter kernel. Default is 3.
 
     Returns
@@ -3238,13 +3234,13 @@ def _median_filter_nd(
 
 
 def _median_filter_scipy(
-    real: ArrayLike,
-    imag: ArrayLike,
+    real: NDArray[Any],
+    imag: NDArray[Any],
+    axes: Sequence[int],
     /,
     *,
     repeat: int = 1,
-    size: int | None = 3,
-    axes: Sequence[int] | None = None,
+    size: int = 3,
     **kwargs: Any,
 ) -> tuple[NDArray[Any], NDArray[Any]]:
     """Return the phasor coordinates after applying a median filter.
@@ -3257,12 +3253,11 @@ def _median_filter_scipy(
         Real components of the phasor coordinates.
     imag : ndarray
         Imaginary components of the phasor coordinates.
-    axes : int or sequence of int
-        Axes along which to apply the filter. By default, filtering is
-        applied to all axes.
+    axes : sequence of int
+        Axes along which to apply the filter.
     repeat : int, optional
         Number of times to apply filter. The default is 1.
-    size : int or tuple of int, optional
+    size : int, optional
         The size of the median filter kernel. Default is 3.
     **kwargs
         Optional arguments passed to :py:func:`scipy.ndimage.median_filter`.

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -3124,11 +3124,11 @@ def _2d_median_filter(
         Filtered imaginary component of phasor coordinates.
 
     """
-    real = numpy.asarray(real, dtype=float)
-    imag = numpy.asarray(imag, dtype=float)
+    real = numpy.asarray(real, dtype=float).copy()
+    imag = numpy.asarray(imag, dtype=float).copy()
 
     if axes is None:
-        axes = list(range(real.ndim))
+        axes = range(real.ndim)
     if len(axes) != 2:
         raise ValueError(
             "Exactly 2 axes for filtering are required by this method."
@@ -3205,6 +3205,7 @@ def _multidim_median_filter(
         axes = list(range(real.ndim))
 
     kernel_shape = (size,) * numpy.ndim(real)
+    nan_mask = numpy.isnan(real) | numpy.isnan(imag)
 
     for _ in range(repeat):
         kernel_shape = tuple(
@@ -3226,8 +3227,10 @@ def _multidim_median_filter(
         imag = numpy.nanmedian(
             windows_imag, axis=tuple(range(-len(kernel_shape), 0))
         )
+        real = numpy.where(nan_mask, numpy.nan, numpy.asarray(real))
+        imag = numpy.where(nan_mask, numpy.nan, numpy.asarray(imag))
 
-    return numpy.asarray(real), numpy.asarray(imag)
+    return real, imag
 
 
 def _scipy_median_filter(

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -3184,11 +3184,9 @@ def _median_filter_2d(
             _apply_2d_median_filter(
                 real_slice, filtered_slice, size, num_threads
             )
-            # numpy.copyto(real_slice, filtered_slice)
             _apply_2d_median_filter(
                 imag_slice, filtered_slice, size, num_threads
             )
-            # numpy.copyto(imag_slice, filtered_slice)
 
             real[full_index] = real_slice
             imag[full_index] = imag_slice

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -2696,7 +2696,7 @@ def phasor_filter(
 
         - ``'median'``: Spatial median of phasor coordinates.
         - ``'median_scipy'``: Spatial median of phasor coordinates
-            based on :py:func:`scipy.ndimage.median_filter`.
+          based on :py:func:`scipy.ndimage.median_filter`.
 
     repeat : int, optional
         Number of times to apply filter. The default is 1.

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -3188,9 +3188,6 @@ def _median_filter_2d(
                 imag_slice, filtered_slice, size, num_threads
             )
 
-            real[full_index] = real_slice
-            imag[full_index] = imag_slice
-
     return numpy.asarray(real), numpy.asarray(imag)
 
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -3242,8 +3242,8 @@ def _median_filter_nd(
         real_pad = numpy.pad(real, pad_width, mode='edge')
         imag_pad = numpy.pad(imag, pad_width, mode='edge')
 
-        windows_real = sliding_window_view(real_pad, tuple(kernel_shape))
-        windows_imag = sliding_window_view(imag_pad, tuple(kernel_shape))
+        windows_real = sliding_window_view(real_pad, kernel_shape)
+        windows_imag = sliding_window_view(imag_pad, kernel_shape)
 
         real = numpy.nanmedian(windows_real, axis=axis)
         imag = numpy.nanmedian(windows_imag, axis=axis)

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -42,6 +42,11 @@ from phasorpy.phasor import (
 from phasorpy.plot import PhasorPlot, plot_phasor_image
 
 VALUES_WITH_NAN = [0.5, nan, 0.1], [0.5, 0.5, 0.1]
+VALUES_WITH_NAN_2D = [[0.5, nan, 0.1], [0.5, 0.5, 0.1], [0.2, 0.3, nan]], [
+    [0.5, 0.5, 0.1],
+    [0.2, nan, 0.3],
+    [0.4, 0.4, 0.4],
+]
 
 
 def test_phasorplot_nan():
@@ -151,15 +156,21 @@ def test_phasor_divide_nan():
     assert_allclose(phasor, [[0.5, nan, 0.1], [0.0, nan, 0.0]], atol=1e-3)
 
 
-@pytest.mark.xfail
 def test_phasor_filter_nan():
     """Test phasor_filter function with NaN values."""
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        phasor = phasor_filter(*VALUES_WITH_NAN)
-    # TODO: this is undefined. https://github.com/phasorpy/phasorpy/issues/87
-    assert_allclose(phasor[0], [0.5, nan, 0.1], atol=1e-3)
-    assert_allclose(phasor[1], [0.5, 0.5, 0.1], atol=1e-3)
+        phasor = phasor_filter(*VALUES_WITH_NAN_2D)
+    assert_allclose(
+        phasor[0],
+        [[0.5, nan, 0.1], [0.5, 0.3, 0.1], [0.3, 0.3, nan]],
+        atol=1e-3,
+    )
+    assert_allclose(
+        phasor[1],
+        [[0.5, 0.4, 0.2], [0.4, nan, 0.35], [0.4, 0.4, 0.4]],
+        atol=1e-3,
+    )
 
 
 def test_phasor_from_apparent_lifetime_nan():

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -2414,6 +2414,21 @@ def test_parse_skip_axis():
                 skip_axis=0,
             ),
         ),
+        # non-contiguos axes for 2D filtering.
+        (
+            numpy.arange(81).reshape(3, 3, 3, 3),
+            numpy.arange(10, 91).reshape(3, 3, 3, 3),
+            'median',
+            1,
+            [0, 2],
+            {},
+            phasor_filter(
+                numpy.arange(81).reshape(3, 3, 3, 3),
+                numpy.arange(10, 91).reshape(3, 3, 3, 3),
+                method='median_scipy',
+                skip_axis=[0, 2],
+            ),
+        ),
     ],
 )
 def test_phasor_filter(

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -2371,6 +2371,49 @@ def test_parse_skip_axis():
                 ],
             ),
         ),
+        # same output for methods from 2D array without `NaN`
+        (
+            numpy.arange(25).reshape(5, 5),
+            numpy.arange(25, 50).reshape(5, 5),
+            'median',
+            1,
+            None,
+            {},
+            phasor_filter(
+                numpy.arange(25).reshape(5, 5),
+                numpy.arange(25, 50).reshape(5, 5),
+                method='median_scipy',
+            ),
+        ),
+        # same output for methods from 3D array without `NaN`
+        (
+            numpy.arange(27).reshape(3, 3, 3),
+            numpy.arange(10, 37).reshape(3, 3, 3),
+            'median',
+            1,
+            None,
+            {},
+            phasor_filter(
+                numpy.arange(27).reshape(3, 3, 3),
+                numpy.arange(10, 37).reshape(3, 3, 3),
+                method='median_scipy',
+            ),
+        ),
+        # same output for methods from 3D array without `NaN` and skip axes
+        (
+            numpy.arange(27).reshape(3, 3, 3),
+            numpy.arange(10, 37).reshape(3, 3, 3),
+            'median',
+            1,
+            0,
+            {},
+            phasor_filter(
+                numpy.arange(27).reshape(3, 3, 3),
+                numpy.arange(10, 37).reshape(3, 3, 3),
+                method='median_scipy',
+                skip_axis=0,
+            ),
+        ),
     ],
 )
 def test_phasor_filter(

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -2401,13 +2401,10 @@ def test_phasor_filter_errors():
     # shape mismatch
     with pytest.raises(ValueError):
         phasor_filter([0], [[0]], repeat=1)
-    # repeat = 0
-    with pytest.raises(ValueError):
-        phasor_filter([[0]], [[0]], repeat=0)
-    # repeat < 1
+    # repeat < 0
     with pytest.raises(ValueError):
         phasor_filter([[0]], [[0]], repeat=-3)
-    # size < 2
+    # size < 1
     with pytest.raises(ValueError):
         phasor_filter([[0]], [[0]], size=0)
 

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -2477,7 +2477,7 @@ def test_parse_skip_axis():
             {},
             (
                 numpy.arange(9).reshape(3, 3),
-                numpy.arange(10, 19).reshape(3, 3)
+                numpy.arange(10, 19).reshape(3, 3),
             ),
         ),
         # size = 1
@@ -2491,7 +2491,7 @@ def test_parse_skip_axis():
             {},
             (
                 numpy.arange(9).reshape(3, 3),
-                numpy.arange(10, 19).reshape(3, 3)
+                numpy.arange(10, 19).reshape(3, 3),
             ),
         ),
     ],

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -2224,16 +2224,17 @@ def test_parse_skip_axis():
 
 
 @pytest.mark.parametrize(
-    'real, imag, method, repeat, skip_axis, kwargs, expected',
+    'real, imag, method, repeat, size, skip_axis, kwargs, expected',
     [
         # single element
-        ([0], [0], 'median', 1, None, {}, ([0], [0])),
+        ([0], [0], 'median', 1, 3, None, {}, ([0], [0])),
         # all equal
         (
             [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
             [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
             'median',
             1,
+            3,
             None,
             {},
             (
@@ -2247,6 +2248,7 @@ def test_parse_skip_axis():
             [[5.0, 6.0, 2.0], [10.0, 4.0, 8.0], [0.0, 7.0, 8.0]],
             'median',
             1,
+            3,
             None,
             {},
             (
@@ -2260,6 +2262,7 @@ def test_parse_skip_axis():
             numpy.arange(25, 50).reshape(5, 5),
             'median',
             1,
+            3,
             None,
             {},
             (
@@ -2285,6 +2288,7 @@ def test_parse_skip_axis():
             numpy.arange(25, 50).reshape(5, 5),
             'median',
             5,
+            3,
             None,
             {},
             (
@@ -2304,12 +2308,39 @@ def test_parse_skip_axis():
                 ],
             ),
         ),
+        # 5x5 array with 5x5 filter repeated 1 time
+        (
+            numpy.arange(25).reshape(5, 5),
+            numpy.arange(25, 50).reshape(5, 5),
+            'median',
+            1,
+            5,
+            None,
+            {},
+            (
+                [
+                    [2, 3, 4, 4, 4],
+                    [5, 6, 7, 8, 9],
+                    [10, 11, 12, 13, 14],
+                    [15, 16, 17, 18, 19],
+                    [20, 20, 20, 21, 22],
+                ],
+                [
+                    [27, 28, 29, 29, 29],
+                    [30, 31, 32, 33, 34],
+                    [35, 36, 37, 38, 39],
+                    [40, 41, 42, 43, 44],
+                    [45, 45, 45, 46, 47],
+                ],
+            ),
+        ),
         # 5x5 array with float32 dtype values
         (
             numpy.arange(25, dtype=numpy.float32).reshape(5, 5),
             numpy.arange(25, 50, dtype=numpy.float32).reshape(5, 5),
             'median',
             5,
+            3,
             None,
             {},
             (
@@ -2335,6 +2366,7 @@ def test_parse_skip_axis():
             numpy.arange(10, 37).reshape(3, 3, 3),
             'median',
             3,
+            3,
             0,
             {},
             (
@@ -2355,6 +2387,7 @@ def test_parse_skip_axis():
             numpy.arange(27).reshape(3, 3, 3),
             numpy.arange(10, 37).reshape(3, 3, 3),
             'median_scipy',
+            3,
             3,
             None,
             {'axes': (1, 2)},
@@ -2377,6 +2410,7 @@ def test_parse_skip_axis():
             numpy.arange(25, 50).reshape(5, 5),
             'median',
             1,
+            3,
             None,
             {},
             phasor_filter(
@@ -2391,6 +2425,7 @@ def test_parse_skip_axis():
             numpy.arange(10, 37).reshape(3, 3, 3),
             'median',
             1,
+            3,
             None,
             {},
             phasor_filter(
@@ -2405,6 +2440,7 @@ def test_parse_skip_axis():
             numpy.arange(10, 37).reshape(3, 3, 3),
             'median',
             1,
+            3,
             0,
             {},
             phasor_filter(
@@ -2420,6 +2456,7 @@ def test_parse_skip_axis():
             numpy.arange(10, 91).reshape(3, 3, 3, 3),
             'median',
             1,
+            3,
             [0, 2],
             {},
             phasor_filter(
@@ -2429,10 +2466,38 @@ def test_parse_skip_axis():
                 skip_axis=[0, 2],
             ),
         ),
+        # repeat = 0
+        (
+            numpy.arange(9).reshape(3, 3),
+            numpy.arange(10, 19).reshape(3, 3),
+            'median',
+            0,
+            3,
+            None,
+            {},
+            (
+                numpy.arange(9).reshape(3, 3),
+                numpy.arange(10, 19).reshape(3, 3)
+            ),
+        ),
+        # size = 1
+        (
+            numpy.arange(9).reshape(3, 3),
+            numpy.arange(10, 19).reshape(3, 3),
+            'median',
+            1,
+            1,
+            None,
+            {},
+            (
+                numpy.arange(9).reshape(3, 3),
+                numpy.arange(10, 19).reshape(3, 3)
+            ),
+        ),
     ],
 )
 def test_phasor_filter(
-    real, imag, method, repeat, skip_axis, kwargs, expected
+    real, imag, method, repeat, size, skip_axis, kwargs, expected
 ):
     """Test `phasor_filter` function."""
     assert_allclose(
@@ -2441,6 +2506,7 @@ def test_phasor_filter(
             imag,
             method=method,
             repeat=repeat,
+            size=size,
             skip_axis=skip_axis,
             **kwargs,
         ),

--- a/tutorials/api/phasorpy_multi-harmonic.py
+++ b/tutorials/api/phasorpy_multi-harmonic.py
@@ -122,10 +122,10 @@ numpy.testing.assert_allclose(
 # Applying median filter to the calibrated phasor coordinates,
 # often multiple times, improves contrast and reduces noise.
 # This is done at multiple harmonics simultaneously by excluding the
-# harmonic axis from the filter:å
+# harmonic axis from the filter:
 
 real, imag = phasor_filter(
-    real, imag, method='median', size=3, repeat=2, axes=(1, 2)
+    real, imag, method='median', size=3, repeat=2, skip_axis=0
 )
 
 # %%


### PR DESCRIPTION
## Description

This PR proposes the replacement of the current implementation of the median filter method in `phasorpy.phasor.phasor_filter`, which is a convenience wrapper around [`scipy.ndimage.median_filter`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.median_filter.html#scipy.ndimage.median_filter). As it was suggested in #87, this method has undefined behaviour for `NaN` values, giving inconsistent results.

There are two extra methods proposed at the moment:

- `_median_filter_2d`: based on a cython implementation of a 2D median filter. This method handles `NaN` values predictably, by ignoring them when creating the 2D-kernel for filtering. In the case a kernel has an even number of elements, the average value of the two middle elements is selected as the median, which is what [`numpy.nanmedian`](https://numpy.org/doc/stable/reference/generated/numpy.nanmedian.html#) does.

- `_median_filter_nd`: is an alternative for n-dimensional filtering, which is the main advantage of Scipy's median filter. This function uses `numpy.sliding_window_view` and `numpy.nanmedian` to perform the median filtering with n-dimensional kernels.  This function also ignores `NaN` values when performing the median calculation for the kernel, with the same criteria as the `_median_filter_2d` method.

Regarding execution times:
- The fastest method for 2D filtering is `_median_filter_2d`, which is marginally faster (10-15%) than `_median_filter_scipy`.
- `_median_filter_nd` is around 3-6 times slower than `_median_filter_scipy` for any dimensional arrays.


## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
