### PR TITLE
Fix RST code is two backticks

### DIFF
--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,10 +14,10 @@ documentation and maintenance changes.
 ----------------
 
 This is the third alpha release of the PhasorPy library.
-It fixes the averaging of phasor coordinates in the `phasor_center` and
-`phasor_calibrate` functions, replaces the `phasor_filter` function
-with `phasor_filter_median`, adds support for multiple harmonics to
-`phasor_threshold`, and adds the `read_imspector_tiff` function to read
+It fixes the averaging of phasor coordinates in the ``phasor_center`` and
+``phasor_calibrate`` functions, replaces the ``phasor_filter`` function
+with ``phasor_filter_median``, adds support for multiple harmonics to
+``phasor_threshold``, and adds the ``read_imspector_tiff`` function to read
 ImSpector FLIM TIFF files. This release supports Python 3.10 to 3.13.
 
 What's Changed


### PR DESCRIPTION
## Description

Fixes the following pre-commit failures:

```
rst ``code`` is two backticks............................................Failed
- hook id: rst-backticks
- exit code: 1

docs/release.rst:17:It fixes the averaging of phasor coordinates in the `phasor_center` and
docs/release.rst:18:`phasor_calibrate` functions, replaces the `phasor_filter` function
docs/release.rst:19:with `phasor_filter_median`, adds support for multiple harmonics to
docs/release.rst:20:`phasor_threshold`, and adds the `read_imspector_tiff` function to read
```

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
