### PR TITLE
Fix module attribute of functions in phasorpy.io

### DIFF
--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -12,6 +12,7 @@ __all__: list[str] = [
     'phasor_from_polar_scalar',
     'phasor_to_polar_scalar',
     'scale_matrix',
+    'set_module',
     'sort_coordinates',
     'update_kwargs',
 ]
@@ -517,3 +518,23 @@ def chunk_iter(
                 for i in range(ndim)
             ),
         )
+
+
+def set_module(globs: dict[str, Any], /) -> None:
+    """Set ``__module__`` attribute for objects in ``__all__``.
+
+    Parameters
+    ----------
+    globs : dict
+        Module namespace to modify.
+
+    Examples
+    --------
+    >>> set_module(globals())
+
+    """
+    name = globs['__name__']
+    for item in globs['__all__']:
+        obj = globs[item]
+        if hasattr(obj, '__module__'):
+            obj.__module__ = name

--- a/src/phasorpy/io.py
+++ b/src/phasorpy/io.py
@@ -3,3 +3,7 @@
 
 from ._io import *
 from ._io import __all__, __doc__
+from ._utils import set_module
+
+set_module(globals())
+del set_module

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -265,5 +265,13 @@ def test_chunk_iter():
         list(chunk_iter((2,), (1, 2)))
 
 
+def test_set_module():
+    """Test set_module function."""
+    from phasorpy._utils import set_module  # noqa: F401
+    from phasorpy.io import phasor_from_ometiff
+
+    assert phasor_from_ometiff.__module__ == 'phasorpy.io'
+
+
 # mypy: allow-untyped-defs, allow-untyped-calls
 # mypy: disable-error-code="arg-type"


### PR DESCRIPTION
## Description

The `__module__` attributes of functions in `phasorpy.io` are corrected from `'phasorpy._io'` (private namespace) to `'phasorpy.io'` (public namespace). 

The helper function, `phasorpy._utils.set_module`, can be reused when moving `phasorpy.phasorpy.*` to the `phasorpy` namespace.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
