### PR TITLE
Release v0.2

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -1,12 +1,12 @@
 [
   {
     "name": "dev",
-    "version": "0.2",
+    "version": "0.3",
     "url": "https://www.phasorpy.org/docs/dev/"
   },
   {
-    "name": "0.1 (stable)",
-    "version": "0.1",
+    "name": "0.2 (stable)",
+    "version": "0.2",
     "url": "https://www.phasorpy.org/docs/stable/",
     "preferred": true
   }

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -10,6 +10,40 @@ documentation and maintenance changes.
     It is not nearly feature complete.
     Large, backwards-incompatible changes may occur between revisions.
 
+0.2 (2024.11.30)
+----------------
+
+This is the second alpha release of the PhasorPy library.
+It fixes NaN handling in the median filter, simplifies multiple harmonic
+calibration, and adds functions for spectral vector denoising and Anscombe
+transformation. This release supports Python 3.10 to 3.13.
+
+What's Changed
+..............
+
+* Bump version by @cgohlke in https://github.com/phasorpy/phasorpy/pull/132
+* Add documentation version switcher config file by @cgohlke in https://github.com/phasorpy/phasorpy/pull/134
+* Bump pypa/cibuildwheel from 2.20.0 to 2.21.1 in the github-actions group by @dependabot in https://github.com/phasorpy/phasorpy/pull/133
+* Update FLUTE license by @cgohlke in https://github.com/phasorpy/phasorpy/pull/137
+* Support Linux on AArch64 by @cgohlke in https://github.com/phasorpy/phasorpy/pull/135
+* Improve private parse_harmonic function by @cgohlke in https://github.com/phasorpy/phasorpy/pull/138
+* Add Anscombe transformation functions by @cgohlke in https://github.com/phasorpy/phasorpy/pull/139
+* Mention PhasorPlots for dummies by @cgohlke in https://github.com/phasorpy/phasorpy/pull/140
+* Simplify multiple harmonic calibration by @bruno-pannunzio in https://github.com/phasorpy/phasorpy/pull/124
+* Add documentation version switcher dropdown by @cgohlke in https://github.com/phasorpy/phasorpy/pull/136
+* Mention AlliGator software by @cgohlke in https://github.com/phasorpy/phasorpy/pull/141
+* Bump pypa/cibuildwheel from 2.21.1 to 2.21.3 in the github-actions group by @dependabot in https://github.com/phasorpy/phasorpy/pull/144
+* Add tool to print SHA256 hashes of dataset files by @cgohlke in https://github.com/phasorpy/phasorpy/pull/143
+* Add Convallaria dataset by @bruno-pannunzio in https://github.com/phasorpy/phasorpy/pull/145
+* Mention LIFA software by @cgohlke in https://github.com/phasorpy/phasorpy/pull/146
+* Upgrade GitHub Actions to macOS-13 environment by @cgohlke in https://github.com/phasorpy/phasorpy/pull/149
+* Add spectral vector denoising by @cgohlke in https://github.com/phasorpy/phasorpy/pull/148
+* Replace median filter implementation for NaN handling consistency by @bruno-pannunzio in https://github.com/phasorpy/phasorpy/pull/147
+* Improve median filter by @cgohlke in https://github.com/phasorpy/phasorpy/pull/150
+* Release v0.2 by @cgohlke in https://github.com/phasorpy/phasorpy/pull/151
+
+**Full Changelog**: https://github.com/phasorpy/phasorpy/compare/v0.1...v0.2
+
 0.1 (2024.9.30)
 ---------------
 

--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__ = '0.2.dev'
+__version__ = '0.2'
 
 
 def versions(


### PR DESCRIPTION
## Description

- [x] Open PR named `Release v0.2`
- [x] Set `__version__ = '0.2'` in `src/phasorpy/version.py`
- [x] Bump versions in `docs/_static/switcher.json`
- [x] Create release notes (copy changes from GitHub release notes tool)
- [x] Merge this PR
- [x] Use GitHub to create new release and tag `v0.2`
- [x] Copy sdist and wheels from GitHub Actions
- [x] Build wheels locally for linux_aarch64 using `tools/build_manylinux2014` script
- [x] Upload sdist and wheels to GitHub release
- [x] Upload sdist and wheels to [PyPI](https://pypi.org/project/phasorpy/) using twine
- [x] Change `docs/stable` symlink to point to `docs/v0.2` (`mklink /D stable v0.2`) at [phasorpy.github.io](https://github.com/phasorpy/phasorpy.github.io)
- [x] Update version to `0.2 (stable)` in [phasorpy-homepage/docs.rst](https://github.com/phasorpy/phasorpy-homepage/blob/main/docs.rst)
- [x] Add news entry `Nov 30, 2024: PhasorPy 0.2 is released.` to [phasorpy-homepage](https://github.com/phasorpy/phasorpy-homepage/blob/main/index.rst)
- [x] Set `__version__ = '0.3.dev'` in `src/phasorpy/version.py` and create PR named `Bump version`
- [ ] Fix authors, affiliations, and license in [Zenodo record](https://doi.org/10.5281/zenodo.13862586)

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
