### PR TITLE
Fix new mypy errors with numpy 2.2.4

### DIFF
--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__: list[str] = [
+__all__ = [
     'chunk_iter',
     'dilate_coordinates',
     'kwargs_notnone',
@@ -438,7 +438,7 @@ def parse_harmonic(
             return list(range(1, harmonic_max + 1)), True
         raise ValueError(f'{harmonic=!r} is not a valid harmonic')
 
-    h = numpy.atleast_1d(numpy.asarray(harmonic))
+    h = numpy.atleast_1d(harmonic)
     if h.size == 0:
         raise ValueError(f'{harmonic=} is empty')
     if h.dtype.kind not in 'iu' or h.ndim != 1:
@@ -449,7 +449,7 @@ def parse_harmonic(
         raise IndexError(f'{harmonic=} element > {harmonic_max}]')
     if numpy.unique(h).size != h.size:
         raise ValueError(f'{harmonic=} elements must be unique')
-    return h.tolist(), True
+    return [int(i) for i in harmonic], True
 
 
 def chunk_iter(

--- a/src/phasorpy/cli.py
+++ b/src/phasorpy/cli.py
@@ -8,6 +8,8 @@ Invoke the command line application with::
 
 from __future__ import annotations
 
+__all__: list[str] = []
+
 import os
 from typing import TYPE_CHECKING
 

--- a/src/phasorpy/conftest.py
+++ b/src/phasorpy/conftest.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__: list[str] = []
+
 import math
 from typing import TYPE_CHECKING
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -504,7 +504,8 @@ def phasor_to_signal(
     else:
         keepdims = mean.ndim > 0 or real.ndim > 0
 
-    mean, real = numpy.atleast_1d(mean, real)
+    mean = numpy.atleast_1d(mean)
+    real = numpy.atleast_1d(real)
 
     if real.dtype.kind != 'f' or imag.dtype.kind != 'f':
         raise ValueError(f'{real.dtype=} or {imag.dtype=} not floating point')

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -504,8 +504,8 @@ def phasor_to_signal(
     else:
         keepdims = mean.ndim > 0 or real.ndim > 0
 
-    mean = numpy.atleast_1d(mean)
-    real = numpy.atleast_1d(real)
+    mean = numpy.asarray(numpy.atleast_1d(mean))
+    real = numpy.asarray(numpy.atleast_1d(real))
 
     if real.dtype.kind != 'f' or imag.dtype.kind != 'f':
         raise ValueError(f'{real.dtype=} or {imag.dtype=} not floating point')

--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+__all__ = ['__version__', 'versions']
+
 __version__ = '0.5.dev'
 
 


### PR DESCRIPTION
## Description

numpy 2.2.4, released today, includes many fixes related to typing. This caused some new mypy errors in PhasorPy code related to the use of `numpy.atleast_1d`. This PR works around the new errors and also adds missing `__all__` attributes to modules.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
