### PR TITLE
 Upgrade GitHub Actions to macOS-13 environment

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, macos-13, windows-2019]
     steps:
       - uses: actions/checkout@v4
       # - name: Set up QEMU

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-2019", "macos-12"]
+        os: ["windows-2019", "macos-13"]
         python-version: ["3.10"]
         # 3.12 tested with cibuildwheel
     steps:
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2019", "macos-12"]
+        os: ["ubuntu-22.04", "windows-2019", "macos-13"]
     steps:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v2.21.3


### PR DESCRIPTION
## Description

The macOS-12 environment is deprecated in GitHub Actions. See https://github.com/actions/runner-images/issues/10721

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
