### PR TITLE
Add support for Leica LIF files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ all = [
     "lfdfiles>=2024.5.24",
     "sdtfile>=2024.5.24",
     "ptufile>=2024.9.14",
+    "liffile>=2025.1.26",
 ]
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,5 +188,5 @@ norecursedirs = [
 
 [tool.cibuildwheel]
 skip = "pp* cp37* cp38* cp39* *musllinux* *i686 *ppc64le *s390x cp39*win*arm64 cp310*win*arm64"
-test-requires = ["lfdfiles", "sdtfile", "ptufile", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
+test-requires = ["lfdfiles", "sdtfile", "ptufile", "liffile", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
 test-command = "pytest {project}/tests"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -62,3 +62,4 @@ pre-commit-hooks
 lfdfiles
 sdtfile
 ptufile
+liffile

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -361,6 +361,22 @@ FLIMLABS = pooch.create(
     },
 )
 
+FIGSHARE_22336594 = pooch.create(
+    path=pooch.os_cache('phasorpy'),
+    base_url=(
+        'https://github.com/phasorpy/phasorpy-data/raw/main/figshare_22336594'
+        if DATA_ON_GITHUB
+        else 'doi:10.6084/m9.figshare.22336594.v1'
+    ),
+    env=ENV,
+    registry={
+        'FLIM_testdata.lif': (
+            'sha256:'
+            '902d8fa6cd39da7cf062b32d43aab518fa2a851eab72b4bd8b8eca1bad591850'
+        ),
+    },
+)
+
 REPOSITORIES: dict[str, pooch.Pooch] = {
     'tests': TESTS,
     'lfd-workshop': LFD_WORKSHOP,
@@ -369,6 +385,7 @@ REPOSITORIES: dict[str, pooch.Pooch] = {
     'zenodo-13625087': ZENODO_13625087,
     'convallaria-fbd': CONVALLARIA_FBD,
     'flimlabs': FLIMLABS,
+    'figshare_22336594': FIGSHARE_22336594,
 }
 """Pooch repositories."""
 

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -1010,12 +1010,12 @@ def phasor_from_lif(
 
     Examples
     --------
-    >>> mean, real, imag, attrs = phasor_from_lif('FLIM.lif')  # doctest: +SKIP
-    >>> real.shape  # doctest: +SKIP
+    >>> mean, real, imag, attrs = phasor_from_lif(fetch('FLIM_testdata.lif'))
+    >>> real.shape
     (1024, 1024)
-    >>> attrs['dims']  # doctest: +SKIP
+    >>> attrs['dims']
     ('Y', 'X')
-    >>> attrs['frequency']  # doctest: +SKIP
+    >>> attrs['frequency']
     19.505
 
     """

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1977,6 +1977,7 @@ def lifetime_fraction_from_amplitude(
     array([0.8, 0.2])
 
     """
+    t: NDArray[numpy.float64]
     t = numpy.multiply(amplitude, lifetime, dtype=numpy.float64)
     t /= numpy.sum(t, axis=axis, keepdims=True)
     return t

--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -44,6 +44,7 @@ def versions(
         'lfdfiles',
         'sdtfile',
         'ptufile',
+        'liffile',
         'matplotlib',
         'scipy',
         'skimage',

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1060,9 +1060,10 @@ def test_phasor_from_lif():
     # assert 'frequency' not in attrs
 
     # file does not contain FLIM data
-    filename = private_file('ScanModesExamples.lif')
-    with pytest.raises(ValueError):
-        phasor_from_lif(filename)
+    if not SKIP_PRIVATE:
+        filename = private_file('ScanModesExamples.lif')
+        with pytest.raises(ValueError):
+            phasor_from_lif(filename)
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1037,10 +1037,10 @@ def test_phasor_to_simfcs_referenced_multiharmonic():
             assert imag.shape == (2, 32, 32)
 
 
-@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_phasor_from_lif():
     """Test read phasor coordinates from Leica LIF file."""
-    filename = private_file('FLIM.lif')
+    filename = fetch('FLIM_testdata.lif')
     mean, real, imag, attrs = phasor_from_lif(filename)
     for data in (mean, real, imag):
         assert data.shape == (1024, 1024)
@@ -1096,7 +1096,7 @@ def test_signal_from_lif():
         signal_from_lif(filename, series='XYZLambdaT', dim='Λ')
 
     # file does not contain hyperspectral signal
-    filename = private_file('FLIM.lif')
+    filename = fetch('FLIM_testdata.lif')
     with pytest.raises(ValueError):
         signal_from_lif(filename)
 


### PR DESCRIPTION
## Description

This PR adds two functions, `phasor_from_lif` and `signal_from_lif`, to `phasorpy.io`. This partly implements #17.

The implementation depends on the newly developed [`liffile`](https://github.com/cgohlke/liffile/) library, which is not quite feature complete or stable yet. However, compared to existing libraries, `readlif` and `Bio-Formats`, `liffile`'s license is MIT-compatible and the library can correctly read phasor coordinates, float16 and float32 images, and any-dimensional image data. "FLIM Compressed" raw images are not supported because the compression scheme is patent-pending.

The [FLIM testdata](https://figshare.com/articles/dataset/FLIM_testdata/22336594/1) is added to `phasorpy.datasets`.

Issues to discuss:

- No appropriate (public, small) hyperspectral LIF files (public, small) are currently available for testing.

- The `signal_from_lif` function only reads hyperspectral data. FLIM/TCSPC histograms are not supported because they are stored in a patent-pending compression scheme.

- The LIF emission `λ` and excitation `Λ` dimensions are returned as dimension `"C"` from `signal_from_lif` to match similar functions. This assumes that there are either `λ` or `Λ`, and no other channel dimensions in hyperspectral LIF files. Is this a safe assumption?

- There's a possibility that the FLIM metadata, including the frequency, are not stored in all LIF files. In that case no frequency is returned.

- The phasor coordinates are assumed to be first harmonic. That may not always be the case.

- The phasor coordinates in LIF files are apparently uncalibrated. I am still trying to find settings in the LIF XML metadata that can be used for calibration. Alternatively, it may be possible to calculate calibration settings from the lifetime or phasor plot images in the file, if any.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
