### PR TITLE
Move parse_skip_axis function to _utils module

### DIFF
--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -9,6 +9,7 @@ __all__: list[str] = [
     'parse_harmonic',
     'parse_kwargs',
     'parse_signal_axis',
+    'parse_skip_axis',
     'phasor_from_polar_scalar',
     'phasor_to_polar_scalar',
     'scale_matrix',
@@ -19,10 +20,11 @@ __all__: list[str] = [
 
 import math
 import numbers
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._typing import Any, Sequence, ArrayLike, Literal, NDArray, Iterator
+    from ._typing import Any, ArrayLike, Literal, NDArray, Iterator
 
 import numpy
 
@@ -311,6 +313,65 @@ def parse_signal_axis(
     if isinstance(axis, int):
         return axis, ''
     raise ValueError(f'{axis=} not valid for {type(signal)=}')
+
+
+def parse_skip_axis(
+    skip_axis: int | Sequence[int] | None,
+    /,
+    ndim: int,
+    prepend_axis: bool = False,
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Return axes to skip and not to skip.
+
+    This helper function is used to validate and parse `skip_axis`
+    parameters.
+
+    Parameters
+    ----------
+    skip_axis : int or sequence of int, optional
+        Axes to skip. If None, no axes are skipped.
+    ndim : int
+        Dimensionality of array in which to skip axes.
+    prepend_axis : bool, optional
+        Prepend one dimension and include in `skip_axis`.
+
+    Returns
+    -------
+    skip_axis : tuple of int
+        Ordered, positive values of `skip_axis`.
+    other_axis : tuple of int
+        Axes indices not included in `skip_axis`.
+
+    Raises
+    ------
+    IndexError
+        If any `skip_axis` value is out of bounds of `ndim`.
+
+    Examples
+    --------
+    >>> parse_skip_axis((1, -2), 5)
+    ((1, 3), (0, 2, 4))
+
+    >>> parse_skip_axis((1, -2), 5, True)
+    ((0, 2, 4), (1, 3, 5))
+
+    """
+    if ndim < 0:
+        raise ValueError(f'invalid {ndim=}')
+    if skip_axis is None:
+        if prepend_axis:
+            return (0,), tuple(range(1, ndim + 1))
+        return (), tuple(range(ndim))
+    if not isinstance(skip_axis, Sequence):
+        skip_axis = (skip_axis,)
+    if any(i >= ndim or i < -ndim for i in skip_axis):
+        raise IndexError(f'skip_axis={skip_axis} out of range for {ndim=}')
+    skip_axis = sorted(int(i % ndim) for i in skip_axis)
+    if prepend_axis:
+        skip_axis = [0] + [i + 1 for i in skip_axis]
+        ndim += 1
+    other_axis = tuple(i for i in range(ndim) if i not in skip_axis)
+    return tuple(skip_axis), other_axis
 
 
 def parse_harmonic(

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -11,6 +11,7 @@ from phasorpy._utils import (
     parse_harmonic,
     parse_kwargs,
     parse_signal_axis,
+    parse_skip_axis,
     phasor_from_polar_scalar,
     phasor_to_polar_scalar,
     scale_matrix,
@@ -191,6 +192,25 @@ def test_parse_signal_axis():
 
     with pytest.raises(ValueError):
         parse_signal_axis(DataArray(), 'not found')
+
+
+def test_parse_skip_axis():
+    """Test parse_skip_axis function."""
+    assert parse_skip_axis(None, 0) == ((), ())
+    assert parse_skip_axis(None, 1) == ((), (0,))
+    assert parse_skip_axis((), 1) == ((), (0,))
+    assert parse_skip_axis(0, 1) == ((0,), ())
+    assert parse_skip_axis(0, 2) == ((0,), (1,))
+    assert parse_skip_axis(-1, 2) == ((1,), (0,))
+    assert parse_skip_axis((1, -2), 5) == ((1, 3), (0, 2, 4))
+    with pytest.raises(ValueError):
+        parse_skip_axis(0, -1)
+    with pytest.raises(IndexError):
+        parse_skip_axis(0, 0)
+    with pytest.raises(IndexError):
+        parse_skip_axis(1, 1)
+    with pytest.raises(IndexError):
+        parse_skip_axis(-2, 1)
 
 
 def test_chunk_iter():

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -23,7 +23,6 @@ except ImportError:
     mkl_fft = None
 
 from phasorpy.phasor import (
-    _parse_skip_axis,
     lifetime_fraction_from_amplitude,
     lifetime_fraction_to_amplitude,
     lifetime_from_frequency,
@@ -2500,25 +2499,6 @@ def test_phasor_to_principal_plane():
     # exception
     with pytest.raises(ValueError):
         phasor_to_principal_plane([0.0, 1.0], [0.0])
-
-
-def test_parse_skip_axis():
-    """Test _parse_skip_axis function."""
-    assert _parse_skip_axis(None, 0) == ((), ())
-    assert _parse_skip_axis(None, 1) == ((), (0,))
-    assert _parse_skip_axis((), 1) == ((), (0,))
-    assert _parse_skip_axis(0, 1) == ((0,), ())
-    assert _parse_skip_axis(0, 2) == ((0,), (1,))
-    assert _parse_skip_axis(-1, 2) == ((1,), (0,))
-    assert _parse_skip_axis((1, -2), 5) == ((1, 3), (0, 2, 4))
-    with pytest.raises(ValueError):
-        _parse_skip_axis(0, -1)
-    with pytest.raises(IndexError):
-        _parse_skip_axis(0, 0)
-    with pytest.raises(IndexError):
-        _parse_skip_axis(1, 1)
-    with pytest.raises(IndexError):
-        _parse_skip_axis(-2, 1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Move the `phasor._parse_skip_axis` function to `_utils.parse_skip_axis` so it can be reused in other modules.

Required by #201.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
