### PR TITLE
Document availability on conda-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ lifetime and hyperspectral images using the phasor approach.
 - [Homepage](https://www.phasorpy.org)
 - [Documentation](https://www.phasorpy.org/docs/stable/)
 - [Source code](https://github.com/phasorpy/phasorpy)
-- [Download releases](https://pypi.org/project/phasorpy/#files)
+- [Install with pip](https://pypi.org/project/phasorpy/) or [conda](https://anaconda.org/conda-forge/phasorpy).
 - [Data files](https://zenodo.org/communities/phasorpy/)
 - [Issues and questions](https://github.com/phasorpy/phasorpy/issues)
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,8 @@ The library's source code and documentation are maintained in the
 `PhasorPy repository on GitHub <https://github.com/phasorpy/phasorpy>`_.
 
 Releases can be downloaded and installed from the
-`PhasorPy project on PyPI <https://pypi.org/project/phasorpy/>`_.
+`PhasorPy project on PyPI <https://pypi.org/project/phasorpy/>`_
+or `conda-forge <https://anaconda.org/conda-forge/phasorpy>`_.
 
 Sample data files used in tutorials and testing are available from the
 `PhasorPy community on Zenodo <https://zenodo.org/communities/phasorpy>`_.

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -34,6 +34,12 @@ image processing, array programming, and Python.
 #
 #     python -m pip install -U "phasorpy[all]"
 #
+# Alternatively, PhasorPy can be installed via
+# `conda-forge <https://anaconda.org/conda-forge/phasorpy>`_ in an Anaconda
+# environment::
+#
+#    conda install conda-forge::phasorpy
+#
 # The development version of PhasorPy can be installed instead from the
 # latest source code on GitHub. This requires a C compiler, such as
 # XCode, Visual Studio, or gcc, to be installed::


### PR DESCRIPTION
## Description

PhasorPy is now available on [conda-forge](https://anaconda.org/conda-forge/phasorpy). See #154

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
