### PR TITLE
Add PTU file exported from FLIM_testdata.lif with photon filter

### DIFF
--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -436,6 +436,14 @@ FIGSHARE_22336594_EXPORTED = pooch.create(
             'sha256:'
             'ad0ad6389f38dcba6f9809b54934ef3f19da975d9dabeb4c3a248692b959b9cf'
         ),
+        'FLIM_testdata.lif.filtered.ptu': (
+            'sha256:'
+            'a00b84f626a39e79263322c60ae50b64163b36bb977ecc4dc54619097ba7f5b7'
+        ),
+        'FLIM_testdata.lif.filtered.ptu.zip': (
+            'sha256:'
+            '717366b231213bfd6e295c3efb7bf1bcd90e720eb28aab3223376087172e93e5'
+        ),
     },
 )
 

--- a/tutorials/api/phasorpy_io.py
+++ b/tutorials/api/phasorpy_io.py
@@ -202,25 +202,24 @@ plot_phasor(
 # library.
 #
 # The :py:func:`phasorpy.io.signal_from_ptu` function is used to read
-# the TCSPC histogram from a PTU file exported from the `FLIM_testdata dataset
-# <https://dx.doi.org/10.6084/m9.figshare.22336594.v1>`_ with the
-# Leica LAS X software.
-# By default, the function returns a 5-dimensional image with dimension order
-# TYXCH. Channel and frames are specified to reduce the dimensionality:
+# the TCSPC histogram from a PTU file exported from the `FLIM_testdata LIF
+# dataset <https://dx.doi.org/10.6084/m9.figshare.22336594.v1>`_ with the
+# Leica LAS X software. For phasor analysis, all photons in periods with
+# multiple photons must be discarded before exporting to PTU format.
+# In the LAS X software, select ...(TODO)
+# By default, the PTU reader function returns a 5-dimensional image with
+# dimension order TYXCH. Channel and frames are specified to reduce the
+# dimensionality:
 
 from phasorpy.io import signal_from_ptu
 
-filename = 'FLIM_testdata.lif.ptu'
+filename = 'FLIM_testdata.lif.filtered.ptu'
 
 signal = signal_from_ptu(fetch(filename), channel=0, frame=0, keepdims=False)
 
 plot_signal_image(signal, title=filename, xlabel='delay-time (ns)')
 
 # %%
-# The TCSPC histogram contains more photons than the phasor intensity image
-# stored in the LIF-FLIM file. The LAS X software likely applies a filter to
-# the TCSPC histogram before phasor analysis.
-#
 # The returned ``signal`` is an `xarray.DataArray
 # <https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html>`_
 # holding the TCSPC histogram as a NumPy array, and metadata as a


### PR DESCRIPTION
## Description

This PR adds a PTU file, which was exported by LAS X software from the `FLIM_testdata.lif` file using a filter discarding all photons in periods with multiple photons. The I/O tutorial is updated.

A note describing how/when the filter is applied in LAS X software should be added.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
