### PR TITLE
Fix `phasor_calibrate` for handling higher harmonics than size of first dimension of `reference_real`

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1247,7 +1247,14 @@ def phasor_calibrate(
 
     has_harmonic_axis = reference_mean.ndim + 1 == reference_real.ndim
     harmonic, _ = parse_harmonic(
-        harmonic, reference_real.shape[0] if has_harmonic_axis else None
+        harmonic,
+        (
+            reference_real.shape[0]
+            if has_harmonic_axis
+            and isinstance(harmonic, str)
+            and harmonic == 'all'
+            else None
+        ),
     )
 
     if has_harmonic_axis:

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -1718,6 +1718,24 @@ def test_phasor_from_lifetime_modify():
                 ),
             ),
         ),
+        # harmonics higher than size of first dimension in `reference_real`
+        (
+            (
+                SYNTH_DATA_LIST,
+                SYNTH_DATA_LIST,
+                SYNTH_DATA_LIST,
+                SYNTH_DATA_LIST,
+            ),
+            {
+                'frequency': 80,
+                'harmonic': [1, 2, 6],
+                'lifetime': 4,
+            },
+            (
+                [0.19831079, 0.0582399, 0.00682439],
+                [0.3987275, 0.23419652, 0.0823275],
+            ),
+        ),
         # harmonics = 'all' parameter
         (
             (


### PR DESCRIPTION
## Description

...This PR proposes a fix for the case when multiple harmonics are passed to `phasor_calibrate` with higher harmonics than the size of the first dimension of `reference_real`.

This bug was raised in issue #175 

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
