### PR TITLE
Add support for ImSpector FLIM TIFF files

### DIFF
--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -16,7 +16,7 @@ The ``phasorpy.io`` module provides functions to:
 - read time-resolved and hyperspectral image data and metadata (as relevant
   to phasor analysis) from many file formats used in bio-imaging:
 
-  - :py:func:`read_imspector_tiff` - Imspector FLIM TIFF
+  - :py:func:`read_imspector_tiff` - ImSpector FLIM TIFF
   - :py:func:`read_lsm` - Zeiss LSM
   - :py:func:`read_ifli` - ISS IFLI
   - :py:func:`read_sdt` - Becker & Hickl SDT
@@ -948,7 +948,7 @@ def read_imspector_tiff(
             or len(tif.series) != 1
             or not tif.is_ome
         ):
-            raise ValueError(f'{tif.filename} is not an Imspector TIFF file')
+            raise ValueError(f'{tif.filename} is not an ImSpector TIFF file')
 
         series = tif.series[0]
         ndim = series.ndim
@@ -957,7 +957,7 @@ def read_imspector_tiff(
 
         if ndim < 3 or not axes.endswith('YX'):
             raise ValueError(
-                f'{tif.filename} is not an Imspector FLIM TIFF file'
+                f'{tif.filename} is not an ImSpector FLIM TIFF file'
             )
 
         data = series.asarray()
@@ -1004,7 +1004,7 @@ def read_imspector_tiff(
         or 'FirstAxis' not in axes_labels.attrib
         or 'SecondAxis' not in axes_labels.attrib
     ):
-        raise ValueError(f'{tif.filename} is not an Imspector FLIM TIFF file')
+        raise ValueError(f'{tif.filename} is not an ImSpector FLIM TIFF file')
 
     if axes_labels.attrib['FirstAxis'].endswith('TCSPC T'):
         ax = axes[-3]
@@ -1013,7 +1013,7 @@ def read_imspector_tiff(
         ax = axes[-4]
         assert axes_labels.attrib['SecondAxis-Unit'] == 'ns'
     else:
-        raise ValueError(f'{tif.filename} is not an Imspector FLIM TIFF file')
+        raise ValueError(f'{tif.filename} is not an ImSpector FLIM TIFF file')
     axes = axes.replace(ax, 'H')
     coords['H'] = coords[ax]
     del coords[ax]

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -893,14 +893,12 @@ def read_imspector_tiff(
     filename: str | PathLike[Any],
     /,
 ) -> DataArray:
-    """Return FLIM image stack and metadata from Imspector TIFF file.
-
-    Imspector FLIM TIFF files contain TCSPC image stacks and metadata.
+    """Return FLIM image stack and metadata from ImSpector TIFF file.
 
     Parameters
     ----------
     filename : str or Path
-        Name of OME-TIFF file to read.
+        Name of ImSpector FLIM TIFF file to read.
 
     Returns
     -------
@@ -916,7 +914,7 @@ def read_imspector_tiff(
     tifffile.TiffFileError
         File is not a TIFF file.
     ValueError
-        File is not an Imspector FLIM TIFF file.
+        File is not an ImSpector FLIM TIFF file.
 
     Examples
     --------

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -25,6 +25,7 @@ from phasorpy.io import (
     read_fbd,
     read_flif,
     read_ifli,
+    read_imspector_tiff,
     read_lsm,
     read_ptu,
     read_sdt,
@@ -127,6 +128,34 @@ def test_read_lsm_paramecium():
     assert_almost_equal(
         data.coords['X'][[0, -1]], [0.0, 0.000424265835], decimal=9
     )
+
+
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
+def test_imspector_tiff():
+    """Test read Imspector FLIM TIFF file."""
+    data = read_imspector_tiff(fetch('Embryo.tif'))
+    assert data.values.sum(dtype=numpy.uint64) == 31348436
+    assert data.dtype == numpy.uint16
+    assert data.shape == (56, 512, 512)
+    assert data.dims == ('H', 'Y', 'X')
+    assert_almost_equal(
+        data.coords['H'][[0, -1]], [0.0, 0.218928482143], decimal=12
+    )
+    assert data.attrs['frequency'] == 80.10956424883184
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_imspector_tiff_t():
+    """Test read Imspector FLIM TIFF file with TCSPC in T-axis."""
+    data = read_imspector_tiff(private_file('ZF-1100_noEF.tif'))
+    assert data.values.sum(dtype=numpy.uint64) == 18636271
+    assert data.dtype == numpy.uint16
+    assert data.shape == (56, 512, 512)
+    assert data.dims == ('H', 'Y', 'X')
+    assert_almost_equal(
+        data.coords['H'][[0, -1]], [0.0, 0.218928482143], decimal=12
+    )
+    assert data.attrs['frequency'] == 80.10956424883184
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')

--- a/tutorials/api/phasorpy_multi-harmonic.py
+++ b/tutorials/api/phasorpy_multi-harmonic.py
@@ -15,10 +15,13 @@ of multi-harmonic phasor coordinates.
 # Import required modules and functions:
 
 import numpy
-import tifffile  # TODO: from phasorpy.io import read_ometiff
 
 from phasorpy.datasets import fetch
-from phasorpy.io import phasor_from_ometiff, phasor_to_ometiff
+from phasorpy.io import (
+    phasor_from_ometiff,
+    phasor_to_ometiff,
+    read_imspector_tiff,
+)
 from phasorpy.phasor import (
     phasor_calibrate,
     phasor_filter,
@@ -34,9 +37,8 @@ from phasorpy.plot import PhasorPlot
 # Read a time-correlated single photon counting (TCSPC) histogram,
 # acquired at 80.11 MHz, from a file:
 
-
-signal = tifffile.imread(fetch('Embryo.tif'))
-frequency = 80.11  # MHz; from the XML metadata in the file
+signal = read_imspector_tiff(fetch('Embryo.tif'))
+frequency = signal.attrs['frequency']
 
 # %%
 # Calculate phasor coordinates
@@ -67,7 +69,8 @@ _ = phasor_from_signal(signal, harmonic='all', axis=0)
 # A homogeneous solution of Fluorescein with a fluorescence lifetime of 4.2 ns
 # was imaged as a reference for calibration:
 
-reference_signal = tifffile.imread(fetch('Fluorescein_Embryo.tif'))
+reference_signal = read_imspector_tiff(fetch('Fluorescein_Embryo.tif'))
+assert reference_signal.attrs['frequency'] == frequency
 
 # %%
 # Calculate phasor coordinates from the measured reference signal at

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -61,10 +61,7 @@ print(phasorpy.__version__)
 # array computing and plotting throughout this tutorial:
 
 import numpy
-import tifffile  # TODO: from phasorpy.io import read_ometiff
 from matplotlib import pyplot
-
-from phasorpy.datasets import fetch
 
 # %%
 # Read signal from file
@@ -83,11 +80,13 @@ from phasorpy.datasets import fetch
 # files. For example, an Imspector TIFF file from the
 # `FLUTE <https://zenodo.org/records/8046636>`_  project containing a
 # time-correlated single photon counting (TCSPC) histogram
-# of a zebrafish embryo at day 3, acquired at 80 MHz:
+# of a zebrafish embryo at day 3, acquired at 80.11 MHz:
 
+from phasorpy.datasets import fetch
+from phasorpy.io import read_imspector_tiff
 
-signal = tifffile.imread(fetch('Embryo.tif'))
-frequency = 80.11  # MHz; from the XML metadata in the file
+signal = read_imspector_tiff(fetch('Embryo.tif'))
+frequency = signal.attrs['frequency']
 
 print(signal.shape, signal.dtype)
 
@@ -167,7 +166,8 @@ numpy.testing.assert_allclose(
 #
 # Read the signal of the reference measurement from a file:
 
-reference_signal = tifffile.imread(fetch('Fluorescein_Embryo.tif'))
+reference_signal = read_imspector_tiff(fetch('Fluorescein_Embryo.tif'))
+assert reference_signal.attrs['frequency'] == frequency
 
 # %%
 # Calculate phasor coordinates from the measured reference signal:
@@ -461,3 +461,4 @@ print(phasorpy.versions())
 # sphinx_gallery_thumbnail_number = -7
 # mypy: allow-untyped-defs, allow-untyped-calls
 # mypy: disable-error-code="arg-type"
+# isort: skip_file

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -77,7 +77,7 @@ from matplotlib import pyplot
 # ``signal`` in the PhasorPy library.
 #
 # The :py:mod:`phasorpy.datasets` module provides access to various sample
-# files. For example, an Imspector TIFF file from the
+# files. For example, an ImSpector TIFF file from the
 # `FLUTE <https://zenodo.org/records/8046636>`_  project containing a
 # time-correlated single photon counting (TCSPC) histogram
 # of a zebrafish embryo at day 3, acquired at 80.11 MHz:


### PR DESCRIPTION
## Description

This PR adds a `read_imspector_tiff` function to the `phasorpy.io` module to read TCSPC image stacks and select metadata from ImSpector FLIM TIFF formatted files. The implementation is based on reverse engineering very few [data files by the FLUTE project](https://zenodo.org/records/8046636).

Closes #105.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
