### PR TITLE
Support labelled signal axes

### DIFF
--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -986,7 +986,7 @@ def read_imspector_tiff(
         attrib = 'TimeIncrement' if ax == 'T' else f'PhysicalSize{ax}'
         if ax not in axes or attrib not in pixels.attrib:
             continue
-        size = float(pixels.attrib[attrib])
+        size = float(pixels.attrib[attrib]) * shape[axes.index(ax)]
         physical_size[ax] = size
         coords[ax] = numpy.linspace(
             0.0,
@@ -996,7 +996,7 @@ def read_imspector_tiff(
             dtype=numpy.float64,
         )
 
-    axes_labels = root.find('.//ca:CustomAttributes/AxesLabels', ns)
+    axes_labels = root.find('.//Image/ca:CustomAttributes/AxesLabels', ns)
     if (
         axes_labels is None
         or 'X' not in axes_labels.attrib
@@ -1006,10 +1006,15 @@ def read_imspector_tiff(
     ):
         raise ValueError(f'{tif.filename} is not an ImSpector FLIM TIFF file')
 
-    if axes_labels.attrib['FirstAxis'].endswith('TCSPC T'):
+    if axes_labels.attrib['FirstAxis'] == 'lifetime' or axes_labels.attrib[
+        'FirstAxis'
+    ].endswith('TCSPC T'):
         ax = axes[-3]
         assert axes_labels.attrib['FirstAxis-Unit'] == 'ns'
-    elif axes_labels.attrib['SecondAxis'].endswith('TCSPC T') and ndim > 3:
+    elif ndim > 3 and (
+        axes_labels.attrib['SecondAxis'] == 'lifetime'
+        or axes_labels.attrib['SecondAxis'].endswith('TCSPC T')
+    ):
         ax = axes[-4]
         assert axes_labels.attrib['SecondAxis-Unit'] == 'ns'
     else:
@@ -1018,9 +1023,7 @@ def read_imspector_tiff(
     coords['H'] = coords[ax]
     del coords[ax]
 
-    attrs['frequency'] = float(
-        1000.0 / (shape[axes.index('H')] * physical_size[ax])
-    )
+    attrs['frequency'] = float(1000.0 / physical_size[ax])
 
     metadata = _metadata(axes, shape, filename, attrs=attrs, **coords)
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -149,7 +149,7 @@ from ._phasorpy import (
     _polar_from_single_lifetime,
     _polar_to_apparent_lifetime,
 )
-from ._utils import parse_harmonic
+from ._utils import parse_harmonic, parse_signal_axis
 from .utils import number_threads
 
 
@@ -157,7 +157,7 @@ def phasor_from_signal(
     signal: ArrayLike,
     /,
     *,
-    axis: int = -1,
+    axis: int | str | None = None,
     harmonic: int | Sequence[int] | Literal['all'] | str | None = None,
     sample_phase: ArrayLike | None = None,
     use_fft: bool | None = None,
@@ -174,9 +174,10 @@ def phasor_from_signal(
         Frequency-domain, time-domain, or hyperspectral data.
         A minimum of three samples are required along `axis`.
         The samples must be uniformly spaced.
-    axis : int, optional
+    axis : int or str, optional
         Axis over which to compute phasor coordinates.
-        The default is the last axis (-1).
+        By default, the 'H' or 'C' axes if signal contains such dimension
+        names, else the last axis (-1).
     harmonic : int, sequence of int, or 'all', optional
         Harmonics to return.
         If `'all'`, return all harmonics for `signal` samples along `axis`.
@@ -287,6 +288,9 @@ def phasor_from_signal(
     """
     # TODO: C-order not required by rfft?
     # TODO: preserve array subtypes?
+
+    axis, _ = parse_signal_axis(signal, axis)
+
     signal = numpy.asarray(signal, order='C')
     if signal.dtype.kind not in 'uif':
         raise TypeError(f'signal must be real valued, not {signal.dtype=}')

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -10,6 +10,7 @@ from phasorpy._utils import (
     kwargs_notnone,
     parse_harmonic,
     parse_kwargs,
+    parse_signal_axis,
     phasor_from_polar_scalar,
     phasor_to_polar_scalar,
     scale_matrix,
@@ -166,6 +167,28 @@ def test_parse_harmonic():
         parse_harmonic(1.0, 1)
     with pytest.raises(TypeError):
         parse_harmonic('all')
+
+
+def test_parse_signal_axis():
+    """Test parse_signal_axis function."""
+
+    class DataArray:
+        dims = ('T', 'C', 'H', 'Y', 'X')
+
+    assert parse_signal_axis(DataArray()) == (2, 'H')
+    assert parse_signal_axis(DataArray(), 'C') == (1, 'C')
+    assert parse_signal_axis(DataArray(), -3) == (-3, 'H')
+    assert parse_signal_axis([]) == (-1, '')
+    assert parse_signal_axis([], 2) == (2, '')
+
+    DataArray.dims = ('T', 'A', 'B', 'Y', 'X')
+    assert parse_signal_axis(DataArray()) == (-1, 'X')
+
+    with pytest.raises(ValueError):
+        parse_signal_axis([], 'H')
+
+    with pytest.raises(ValueError):
+        parse_signal_axis(DataArray(), 'not found')
 
 
 def test_chunk_iter():

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -139,7 +139,7 @@ def test_imspector_tiff():
     assert data.shape == (56, 512, 512)
     assert data.dims == ('H', 'Y', 'X')
     assert_almost_equal(
-        data.coords['H'][[0, -1]], [0.0, 0.218928482143], decimal=12
+        data.coords['H'][[0, -1]], [0.0, 12.259995], decimal=12
     )
     assert data.attrs['frequency'] == 80.10956424883184
 
@@ -153,7 +153,7 @@ def test_imspector_tiff_t():
     assert data.shape == (56, 512, 512)
     assert data.dims == ('H', 'Y', 'X')
     assert_almost_equal(
-        data.coords['H'][[0, -1]], [0.0, 0.218928482143], decimal=12
+        data.coords['H'][[0, -1]], [0.0, 12.259995], decimal=12
     )
     assert data.attrs['frequency'] == 80.10956424883184
 

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -6,6 +6,7 @@ import math
 import numpy
 import pytest
 from matplotlib import pyplot
+from xarray import DataArray
 
 from phasorpy.plot import (
     PhasorPlot,
@@ -430,6 +431,12 @@ def test_plot_signal_image():
         title='percentile',
         show=INTERACTIVE,
     )
+    pyplot.close()
+
+    dataarray = DataArray(
+        data, {'H': numpy.linspace(1, 2, 11)}, ('T', 'Y', 'X', 'H')
+    )
+    plot_signal_image(dataarray, title='DataArray', show=INTERACTIVE)
     pyplot.close()
 
     with pytest.raises(ValueError):

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -91,11 +91,12 @@ frequency = signal.attrs['frequency']
 print(signal.shape, signal.dtype)
 
 # %%
-# Plot the spatial and histogram averages:
+# Plot the spatial and histogram averages. The histogram bins are in the
+# first dimension of the signal array (`axis='H'` or `axis=0`):
 
 from phasorpy.plot import plot_signal_image
 
-plot_signal_image(signal, axis=0)
+plot_signal_image(signal, axis='H')
 
 # %%
 # Calculate phasor coordinates
@@ -112,13 +113,12 @@ plot_signal_image(signal, axis=0)
 # In literature and other software, they are also known as
 # :math:`G` and :math:`S` or :math:`a` and :math:`b` (as in :math:`a + bi`).
 #
-# Phasor coordinates of the first harmonic are calculated from the signal,
-# a TCSPC histogram in this case.
-# The histogram samples are in the first dimension (`axis=0`):
+# Phasor coordinates of the first harmonic are calculated from the signal
+# over the axis containing the TCSPC histogram bins (`axis='H'` or `axis=0`):
 
 from phasorpy.phasor import phasor_from_signal
 
-mean, real, imag = phasor_from_signal(signal, axis=0)
+mean, real, imag = phasor_from_signal(signal, axis='H')
 
 # %%
 # The phasor coordinates are undefined if the mean intensity is zero.


### PR DESCRIPTION
## Description

This PR adds support for passing `axis` string labels (as an alternative to integers) to the `phasor_from_signal` and `plot_signal_image` functions. The labels are used to index `xarray.DataArray` instances returned from the read functions in `phasorpy.io`.

The `axis` parameter default is changed from the last axis to 'H', 'C', or last axis (whatever is found first). 

'H' or 'C' axes coordinates in the DataArray, if any, are used for plotting.

This PR also fixes a bug in the coordinates returned by the `read_imspector_tiff` function (#105).

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
