### PR TITLE
Ignore PhasorPlot.contour cmap if colors is set

### DIFF
--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -372,7 +372,9 @@ class PhasorPlot:
             and :py:meth:`matplotlib.axes.Axes.contour`.
 
         """
-        update_kwargs(kwargs, cmap='Blues', norm='log')
+        if 'cmap' not in kwargs and 'colors' not in kwargs:
+            kwargs['cmap'] = 'Blues'
+        update_kwargs(kwargs, norm='log')
         kwargs_hist2d = parse_kwargs(
             kwargs, 'bins', 'range', 'density', 'weights'
         )

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -119,6 +119,10 @@ class TestPhasorPlot:
         plot.contour(real, imag, bins=200, cmap='viridis', norm='linear')
         self.show(plot)
 
+        plot = PhasorPlot(title='colors=red', allquadrants=True)
+        plot.contour(real, imag, colors='red')
+        self.show(plot)
+
     def test_histogram_contour(self):
         """Test histogram and contour match."""
         real, imag = numpy.random.multivariate_normal(


### PR DESCRIPTION
## Description

This PR fixes `ValueError: Either colors or cmap must be None` if `PhasorPlot.contour` is called with a `colors` parameter.

Closes #212.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
