### PR TITLE
Require Cython>=3.1.0b1

### DIFF
--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -52,7 +52,7 @@ jobs:
       - run: |
           ls
           ls dist
-          python -m pip install -U twine setuptools build wheel numpy Cython>=3.1.0b1
+          python -m pip install -U twine setuptools build wheel numpy "cython>=3.1.0b1"
           python -m twine check dist/*
           python -m pip install --upgrade --no-build-isolation --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
           python -c"from phasorpy import __version__;print(__version__)"

--- a/.github/workflows/build_sdist.yml
+++ b/.github/workflows/build_sdist.yml
@@ -52,7 +52,7 @@ jobs:
       - run: |
           ls
           ls dist
-          python -m pip install -U twine setuptools build wheel numpy Cython
+          python -m pip install -U twine setuptools build wheel numpy Cython>=3.1.0b1
           python -m twine check dist/*
           python -m pip install --upgrade --no-build-isolation --no-cache-dir --no-deps --pre --no-index --find-links=dist phasorpy
           python -c"from phasorpy import __version__;print(__version__)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=68",
     "numpy",
-    "Cython>=3.0.11",
+    "Cython>=3.1.0b1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=68",
     "numpy",
-    "Cython>=3.1.0b1",
+    "cython>=3.1.0b1",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ wheel
 twine
 packaging
 cibuildwheel
-Cython>=3.0.11
+Cython>=3.1.0b1
 # meson-python
 #
 # documentation requirements

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,7 +18,7 @@ wheel
 twine
 packaging
 cibuildwheel
-Cython>=3.1.0b1
+cython>=3.1.0b1
 # meson-python
 #
 # documentation requirements

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -4,6 +4,7 @@
 # cython: wraparound = False
 # cython: cdivision = True
 # cython: nonecheck = False
+# cython: freethreading_compatible = True
 
 """Cython implementation of low-level functions for the PhasorPy library."""
 

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -7,12 +7,6 @@
 
 """Cython implementation of low-level functions for the PhasorPy library."""
 
-# TODO: replace short with unsigned char when Cython supports it
-# https://github.com/cython/cython/pull/6196#issuecomment-2209509572
-
-# TODO: use fused return types for functions returning more than two items
-# https://github.com/cython/cython/issues/6328
-
 cimport cython
 
 from cython.parallel import parallel, prange
@@ -982,7 +976,7 @@ cdef (float_t, float_t) _phasor_divide(
 
 
 @cython.ufunc
-cdef short _is_inside_range(
+cdef unsigned char _is_inside_range(
     float_t x,  # point
     float_t y,
     float_t xmin,  # x range
@@ -1002,7 +996,7 @@ cdef short _is_inside_range(
 
 
 @cython.ufunc
-cdef short _is_inside_rectangle(
+cdef unsigned char _is_inside_rectangle(
     float_t x,  # point
     float_t y,
     float_t x0,  # segment start
@@ -1044,7 +1038,7 @@ cdef short _is_inside_rectangle(
 
 
 @cython.ufunc
-cdef short _is_inside_polar_rectangle(
+cdef unsigned char _is_inside_polar_rectangle(
     float_t x,  # point
     float_t y,
     float_t angle_min,  # phase, -pi to pi
@@ -1083,7 +1077,7 @@ cdef short _is_inside_polar_rectangle(
 
 
 @cython.ufunc
-cdef short _is_inside_circle(
+cdef unsigned char _is_inside_circle(
     float_t x,  # point
     float_t y,
     float_t x0,  # circle center
@@ -1100,7 +1094,7 @@ cdef short _is_inside_circle(
 
 
 @cython.ufunc
-cdef short _is_inside_ellipse(
+cdef unsigned char _is_inside_ellipse(
     float_t x,  # point
     float_t y,
     float_t x0,  # ellipse center
@@ -1135,7 +1129,7 @@ cdef short _is_inside_ellipse(
 
 
 @cython.ufunc
-cdef short _is_inside_ellipse_(
+cdef unsigned char _is_inside_ellipse_(
     float_t x,  # point
     float_t y,
     float_t x0,  # ellipse center
@@ -1164,7 +1158,7 @@ cdef short _is_inside_ellipse_(
 
 
 @cython.ufunc
-cdef short _is_inside_stadium(
+cdef unsigned char _is_inside_stadium(
     float_t x,  # point
     float_t y,
     float_t x0,  # line start
@@ -1210,7 +1204,7 @@ _is_near_segment = _is_inside_stadium
 
 
 @cython.ufunc
-cdef short _is_near_line(
+cdef unsigned char _is_near_line(
     float_t x,  # point
     float_t y,
     float_t x0,  # line start
@@ -1476,7 +1470,7 @@ cdef float_t _distance_from_line(
 
 
 @cython.ufunc
-cdef (double, double, double) _segment_direction_and_length(
+cdef (float_t, float_t, float_t) _segment_direction_and_length(
     float_t x0,  # segment start
     float_t y0,
     float_t x1,  # segment end
@@ -1500,7 +1494,7 @@ cdef (double, double, double) _segment_direction_and_length(
 
 
 @cython.ufunc
-cdef (double, double, double, double) _intersection_circle_circle(
+cdef (float_t, float_t, float_t, float_t) _intersection_circle_circle(
     float_t x0,  # circle 0
     float_t y0,
     float_t r0,
@@ -1538,15 +1532,15 @@ cdef (double, double, double, double) _intersection_circle_circle(
     hd = sqrt(dd) / dr
     ld = ll / dr
     return (
-        ld * dx + hd * dy + x0,
-        ld * dy - hd * dx + y0,
-        ld * dx - hd * dy + x0,
-        ld * dy + hd * dx + y0,
+        <float_t> (ld * dx + hd * dy + x0),
+        <float_t> (ld * dy - hd * dx + y0),
+        <float_t> (ld * dx - hd * dy + x0),
+        <float_t> (ld * dy + hd * dx + y0),
     )
 
 
 @cython.ufunc
-cdef (double, double, double, double) _intersection_circle_line(
+cdef (float_t, float_t, float_t, float_t) _intersection_circle_line(
     float_t x,  # circle
     float_t y,
     float_t r,
@@ -1581,10 +1575,10 @@ cdef (double, double, double, double) _intersection_circle_line(
         return NAN, NAN, NAN, NAN
     rdd = sqrt(rdd)
     return (
-        x + (dd * dy + copysign(1.0, dy) * dx * rdd) / dr,
-        y + (-dd * dx + fabs(dy) * rdd) / dr,
-        x + (dd * dy - copysign(1.0, dy) * dx * rdd) / dr,
-        y + (-dd * dx - fabs(dy) * rdd) / dr,
+        x + <float_t> ((dd * dy + copysign(1.0, dy) * dx * rdd) / dr),
+        y + <float_t> ((-dd * dx + fabs(dy) * rdd) / dr),
+        x + <float_t> ((dd * dy - copysign(1.0, dy) * dx * rdd) / dr),
+        y + <float_t> ((-dd * dx - fabs(dy) * rdd) / dr),
     )
 
 
@@ -1665,7 +1659,7 @@ cdef float_t _blend_lighten(
 
 
 @cython.ufunc
-cdef (double, double, double) _phasor_threshold_open(
+cdef (float_t, float_t, float_t) _phasor_threshold_open(
     float_t mean,
     float_t real,
     float_t imag,
@@ -1727,7 +1721,7 @@ cdef (double, double, double) _phasor_threshold_open(
 
 
 @cython.ufunc
-cdef (double, double, double) _phasor_threshold_closed(
+cdef (float_t, float_t, float_t) _phasor_threshold_closed(
     float_t mean,
     float_t real,
     float_t imag,
@@ -1789,7 +1783,7 @@ cdef (double, double, double) _phasor_threshold_closed(
 
 
 @cython.ufunc
-cdef (double, double, double) _phasor_threshold_mean_open(
+cdef (float_t, float_t, float_t) _phasor_threshold_mean_open(
     float_t mean,
     float_t real,
     float_t imag,
@@ -1809,7 +1803,7 @@ cdef (double, double, double) _phasor_threshold_mean_open(
 
 
 @cython.ufunc
-cdef (double, double, double) _phasor_threshold_mean_closed(
+cdef (float_t, float_t, float_t) _phasor_threshold_mean_closed(
     float_t mean,
     float_t real,
     float_t imag,
@@ -1829,7 +1823,7 @@ cdef (double, double, double) _phasor_threshold_mean_closed(
 
 
 @cython.ufunc
-cdef (double, double, double) _phasor_threshold_nan(
+cdef (float_t, float_t, float_t) _phasor_threshold_nan(
     float_t mean,
     float_t real,
     float_t imag,

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -216,7 +216,7 @@ def graphical_component_analysis(
     >>> graphical_component_analysis(
     ...     [0.6, 0.3], [0.35, 0.38], [0.2, 0.9], [0.4, 0.3], fractions=6
     ... )  # doctest: +NUMBER
-    (array([0, 0, 1, 0, 1, 0]),)
+    (array([0, 0, 1, 0, 1, 0], dtype=uint64),)
 
     Count the number of phasors between the combinations of three components:
 
@@ -227,9 +227,9 @@ def graphical_component_analysis(
     ...     [0.0, 0.4, 0.3],
     ...     fractions=6,
     ... )  # doctest: +NUMBER +NORMALIZE_WHITESPACE
-    (array([0, 1, 1, 1, 1, 0]),
-     array([0, 1, 0, 0, 0, 0]),
-     array([0, 1, 2, 0, 0, 0]))
+    (array([0, 1, 1, 1, 1, 0], dtype=uint64),
+     array([0, 1, 0, 0, 0, 0], dtype=uint64),
+     array([0, 1, 2, 0, 0, 0], dtype=uint64))
 
     """
     real = numpy.asarray(real)
@@ -305,7 +305,7 @@ def graphical_component_analysis(
                         components_imag[3 - i - j],  # c_imag
                         radius,
                     )
-                fraction_counts = numpy.sum(mask)
+                fraction_counts = numpy.sum(mask, dtype=numpy.uint64)
                 component_counts.append(fraction_counts)
 
             counts.append(numpy.asarray(component_counts))

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -3606,6 +3606,28 @@ def test_phasor_threshold():
     )
 
 
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+@pytest.mark.parametrize(
+    'kwargs',
+    [
+        {},
+        {'mean_min': 0.5},
+        {'real_min': 0.5, 'phase_max': 0.7},
+    ],
+)
+def test_phasor_threshold_dtype(dtype, kwargs):
+    """Test phasor_threshold function preserves dtype."""
+    mean, real, imag = phasor_threshold(
+        numpy.asarray([0.5, 0.4], dtype=dtype),
+        numpy.asarray([0.2, 0.5], dtype=dtype),
+        numpy.asarray([0.3, 0.5], dtype=dtype),
+        **kwargs,
+    )
+    assert mean.dtype == dtype
+    assert real.dtype == dtype
+    assert imag.dtype == dtype
+
+
 def test_phasor_threshold_harmonic():
     """Test phasor_threshold function with multiple harmonics."""
     nan = numpy.nan


### PR DESCRIPTION
## Description

This PR bumps the Cython dependency to version 3.1.0b1 (released today), which fixes some long standing bugs relevant to this project:

- https://github.com/cython/cython/pull/6196#issuecomment-2209509572
- https://github.com/cython/cython/issues/6328

Workarounds for Cython<3.1 are removed. Masking operations should now be more efficient and the `phasor_threshold` output data type matches the input type. The output of the `graphical_component_analysis` is explicitly set to `uint64`.

This PR also adds a flag to signal [free-threading](https://docs.python.org/3/howto/free-threading-python.html) compatibility (tested on my Windows system).

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
