### PR TITLE
WIP: Support FLIMLABS JSON image files

### DIFF
--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -1063,6 +1063,7 @@ def read_flimlabs_json(
     ------
     ValueError
         File is not a FLIMLABS JSON image file.
+        `dtype` is not an unsigned integer.
 
     Examples
     --------
@@ -1085,14 +1086,14 @@ def read_flimlabs_json(
 
     with open(filename) as fh:
         try:
-            jdata = json.load(fh)
+            data = json.load(fh)
         except json.JSONDecodeError as exc:
             raise ValueError('not a FLIMLABS JSON file') from exc
 
     if (
-        'data' not in jdata
-        or 'header' not in jdata
-        or 'laser_period_ns' not in jdata['header']
+        'data' not in data
+        or 'header' not in data
+        or 'laser_period_ns' not in data['header']
     ):
         raise ValueError('not a FLIMLABS JSON file')
 
@@ -1101,9 +1102,9 @@ def read_flimlabs_json(
     else:
         dtype = numpy.dtype(dtype)
         if dtype.kind != 'u':
-            raise ValueError(f'{dtype=} is not unsigned')
+            raise ValueError(f'{dtype=} is not an unsigned integer type')
 
-    header = jdata['header']
+    header = data['header']
     channels = len([c for c in header['channels'] if c])
     # TODO: how to use header['frames']?
     height = header['image_height']
@@ -1118,13 +1119,13 @@ def read_flimlabs_json(
         axes = 'YXH'
 
     if channel is None:
-        for c, channel_ in enumerate(jdata['data']):
+        for c, channel_ in enumerate(data['data']):
             for i, pixel in enumerate(channel_):
                 hist = histogram[c, i]
                 for index, count in pixel:
                     hist[index] = count
     else:
-        for i, pixel in enumerate(jdata['data'][channel]):
+        for i, pixel in enumerate(data['data'][channel]):
             hist = histogram[i]
             for index, count in pixel:
                 hist[index] = count

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -24,6 +24,7 @@ from phasorpy.io import (
     read_bhz,
     read_fbd,
     read_flif,
+    read_flimlabs_json,
     read_ifli,
     read_imspector_tiff,
     read_lsm,
@@ -156,6 +157,31 @@ def test_imspector_tiff_t():
         data.coords['H'][[0, -1]], [0.0, 0.218928482143], decimal=12
     )
     assert data.attrs['frequency'] == 80.10956424883184
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_flimlabs_json():
+    """Test read FLIMLABS JSON image file."""
+    filename = private_file('test03_1733492714_imaging.json')
+    data = read_flimlabs_json(filename)
+    assert data.values.sum(dtype=numpy.uint64) == 4680256
+    assert data.dtype == numpy.uint16
+    assert data.shape == (3, 256, 256, 256)
+    assert data.dims == ('C', 'Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'][[0, -1]], [0.0, 12.451171875], decimal=12
+    )
+    assert_array_equal(data.coords['C'], [0, 1, 2])
+    assert data.attrs['frequency'] == 80.0
+
+    data = read_flimlabs_json(filename, channel=1, dtype=numpy.uint8)
+    assert data.values.sum(dtype=numpy.uint64) == 1388562
+    assert data.dtype == numpy.uint8
+    assert data.shape == (256, 256, 256)
+    assert data.dims == ('Y', 'X', 'H')
+
+    with pytest.raises(ValueError):
+        data = read_flimlabs_json(filename, channel=1, dtype=numpy.int8)
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')


### PR DESCRIPTION
## Description

This PR adds a `read_flimlabs_json` function to the `phasorpy.io` module to read data and metadata from FLIMLABS JSON image files. See #164.

TODO: The `read_flimlabs_json` function and docstring examples are currently not tested during CI since no public data files are available on Zenodo or GitHub.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
