### PR TITLE
Fix phasor_normalize with numpy 1.24

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1050,9 +1050,7 @@ def phasor_normalize(
     else:
         real = numpy.array(real_unnormalized, dtype, copy=True)
     imag = numpy.array(imag_unnormalized, real.dtype, copy=True)
-    mean = numpy.array(
-        mean_unnormalized, real.dtype, copy=None if samples == 1 else True
-    )
+    mean = numpy.array(mean_unnormalized, real.dtype, copy=True)
 
     with numpy.errstate(divide='ignore', invalid='ignore'):
         numpy.divide(real, mean, out=real)

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -415,6 +415,16 @@ def test_phasor_normalization(harmonics, normalize):
         assert_allclose(real2, real1, 1e-4)
         assert_allclose(imag2, imag1, 1e-4)
 
+        mean2, real2, imag2 = phasor_normalize(
+            mean0, real0, imag0, samples=1, dtype=numpy.float64
+        )
+        assert_array_equal(mean0, mean_)
+        assert_array_equal(real0, real_)
+        assert_array_equal(imag0, imag_)
+        assert_array_equal(mean2, mean0)
+        assert_allclose(real2, real1, 1e-8)
+        assert_allclose(imag2, imag1, 1e-8)
+
         with pytest.raises(ValueError):
             phasor_normalize(mean0, real0, imag0, samples=0)
 


### PR DESCRIPTION
## Description

Fix the `phasor_normalize` function with `samples=1` on numpy 1.24. See #167.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
