### PR TITLE
Improve median filter

### DIFF
--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -230,22 +230,20 @@ numpy.testing.assert_allclose(
 # Filter phasor coordinates
 # -------------------------
 #
+# Applying median filter to the calibrated phasor coordinates,
+# often multiple times, improves contrast and reduces noise:
+
+from phasorpy.phasor import phasor_filter
+
+real, imag = phasor_filter(real, imag, method='median', size=3, repeat=2)
+
+# %%
 # Pixels with low intensities are commonly excluded from analysis and
 # visualization of phasor coordinates:
 
 from phasorpy.phasor import phasor_threshold
 
 mean, real, imag = phasor_threshold(mean, real, imag, mean_min=1)
-
-# %%
-# Applying median filter to the calibrated phasor coordinates,
-# often multiple times, improves contrast and reduces noise when
-# visualizing phasor coordinates (however, the filtered coordinates
-# can no longer be used to reconstruct the original signal):
-
-from phasorpy.phasor import phasor_filter
-
-real, imag = phasor_filter(real, imag, method='median', size=3, repeat=2)
 
 # %%
 # Show the calibrated, filtered phasor coordinates:

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -230,20 +230,22 @@ numpy.testing.assert_allclose(
 # Filter phasor coordinates
 # -------------------------
 #
-# Applying median filter to the calibrated phasor coordinates,
-# often multiple times, improves contrast and reduces noise:
-
-from phasorpy.phasor import phasor_filter
-
-real, imag = phasor_filter(real, imag, method='median', size=3, repeat=2)
-
-# %%
 # Pixels with low intensities are commonly excluded from analysis and
 # visualization of phasor coordinates:
 
 from phasorpy.phasor import phasor_threshold
 
 mean, real, imag = phasor_threshold(mean, real, imag, mean_min=1)
+
+# %%
+# Applying median filter to the calibrated phasor coordinates,
+# often multiple times, improves contrast and reduces noise when
+# visualizing phasor coordinates (however, the filtered coordinates
+# can no longer be used to reconstruct the original signal):
+
+from phasorpy.phasor import phasor_filter
+
+real, imag = phasor_filter(real, imag, method='median', size=3, repeat=2)
 
 # %%
 # Show the calibrated, filtered phasor coordinates:


### PR DESCRIPTION
## Description

This PR improves upon #147, simplifying the implementation and boosting performance of median filtering:

- Do not call `_quickselect` twice in `_median` function for even-sized kernels.
  The functions are now merged into one `_median` function.
- Move "repeat" loop into `_apply_2d_median_filter` function nogil section.
- Separate "repeat" loops for real and imag to improve memory efficiency.
- Merge `_median_filter_2d` and `_median_filter_nd` into one `_median_filter` function.
- Rename `_apply_2d_median_filter` to `_median_filter_2d`.
- Use separate `nan_mask` for real and imag to match Cython implementation.
- ~Move median filter after thresholding in introductory tutorial. That should be better practice now that the median filter correctly handles NaN, no? Added a note that "filtered coordinates can no longer be used to reconstruct the original signal" (is there a better phrasing? Should that be added to the function docstring?)~


## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
