### PR TITLE
Fix mypy errors with matplotlib-3.10

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -171,12 +171,16 @@ class PhasorPlot:
     @property
     def fig(self) -> Figure | None:
         """Matplotlib :py:class:`matplotlib.figure.Figure`."""
-        return self._ax.get_figure()
+        try:
+            # matplotlib >= 3.10.0
+            return self._ax.get_figure(root=True)
+        except TypeError:
+            return self._ax.get_figure()  # type: ignore[return-value]
 
     @property
     def dataunit_to_point(self) -> float:
         """Factor to convert data to point unit."""
-        fig = self._ax.get_figure()
+        fig = self.fig
         assert fig is not None
         length = fig.bbox_inches.height * self._ax.get_position().height * 72.0
         vrange: float = numpy.diff(self._ax.get_ylim()).item()


### PR DESCRIPTION
## Description

Matplotlib 3.10 changed the behavior of the `Axes.get_figure` method to possibly return `SubFigure` instances. See https://github.com/matplotlib/matplotlib/pull/28177

This PR ensures `PhasorPlot.fig` continues to only return `Figure` instances on matplotlib>=3.10.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
