### PR TITLE
Return more metadata from IFLI and FBD readers

### DIFF
--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -2305,7 +2305,7 @@ def signal_from_fbd(
                 data = data[0]
                 axes = axes[1:]
         else:
-            if frame < 0 or frame > data.shape[0]:
+            if frame < 0 or frame >= data.shape[0]:
                 raise IndexError(f'{frame=} out of bounds')
             if keepdims:
                 data = data[frame : frame + 1]

--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -260,6 +260,9 @@ def phasor_to_ometiff(
     extension is used to store multi-harmonic phasor coordinates.
     The modulo type for the first, harmonic dimension is "other".
 
+    The implementation is based on the
+    `tifffile <https://github.com/cgohlke/tifffile/>`__ library.
+
     Examples
     --------
     >>> mean, real, imag = numpy.random.rand(3, 32, 32, 32)
@@ -438,6 +441,9 @@ def phasor_from_ometiff(
     Scalar or one-dimensional phasor coordinates stored in the file are
     returned as two-dimensional images (three-dimensional if multiple
     harmonics are present).
+
+    The implementation is based on the
+    `tifffile <https://github.com/cgohlke/tifffile/>`__ library.
 
     Examples
     --------
@@ -764,6 +770,11 @@ def phasor_from_simfcs_referenced(
     --------
     phasorpy.io.phasor_to_simfcs_referenced
 
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
+
     Examples
     --------
     >>> phasor_to_simfcs_referenced(
@@ -863,6 +874,8 @@ def phasor_from_ifli(
           first axis.
         - ``'frequency'`` (float):
           Fundamental frequency of time-resolved phasor coordinates in MHz.
+        - ``'samples'`` (int):
+            Number of samples per frequency.
         - ``'ifli_header'`` (dict):
           Metadata from IFLI file header.
 
@@ -872,6 +885,11 @@ def phasor_from_ifli(
         File is not an ISS IFLI file.
     IndexError
         Harmonic is not found in file.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
     --------
@@ -888,6 +906,8 @@ def phasor_from_ifli(
     [1, 2, 3, 5]
     >>> attr['frequency']  # doctest: +NUMBER
     80.33
+    >>> attr['samples']
+    64
     >>> attr['ifli_header']
     {'Version': 16, ... 'ModFrequency': (...), 'RefLifetime': (2.5,), ...}
 
@@ -913,6 +933,7 @@ def phasor_from_ifli(
     dims = dims[:-2]
     del data
 
+    samples = header['HistogramResolution']
     frequencies = header['ModFrequency']
     frequency = frequencies[0]
     harmonic_stored = [
@@ -963,6 +984,7 @@ def phasor_from_ifli(
         'dims': tuple(dims),
         'harmonic': harmonic,
         'frequency': frequency * 1e-6,
+        'samples': samples,
         'ifli_header': header,
     }
 
@@ -1014,6 +1036,11 @@ def phasor_from_lif(
         File is not a Leica image file.
     ValueError
         File or `image` do not contain phasor coordinates and metadata.
+
+    Notes
+    -----
+    The implementation is based on the
+    `liffile <https://github.com/cgohlke/liffile/>`__ library.
 
     Examples
     --------
@@ -1125,6 +1152,11 @@ def lifetime_from_lif(
         File is not a Leica image file.
     ValueError
         File or `image` does not contain lifetime coordinates and metadata.
+
+    Notes
+    -----
+    The implementation is based on the
+    `liffile <https://github.com/cgohlke/liffile/>`__ library.
 
     Examples
     --------
@@ -1545,6 +1577,11 @@ def signal_from_lif(
     ValueError
         File is not a Leica image file or does not contain hyperspectral image.
 
+    Notes
+    -----
+    The implementation is based on the
+    `liffile <https://github.com/cgohlke/liffile/>`__ library.
+
     Examples
     --------
     >>> signal = signal_from_lif('ScanModesExamples.lif')  # doctest: +SKIP
@@ -1623,6 +1660,11 @@ def signal_from_lsm(
         File is not a TIFF file.
     ValueError
         File is not an LSM file or does not contain hyperspectral image.
+
+    Notes
+    -----
+    The implementation is based on the
+    `tifffile <https://github.com/cgohlke/tifffile/>`__ library.
 
     Examples
     --------
@@ -1727,6 +1769,11 @@ def signal_from_imspector_tiff(
         File is not a TIFF file.
     ValueError
         File is not an ImSpector FLIM TIFF file.
+
+    Notes
+    -----
+    The implementation is based on the
+    `tifffile <https://github.com/cgohlke/tifffile/>`__ library.
 
     Examples
     --------
@@ -1880,6 +1927,11 @@ def signal_from_sdt(
     ValueError
         File is not a SDT file containing TCSPC histogram.
 
+    Notes
+    -----
+    The implementation is based on the
+    `sdtfile <https://github.com/cgohlke/sdtfile/>`__ library.
+
     Examples
     --------
     >>> signal = signal_from_sdt(fetch('tcspc.sdt'))
@@ -1996,6 +2048,11 @@ def signal_from_ptu(
     ValueError
         File is not a PicoQuant PTU T3 mode file containing TCSPC data.
 
+    Notes
+    -----
+    The implementation is based on the
+    `ptufile <https://github.com/cgohlke/ptufile/>`__ library.
+
     Examples
     --------
     >>> signal = signal_from_ptu(fetch('hazelnut_FLIM_single_image.ptu'))
@@ -2091,6 +2148,11 @@ def signal_from_flif(
     lfdfiles.LfdFileError
         File is not a FlimFast FLIF file.
 
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
+
     Examples
     --------
     >>> signal = signal_from_flif(fetch('flimfast.flif'))
@@ -2181,11 +2243,20 @@ def signal_from_fbd(
 
         - ``coords['H']``: phases in radians.
         - ``attrs['frequency']``: repetition frequency in MHz.
+        - ``attrs['harmonic']``: harmonic contained in histogram.
+        - ``attrs['flimbox_header']``: FBD binary header, if any.
+        - ``attrs['flimbox_firmware']``: FLIMbox firmware settings, if any.
+        - ``attrs['flimbox_settings']``: Settings from FBS XML, if any.
 
     Raises
     ------
     lfdfiles.LfdFileError
         File is not a FLIMbox FBD file.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
     --------
@@ -2251,6 +2322,13 @@ def signal_from_fbd(
         metadata = _metadata(axes, data.shape, H=phases)
         attrs = metadata['attrs']
         attrs['frequency'] = fbd.laser_frequency * 1e-6
+        attrs['harmonic'] = fbd.harmonics
+        if fbd.header is not None:
+            attrs['flimbox_header'] = fbd.header
+        if fbd.fbf is not None:
+            attrs['flimbox_firmware'] = fbd.fbf
+        if fbd.fbs is not None:
+            attrs['flimbox_settings'] = fbd.fbs
 
     from xarray import DataArray
 
@@ -2282,6 +2360,11 @@ def signal_from_b64(
         File is not a SimFCS B64 file.
     ValueError
         File does not contain an image stack.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
     --------
@@ -2339,6 +2422,11 @@ def signal_from_z64(
     lfdfiles.LfdFileError
         File is not a SimFCS Z64 file.
 
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
+
     Examples
     --------
     >>> signal = signal_from_z64(fetch('simfcs.z64'))
@@ -2388,6 +2476,11 @@ def signal_from_bh(
     ------
     lfdfiles.LfdFileError
         File is not a SimFCS B&H file.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
     --------
@@ -2439,6 +2532,11 @@ def signal_from_bhz(
     ------
     lfdfiles.LfdFileError
         File is not a SimFCS BHZ file.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
     --------

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -330,7 +330,7 @@ ZENODO_14860228 = pooch.create(
 CONVALLARIA_FBD = pooch.create(
     path=pooch.os_cache('phasorpy'),
     base_url=(
-        'https://github.com/phasorpy/phasorpy-data/raw/main/zenodo_14026719'
+        'https://github.com/phasorpy/phasorpy-data/raw/main/zenodo_14026720'
         if DATA_ON_GITHUB
         else 'doi:10.5281/zenodo.14026719'
     ),

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -329,7 +329,11 @@ ZENODO_14860228 = pooch.create(
 
 CONVALLARIA_FBD = pooch.create(
     path=pooch.os_cache('phasorpy'),
-    base_url='doi:10.5281/zenodo.14026719',
+    base_url=(
+        'https://github.com/phasorpy/phasorpy-data/raw/main/zenodo_14026719'
+        if DATA_ON_GITHUB
+        else 'doi:10.5281/zenodo.14026719'
+    ),
     env=ENV,
     registry={
         'Convallaria_$EI0S.fbd': (

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -591,6 +591,12 @@ def test_signal_from_fbd():
     assert signal.shape == (1, 1, 256, 256, 64)
     assert signal.dims == ('T', 'C', 'Y', 'X', 'H')
 
+    with pytest.raises(IndexError):
+        signal_from_fbd(filename, frame=9)
+
+    with pytest.raises(IndexError):
+        signal_from_fbd(filename, channel=2)
+
     filename = fetch('simfcs.r64')
     with pytest.raises(lfdfiles.LfdFileError):
         signal_from_fbd(filename)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -548,12 +548,12 @@ def test_signal_from_ptu_irf():
     )
 
 
-@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+@pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_signal_from_fbd():
     """Test read FLIMbox FBD file."""
     # TODO: test files with different firmwares
     # TODO: gather public FBD files and upload to Zenodo
-    filename = private_file('convallaria_000$EI0S.fbd')
+    filename = fetch('Convallaria_$EI0S.fbd')
     signal = signal_from_fbd(filename)
     assert signal.values.sum(dtype=numpy.uint64) == 9310275
     assert signal.dtype == numpy.uint16

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -404,6 +404,7 @@ def test_phasor_from_ifli():
     assert attr['dims'] == ('Y', 'X')
     assert attr['frequency'] == 80.332416
     assert attr['harmonic'] == [1, 2, 3, 5]
+    assert attr['samples'] == 64
 
     mean, real1, imag1, attr = phasor_from_ifli(
         filename, harmonic='any', memmap=True
@@ -562,6 +563,13 @@ def test_signal_from_fbd():
         signal.coords['H'].data[[1, -1]], [0.0981748, 6.1850105]
     )
     assert_almost_equal(signal.attrs['frequency'], 40.0)
+
+    attrs = signal.attrs
+    assert attrs['frequency'] == 40.0
+    assert attrs['harmonic'] == 2
+    assert attrs['flimbox_firmware']['secondharmonic'] == 1
+    assert attrs['flimbox_header'] is not None
+    assert 'flimbox_settings' not in attrs
 
     signal = signal_from_fbd(filename, frame=-1, channel=0)
     assert signal.values.sum(dtype=numpy.uint64) == 9310275


### PR DESCRIPTION
## Description

This PR changes the IFLI and FBD readers to return more metadata, which are required to interpret the returned data:

- Return number of signal samples from `phasor_from_ifli`.
- Return harmonic of histogram as well as original FBD header and firmware settings from `signal_from_fbd`.

Also add references to underlying libraries and enable testing `signal_from_fbd` in CI.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
