### PR TITLE
Support routing channels in signal_from_sdt

### DIFF
--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -1921,8 +1921,9 @@ def signal_from_sdt(
     Returns
     -------
     xarray.DataArray
-        TCSPC histogram with :ref:`axes codes <axes>` ``'YXH'`` and
+        TCSPC histogram with :ref:`axes codes <axes>` ``'QCYXH'`` and
         type ``uint16``, ``uint32``, or ``float32``.
+        Dimensions ``'Q'`` and ``'C'`` are optional detector channels.
 
         - ``coords['H']``: delay-times of histogram bins in ns.
         - ``attrs['frequency']``: repetition frequency in MHz.
@@ -1973,7 +1974,7 @@ def signal_from_sdt(
         times = sdt.times[index] * 1e9
 
     # TODO: get spatial coordinates from scanner settings?
-    metadata = _metadata('QYXH'[-data.ndim :], data.shape, filename, H=times)
+    metadata = _metadata('QCYXH'[-data.ndim :], data.shape, filename, H=times)
     metadata['attrs']['frequency'] = 1e3 / float(times[-1] + times[1])
 
     from xarray import DataArray

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -401,6 +401,21 @@ def test_signal_from_sdt_fcs():
     assert pytest.approx(signal.attrs['frequency']) == 59.959740
 
 
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_signal_from_sdt_bruker():
+    """Test read Becker & Hickl SDT file with routing channel."""
+    # file provided by bruno-pannunzio via email on March 25, 2025
+    filename = private_file('LifetimeData_Cycle00001_000001.sdt')
+    signal = signal_from_sdt(filename)
+    assert signal.dtype == numpy.uint16
+    assert signal.shape == (2, 512, 512, 256)
+    assert signal.dims == ('C', 'Y', 'X', 'H')
+    assert_almost_equal(signal.coords['H'][[0, -1]], [0.0, 12.24], decimal=2)
+    assert pytest.approx(signal.attrs['frequency']) == 81.3802
+    assert signal[0].values.sum(dtype=numpy.uint64) == 15234486
+    assert signal[1].values.sum(dtype=numpy.uint64) == 0
+
+
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_phasor_from_ifli():
     """Test read ISS VistaVision file."""


### PR DESCRIPTION
## Description

This PR adds support for up to two additional routing/detector channels to the `signal_from_sdt` functions. Since version 2025.3.25, `sdtfile` returns up to 5 dimensional data arrays if routing channels are present in SDT files.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
