### PR TITLE
Add more formats to file I/O tutorial

### DIFF
--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -453,6 +453,18 @@ FIGSHARE_22336594_EXPORTED = pooch.create(
     },
 )
 
+MISC = pooch.create(
+    path=pooch.os_cache('phasorpy'),
+    base_url='https://github.com/phasorpy/phasorpy-data/raw/main/misc',
+    env=ENV,
+    registry={
+        'NADHandSHG.ifli': (
+            'sha256:'
+            'dfa65952850b8a222258776a8a14eb1ab7e70ff5f62b58aa2214797c5921b4a3'
+        ),
+    },
+)
+
 REPOSITORIES: dict[str, pooch.Pooch] = {
     'tests': TESTS,
     'lfd-workshop': LFD_WORKSHOP,
@@ -464,6 +476,7 @@ REPOSITORIES: dict[str, pooch.Pooch] = {
     'flimlabs': FLIMLABS,
     'figshare_22336594': FIGSHARE_22336594,
     'figshare_22336594_exported': FIGSHARE_22336594_EXPORTED,
+    'misc': MISC,
 }
 """Pooch repositories."""
 

--- a/tutorials/api/phasorpy_components.py
+++ b/tutorials/api/phasorpy_components.py
@@ -12,8 +12,8 @@ An introduction to component analysis in phasor space.
 import math
 
 import matplotlib.animation as animation
-import matplotlib.pyplot as plt
 import numpy
+from matplotlib import pyplot
 
 from phasorpy.components import (
     graphical_component_analysis,
@@ -137,13 +137,13 @@ counts = graphical_component_analysis(
     radius=radius,
 )
 
-fig, ax = plt.subplots()
+fig, ax = pyplot.subplots()
 ax.plot(fractions, counts[0], '-', label='A vs B')
 ax.set_title('Graphical solution for contributions of two components')
 ax.set_xlabel('Fraction')
 ax.set_ylabel('Counts')
 ax.legend()
-plt.show()
+pyplot.show()
 
 # %%
 # Graphical solution for contributions of three components
@@ -180,7 +180,7 @@ counts = graphical_component_analysis(
     radius=radius,
 )
 
-fig, ax = plt.subplots()
+fig, ax = pyplot.subplots()
 ax.plot(fractions, counts[0], '-', label='A vs B')
 ax.plot(fractions, counts[1], '-', label='A vs C')
 ax.plot(fractions, counts[2], '-', label='B vs C')
@@ -188,7 +188,7 @@ ax.set_title('Graphical solution for contributions of three components')
 ax.set_xlabel('Fraction')
 ax.set_ylabel('Counts')
 ax.legend()
-plt.show()
+pyplot.show()
 
 # %%
 # The graphical method for resolving the contribution of three components
@@ -198,7 +198,7 @@ plt.show()
 # For the full analysis, the process is repeated for the other combinations
 # of components, A vs C and B vs C:
 
-fig, (ax, hist) = plt.subplots(nrows=2, ncols=1, figsize=(5.5, 8))
+fig, (ax, hist) = pyplot.subplots(nrows=2, ncols=1, figsize=(5.5, 8))
 
 plot = PhasorPlot(
     frequency=frequency,
@@ -236,14 +236,14 @@ for i in range(fractions.size):
         color='red',
         alpha=0.5,
     )
-    hist_artists = plt.plot(
+    hist_artists = pyplot.plot(
         fractions[: i + 1], counts[0][: i + 1], linestyle='-', color='tab:blue'
     )
     plots.append(plot_lines + hist_artists)
 
 _ = animation.ArtistAnimation(fig, plots, interval=100, blit=True)
-plt.tight_layout()
-plt.show()
+pyplot.tight_layout()
+pyplot.show()
 
 # %%
 # sphinx_gallery_thumbnail_number = 5

--- a/tutorials/api/phasorpy_cursors.py
+++ b/tutorials/api/phasorpy_cursors.py
@@ -9,7 +9,7 @@ An introduction to selecting phasor coordinates using cursors.
 # %%
 # Import required modules, functions, and classes:
 
-import matplotlib.pyplot as plt
+from matplotlib import pyplot
 
 from phasorpy.color import CATEGORICAL
 from phasorpy.cursors import (
@@ -67,10 +67,10 @@ plot.show()
 
 pseudo_color_image = pseudo_color(*circular_mask)
 
-fig, ax = plt.subplots()
+fig, ax = pyplot.subplots()
 ax.set_title('Pseudo-color image from circular cursors')
 ax.imshow(pseudo_color_image)
-plt.show()
+pyplot.show()
 
 # %%
 # Elliptic cursors
@@ -114,10 +114,10 @@ plot.show()
 
 pseudo_color_image = pseudo_color(*elliptic_mask, intensity=mean)
 
-fig, ax = plt.subplots()
+fig, ax = pyplot.subplots()
 ax.set_title('Pseudo-color image from elliptic cursors and intensity')
 ax.imshow(pseudo_color_image)
-plt.show()
+pyplot.show()
 
 # %%
 # Polar cursors
@@ -159,12 +159,12 @@ pseudo_color_image = pseudo_color(
     *polar_mask, intensity=mean_thresholded, colors=CATEGORICAL[2:]
 )
 
-fig, ax = plt.subplots()
+fig, ax = pyplot.subplots()
 ax.set_title(
     'Pseudo-color image from\npolar cursors and thresholded intensity'
 )
 ax.imshow(pseudo_color_image)
-plt.show()
+pyplot.show()
 
 # %%
 # sphinx_gallery_thumbnail_number = 1

--- a/tutorials/api/phasorpy_io.py
+++ b/tutorials/api/phasorpy_io.py
@@ -2,30 +2,29 @@
 File input/output
 =================
 
-Read and write phasor related data from and to various file formats.
+Read and write phasor-related data from and to various file formats.
 
 The :py:mod:`phasorpy.io` module provides functions to read phasor
 coordinates, FLIM/TCSPC histograms, hyperspectral image stacks, lifetime
 images, and relevant metadata from various file formats used in bio-imaging.
 The module also includes functions to write phasor coordinates to OME-TIFF
-and SimFCS referenced files.
+and SimFCS Referenced files.
 
 """
 
 # %%
-# .. note::
-#   This tutorial is work in progress.
-#   Not all supported file formats are included yet.
-
-# %%
-# Import required modules and functions.
-# Define a helper function to compare image histograms:
+# Import required modules and functions:
 
 import math
+import os
+from tempfile import TemporaryDirectory
 
 import numpy
+from numpy.testing import assert_allclose
 
 from phasorpy.phasor import (
+    phasor_calibrate,
+    phasor_filter_median,
     phasor_from_signal,
     phasor_threshold,
     phasor_to_apparent_lifetime,
@@ -65,9 +64,9 @@ print(filename)
 # Leica image files (LIF and XLEF) are written by Leica LAS X software.
 # They contain collections of multi-dimensional images and metadata from
 # a variety of microscopy acquisition and analysis modes.
-# The PhasorPy library currently supports reading hyperspectral images,
-# phasor coordinates, and lifetime images from Leica image files.
-# The implementation is based on the
+#
+# PhasorPy currently supports reading hyperspectral images,
+# phasor coordinates, and lifetime images from Leica image files via the
 # `liffile <https://github.com/cgohlke/liffile/>`_ library.
 #
 # LIF-FLIM files that were analyzed with the LAS X software contain
@@ -86,7 +85,7 @@ plot_phasor_image(mean, real, imag, title=filename)
 
 # %%
 # The returned mean intensity and uncalibrated phasor coordinates are
-# numpy arrays. ``attrs`` is a dictionary containing metadata, including the
+# NumPy arrays. ``attrs`` is a dictionary holding metadata, including the
 # auto-reference phase (in degrees) and modulation for all image channels,
 # as well as the fundamental laser frequency (in MHz):
 
@@ -166,13 +165,15 @@ plot_histograms(
 # PicoQuant PTU files are written by PicoQuant SymPhoTime, Leica LAS X, and
 # other software. The files contain time-correlated single-photon
 # counting (TCSPC) measurement data and instrumentation parameters.
-# The PhasorPy library supports reading TCSPC histograms from PicoQuant PTU
-# files acquired in T3 imaging mode. The implementation is based on the
-# `ptufile <https://github.com/cgohlke/ptufile/>`_ library.
+#
+# PhasorPy supports reading TCSPC histograms from PTU files acquired in T3
+# imaging mode via the `ptufile <https://github.com/cgohlke/ptufile/>`_
+# library.
 #
 # The :py:func:`phasorpy.io.signal_from_ptu` function is used to read
 # the TCSPC histogram from a PTU file exported from the `FLIM_testdata
-# <https://dx.doi.org/10.6084/m9.figshare.22336594.v1>`_ dataset.
+# <https://dx.doi.org/10.6084/m9.figshare.22336594.v1>`_ dataset with the
+# Leica LAS X software.
 # The function by default returns a 5-dimensional image with dimension order
 # TYXCH. Channel and frames are specified to reduce the dimensionality:
 
@@ -190,12 +191,12 @@ plot_signal_image(signal, title=filename)
 #
 # The returned ``signal`` is an `xarray.DataArray
 # <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
-# containing the TCSPC histogram as a numpy array, and metadata as a
+# holding the TCSPC histogram as a NumPy array, and metadata as a
 # dictionary in the ``attrs`` property.
 # The metadata includes all PTU tags and the fundamental laser frequency,
 # which is needed to interpret the phasor coordinates.
 # The reference phase and modulation previously loaded from the LIF-FLIM file
-# is again used to calibrate the phasor coordinates. The same intensity
+# are again used to calibrate the phasor coordinates. The same intensity
 # threshold is applied:
 
 frequency = signal.attrs['frequency']
@@ -218,7 +219,7 @@ plot_phasor(
 )
 
 # %%
-# Compare the apparent single lifetimes calculated from the PTU with the
+# Compare the apparent single lifetimes calculated from the PTU file with the
 # lifetimes previously read from the LIF-FLIM file:
 
 plot_histograms(
@@ -240,59 +241,348 @@ plot_histograms(
 # Carl Zeiss image files (CZI) are written by Zeiss ZEN software.
 # They contain images and metadata from a variety of microscopy acquisition
 # and analysis modes, including hyperspectral imaging.
+#
 # PhasorPy does not currently support reading CZI files.
 # However, hyperspectral images can be read from CZI files using, for example,
 # the `pylibCZIrw  <https://github.com/ZEISS/pylibczirw/>`_ or
-# `BioIO <https://github.com/bioio-devs/bioio>`_ libraries.
+# `BioIO <https://github.com/bioio-devs/bioio>`_ libraries. Another option is
+# to export CZI files as LSM using the ZEN software.
 
 # %%
 # Zeiss LSM
 # ---------
 #
-# .. todo::
-#   Read hyperspectral image stack from Zeiss LSM file.
+# Carl Zeiss LSM files, a predecessor of the CZI format, are written by
+# Zeiss ZEN software. They contain images and metadata from laser-scanning
+# microscopy.
+#
+# PhasorPy supports reading hyperspectral image data from Zeiss LSM files
+# via the `tifffile <https://github.com/cgohlke/tifffile/>`_ library.
+#
+# The :py:func:`phasorpy.io.signal_from_lsm` function is used to read
+# a hyperspectral dataset with 30 emission wavelengths:
+
+from phasorpy.io import signal_from_lsm
+
+filename = 'paramecium.lsm'
+signal = signal_from_lsm(fetch('paramecium.lsm'))
+
+plot_signal_image(signal, title=filename)
+
+# %%
+# Note that the signal is not well sampled and shows a discontinuity.
+# It may not be accurately represented by the phasor coordinates calculated
+# via DFT.
+#
+# Emission wavelengths (in nm) are available in the coordinates of the
+# channel axis:
+
+print(signal.coords['C'].values.astype(int))
+
+# %%
+# Plot the first harmonic phasor coordinates after applying a median filter.
+
+plot_phasor(
+    *phasor_threshold(
+        *phasor_filter_median(*phasor_from_signal(signal)), mean_min=1
+    )[1:],
+    allquadrants=True,
+    title=filename,
+)
 
 # %%
 # Becker & Hickl SDT
 # ------------------
 #
+# SDT files are written by Becker & Hickl software.
+# They may contain TCSPC histograms and metadata from laser-scanning
+# microscopy.
+#
+# PhasorPy supports reading TCSPC histograms from FBD files via the
+# `lfdfiles <https://github.com/cgohlke/lfdfiles/>`_ library.
+#
+# The :py:func:`phasorpy.io.signal_from_sdt` function is used to read a
+# TCSPC histogram from a SDT file:
+
+from phasorpy.io import signal_from_sdt
+
+filename = 'tcspc.sdt'
+signal = signal_from_sdt(fetch(filename))
+
+plot_signal_image(signal, title=filename)
+
+# %%
+# Plot the uncalibrated phasor coordinates:
+
+frequency = signal.attrs['frequency']
+
+plot_phasor(
+    *phasor_from_signal(signal)[1:],
+    title=f'{filename} ({frequency:.1f} MHz)',
+    allquadrants=True,
+    style='hist2d',
+)
+
+# %%
 # .. todo::
-#   Read TCSPC histogram from Becker & Hickl SDT file.
+#   No accompanying IRF dataset is available to calibrate the phasor
+#   coordinates.
 
 # %%
 # FLIMbox FBD
 # -----------
 #
-# .. todo::
-#   Read TCSPC histogram from FLIMbox FBD file.
+# FLIMbox data files, FBD, are written by SimFCS and ISS software.
+# They contain encoded TCSPC lifetime histograms from digital frequency-domain
+# measurements acquired with the FLIMbox device. Newer file versions
+# contain metadata. The file format is undocumented, not standardized,
+# and files are frequently found corrupted. It is recommended to export
+# FLIMbox data to another format from the software used to acquire the data.
+#
+# PhasorPy supports reading some FLIMbox FBD files via the
+# `lfdfiles <https://github.com/cgohlke/lfdfiles/>`_ library.
+#
+# The :py:func:`phasorpy.io.signal_from_fbd` function is used to read
+# a TCSPC lifetime histograms from the
+# `Convallaria <https://zenodo.org/records/14026720>`_ dataset, which was
+# acquired at the second harmonic. The dataset is a time series of two
+# channels. Since the photon count is low and the second channel empty,
+# only the first channel is read and the time-axis integrated:
+
+from phasorpy.io import signal_from_fbd
+
+filename = 'Convallaria_$EI0S.fbd'
+signal = signal_from_fbd(fetch(filename), frame=-1, channel=0)
+
+frequency = signal.attrs['frequency'] * signal.attrs['harmonic']
+print(signal.sizes)
+
+plot_signal_image(signal, title=filename)
+
+# %%
+# The measurement of a solution of Rhodamine 110 with known lifetime of 4 ns
+# is used as a calibration reference:
+
+reference_filename = 'Calibration_Rhodamine110_$EI0S.fbd'
+reference_signal = signal_from_fbd(
+    fetch(reference_filename), frame=-1, channel=0
+)
+reference_lifetime = 4.0
+
+plot_signal_image(reference_signal, title=reference_filename)
+
+# %%
+# Phasor coordinates are calculated from the signal and calibrated with
+# the reference signal:
+
+mean, real, imag = phasor_from_signal(signal)
+
+real, imag = phasor_calibrate(
+    real,
+    imag,
+    *phasor_from_signal(reference_signal),
+    frequency,
+    reference_lifetime,
+)
+
+plot_phasor(
+    *phasor_threshold(
+        *phasor_filter_median(mean, real, imag, repeat=3), mean_min=1
+    )[1:],
+    title=f'{filename} ({frequency} MHz)',
+    frequency=frequency,
+)
 
 # %%
 # FLIM LABS JSON
 # --------------
 #
-# .. todo::
-#   Read TCSPC histogram from FLIM LABS JSON file.
-
-# %%
-# ISS VistaVision IFLI
-# --------------------
+# FLIM LABS JSON files are written by FLIM Studio software.
+# They contain multi-channel TCSPC histogram images, optional multi-harmonic
+# calibrated phasor coordinates, and metadata from digital frequency-domain
+# measurements.
 #
 # .. todo::
-#   Read phasor coordinates from ISS VistaVision IFLI file.
+#   The FLIM LABS JSON datasets currently available are not suitable to
+#   demonstrate the :py:func:`phasorpy.io.signal_from_flimlabs_json` and
+#   :py:func:`phasorpy.io.phasor_from_flimlabs_json` functions.
+
+# %%
+# ISS IFLI
+# --------
+#
+# IFLI files are written by ISS VistaVision software. They contain calibrated
+# phasor coordinates from analog or digital frequency-domain fluorescence
+# lifetime measurements.
+# IFLI datasets can be up to 9-dimensional in the order of mean/real/imag,
+# frequency, position, emission wavelength, time, channel, Z, Y, and X.
+#
+# PhasorPy supports reading ISS IFLI files via the
+# `lfdfiles <https://github.com/cgohlke/lfdfiles/>`_ library.
+#
+# The :py:func:`phasorpy.io.phasor_from_ifli` function is used to read
+# calibrated phasor coordinates from a measurement of mouse liver fed with
+# Western diet. The second channel and the first three harmonics are
+# selected:
+
+from phasorpy.io import phasor_from_ifli
+
+filename = 'NADHandSHG.ifli'
+mean, real, imag, attrs = phasor_from_ifli(
+    fetch(filename), channel=1, harmonic='all'
+)
+
+plot_phasor_image(mean, real, imag, title=filename)
+
+# %%
+# The first channel in the file contains an SHG image with phasor coordinates
+# about zero:
+
+assert (
+    phasor_from_ifli(fetch(filename), channel=0, harmonic='all')[1].mean()
+    < 1e-2
+)
+
+# %%
+# The ``attrs`` dictionary holds metadata including the fundamental laser
+# frequency, the harmonics in the phasor coordinates, and the reference phasor
+# coordinates used for calibration:
+
+frequency = attrs['frequency']
+harmonic = attrs['harmonic']
+reference_phasor = attrs['ifli_header']['RefDCPhasor']
+reference_lifetime = attrs['ifli_header']['RefLifetime']
+
+# %%
+# Plot the first harmonic phasor coordinates after applying a median filter:
+
+plot_phasor(
+    *phasor_filter_median(mean, real[0], imag[0], repeat=2)[1:],
+    title=f'{filename} ({frequency:.2f} MHz)',
+    frequency=frequency,
+    cmin=10,
+)
+
+# %%
+# Three main lifetime components are expected in the sample:
+# free NADH (~0.4 ns), bound NADH (3.4 ns) and a long lifetime species (~8 ns).
+# It appears the calibration is off in this sample.
 
 # %%
 # SimFCS REF and R64
 # ------------------
 #
-# .. todo::
-#   Read and write phasor coordinates from and to SimFCS referenced files.
+# Referenced files, REF and R64, are written by the SimFCS software and
+# supported in several other software.
+# The files most commonly contain a square-sized average intensity image and
+# the calibrated phasor coordinates of the first two harmonics.
+#
+# PhasorPy supports reading and writing SimFCS Referenced files via the
+# `lfdfiles <https://github.com/cgohlke/lfdfiles/>`_ library.
+#
+# The :py:func:`phasorpy.io.phasor_from_simfcs_referenced` function is used
+# to read calibrated phasor coordinates from a REF file
+# from the `LFD workshop <https://zenodo.org/records/8411056>`_ dataset:
+
+from phasorpy.io import phasor_from_simfcs_referenced
+
+filename = 'capillaries1001.ref'
+mean, real, imag, attrs = phasor_from_simfcs_referenced(
+    fetch(filename), harmonic='all'
+)
+
+plot_phasor_image(mean, real, imag, title=filename)
+
+# %%
+# Plot the first harmonic phasor coordinates after applying a median filter.
+# SimFCS Referenced files do not contain metadata. The frequency and harmonics
+# must be known by the user:
+
+frequency = 80.0  # MHz
+harmonic = [1, 2]
+
+plot_phasor(
+    *phasor_threshold(
+        *phasor_filter_median(mean, real[0], imag[0]),
+        mean_min=25,
+        real_min=1e-3,
+    )[1:],
+    title=f'{filename} ({frequency:.2f} MHz)',
+    frequency=frequency,
+    cmin=2,
+)
+
+# %%
+# The :py:func:`phasorpy.io.phasor_to_simfcs_referenced` function is used
+# to write calibrated phasor coordinates to R64 files in a temporary directory.
+# Images with more than two dimensions or larger than square size are
+# chunked to square-sized images and saved to separate files.
+# Images or chunks with less than two dimensions or smaller than square size
+# are padded with NaN values:
+
+from phasorpy.io import phasor_to_simfcs_referenced
+
+with TemporaryDirectory() as tmpdir:
+
+    fname = os.path.join(tmpdir, 'capillaries1001.r64')
+    phasor_to_simfcs_referenced(fname, mean, real, imag, size=160)
+
+    # print file names
+    filenames = sorted(os.listdir(tmpdir))
+    for fname in filenames:
+        print(fname)
+
+    # verify the first harmonic phasor coordinates in the last file
+    assert_allclose(
+        phasor_from_simfcs_referenced(os.path.join(tmpdir, filenames[-1]))[1],
+        numpy.pad(real[0, 160:, 160:], (0, 64), constant_values=numpy.nan),
+        atol=1e-3,
+        equal_nan=True,
+    )
 
 # %%
 # PhasorPy OME-TIFF
 # -----------------
 #
-# .. todo::
-#  Read and write phasor coordinates from and to PhasorPy OME-TIFF files.
+# PhasorPy can store phasor coordinates and select metadata in
+# `OME-TIFF <https://ome-model.readthedocs.io/en/stable/ome-tiff/>`_
+# formatted files, which are compatible with Bio-Formats, Fiji, and other
+# software. The implementation is based on the
+# `tifffile <https://github.com/cgohlke/tifffile/>`_ library.
+#
+# In comparison with the SimFCS R64 format, OME-TIFF can store higher
+# dimensional, higher precision images of any size, any number of harmonics,
+# and select metadata.
+#
+# PhasorPy OME-TIFF files are intended for temporarily exchanging phasor
+# coordinates with other software, not as a long-term storage solution.
+# It is best practice to archive the original data files in the native format.
+#
+# The :py:func:`phasorpy.io.phasor_to_ometiff` and
+# :py:func:`phasorpy.io.phasor_from_ometiff` functions are used to write and
+# read back calibrated phasor coordinates to/from PhasorPy OME-TIFF files:
+
+from phasorpy.io import phasor_from_ometiff, phasor_to_ometiff
+
+filename = f'{filename}.ome.tiff'
+
+with TemporaryDirectory() as tmpdir:
+
+    phasor_to_ometiff(
+        filename,
+        mean,
+        real,
+        imag,
+        frequency=frequency,
+        dims='YX',
+        description='Written by PhasorPy',
+    )
+
+    mean1, real1, imag1, attrs = phasor_from_ometiff(filename, harmonic='all')
+    assert_allclose(mean, mean1)
+    assert attrs['frequency'] == frequency
+    assert attrs['harmonic'] == [1, 2]
+    assert attrs['description'] == 'Written by PhasorPy'
 
 # %%
 # sphinx_gallery_thumbnail_number = 3


### PR DESCRIPTION
## Description

This PR adds sections for several file formats to the "File input/output" tutorial:

- Zeiss LSM
- Becker & Hickl SDT
- FLIMbox FBD
- ISS IFLI
- SimFCS REF and R64
- PhasorPy OME-TIFF

Also unifies tutorials to use "`from matplotlib import pyplot`" imports.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
