### PR TITLE
Support reading point mode PTU files

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -236,6 +236,7 @@ def test_read_ptu():
         data.coords['H'].data[[1, -1]], [0.0969697, 12.7030303], decimal=4
     )
     assert data.attrs['frequency'] == 78.02
+    assert data.attrs['ptu_tags']['HW_Type'] == 'PicoHarp'
 
     data = read_ptu(
         filename,
@@ -253,6 +254,39 @@ def test_read_ptu():
         data.coords['H'].data[[1, -1]], [0.0969697, 397.09091], decimal=4
     )
     assert data.attrs['frequency'] == 78.02
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_read_ptu_irf():
+    """Test read PicoQuant PTU file containing IRF."""
+    # data file from PicoQuant's Samples.sptw
+    filename = private_file('Cy5_diff_IRF+FLCS-pattern.ptu')
+    data = read_ptu(filename)
+    assert data.values.sum(dtype=numpy.uint64) == 13268548
+    assert data.dtype == numpy.uint32
+    assert data.shape == (1, 1, 1, 2, 6250)
+    assert data.dims == ('T', 'Y', 'X', 'C', 'H')
+    assert_almost_equal(
+        data.coords['H'].data[[1, -1]], [0.007999, 49.991999], decimal=4
+    )
+    assert pytest.approx(data.attrs['frequency'], abs=1e-4) == 19.999732
+    assert data.attrs['ptu_tags']['HW_Type'] == 'PicoHarp 300'
+
+    data = read_ptu(filename, channel=0, keepdims=True)
+    assert data.values.sum(dtype=numpy.uint64) == 6984849
+    assert data.shape == (1, 1, 1, 1, 6250)
+    assert data.dims == ('T', 'Y', 'X', 'C', 'H')
+
+    with pytest.raises(ValueError):
+        read_ptu(filename, dtime=-1)
+
+    data = read_ptu(filename, channel=0, dtime=None, keepdims=False)
+    assert data.values.sum(dtype=numpy.uint64) == 6984849
+    assert data.shape == (1, 1, 4096)
+    assert data.dims == ('Y', 'X', 'H')
+    assert_almost_equal(
+        data.coords['H'].data[[1, -1]], [0.007999, 32.759999], decimal=4
+    )
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')


### PR DESCRIPTION
## Description

This PR adds support for reading point mode PTU files, commonly used to store instrument response functions, to the `read_ptu` function.

Items to discuss:

- No public sample file is available for testing, so coverage in CI decreases.
- The T, Y, and X dimensions are prepended to the point mode TCSPC histograms to make them broadcastable with image data returned by the function. That should facilitate calibration with IRF.
- The xarray returned by the `read_ptu` function now has an additional `ptu_tags` attribute, which contains the original tags read from PTU file. I'm not sure this is a good idea as it adds support overhead, and the metadata might be out of sync with the returned data. If yes, we might want to consider returning original metadata for other read functions as well. Should the attribute have a generic name like `original_metadata` or `vendor_metadata`? But then, users might expect it in a common format, like dict, not xml or numpy recarray...

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
