### PR TITLE
Fix multi-channel FLIM LABS files containing single-channel phasors

### DIFF
--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -1329,6 +1329,8 @@ def phasor_from_flimlabs_json(
     channels = sorted(channels)
 
     if len(channels) > nchannels:
+        # FLIM LABS phasor files may specify more channels than they
+        # actually contain. Let nchannels >= len(channels) pass
         raise ValueError(f'{len(channels)=} > {nchannels=}')
 
     if isinstance(harmonic, str) and harmonic == 'all':

--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -1328,8 +1328,8 @@ def phasor_from_flimlabs_json(
     harmonics = sorted(harmonics)
     channels = sorted(channels)
 
-    if len(channels) != nchannels:
-        raise ValueError(f'{len(channels)=} != {nchannels=}')
+    if len(channels) > nchannels:
+        raise ValueError(f'{len(channels)=} > {nchannels=}')
 
     if isinstance(harmonic, str) and harmonic == 'all':
         harmonic = harmonics

--- a/src/phasorpy/_io.py
+++ b/src/phasorpy/_io.py
@@ -1312,12 +1312,8 @@ def phasor_from_flimlabs_json(
     header = data['header']
     phasor_data = data['phasors_data']
 
-    nchannels = len([c for c in header['channels'] if c])
-    if channel is not None and (channel < 0 or channel >= nchannels):
-        raise IndexError(f'{channel=}')
-
     harmonics = []
-    channels = []
+    channels = []  # 1-based
     for d in phasor_data:
         h = d['harmonic']
         if h not in harmonics:
@@ -1328,10 +1324,10 @@ def phasor_from_flimlabs_json(
     harmonics = sorted(harmonics)
     channels = sorted(channels)
 
-    if len(channels) > nchannels:
-        # FLIM LABS phasor files may specify more channels than they
-        # actually contain. Let nchannels >= len(channels) pass
-        raise ValueError(f'{len(channels)=} > {nchannels=}')
+    if channel is not None:
+        if channel + 1 not in channels:
+            raise IndexError(f'{channel=}')
+        channel += 1  # 1-based index
 
     if isinstance(harmonic, str) and harmonic == 'all':
         harmonic = harmonics
@@ -1359,11 +1355,13 @@ def phasor_from_flimlabs_json(
         if h not in harmonic_index:
             continue
         h = harmonic_index[h]
-        c = channels.index(d['channel'])
         if channel is not None:
-            if c != channel:
+            if d['channel'] != channel:
                 continue
             c = 0
+        else:
+            c = channels.index(d['channel'])
+
         real[h, c] = numpy.asarray(d['g_data'], dtype)
         imag[h, c] = numpy.asarray(d['s_data'], dtype)
 
@@ -1374,7 +1372,7 @@ def phasor_from_flimlabs_json(
         _flimlabs_mean(
             mean,
             data['intensities_data'],
-            -1 if channel is None else channel,
+            -1 if channel is None else channels.index(channel),
         )
         mean.shape = shape[1:]
         # JSON cannot store NaN values

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -2166,6 +2166,7 @@ def _median_filter_2d(
 # Decoder functions
 
 
+@cython.boundscheck(True)
 def _flimlabs_signal(
     uint_t[:, :, ::] signal,   # channel, pixel, bin
     list data,  # list[list[list[[int, int]]]]
@@ -2173,6 +2174,7 @@ def _flimlabs_signal(
 ):
     """Return TCSPC histogram image from FLIM LABS JSON intensity data."""
     cdef:
+        uint_t[::] signal_
         list channels, pixels
         ssize_t c, i, h, count
 
@@ -2181,18 +2183,21 @@ def _flimlabs_signal(
         for channels in data:
             i = 0
             for pixels in channels:
+                signal_ = signal[c, i]
                 for h, count in pixels:
-                    signal[c, i, h] = <uint_t> count
+                    signal_[h] = <uint_t> count
                 i += 1
             c += 1
     else:
         i = 0
         for pixels in data[channel]:
+            signal_ = signal[0, i]
             for h, count in pixels:
-                signal[0, i, h] = <uint_t> count
+                signal_[h] = <uint_t> count
             i += 1
 
 
+@cython.boundscheck(True)
 def _flimlabs_mean(
     float_t[:, ::] mean,   # channel, pixel
     list data,  # list[list[list[[int, int]]]]
@@ -2200,6 +2205,7 @@ def _flimlabs_mean(
 ):
     """Return mean intensity image from FLIM LABS JSON intensity data."""
     cdef:
+        float_t[::] mean_
         list channels, pixels
         ssize_t c, i, h, count
         double sum
@@ -2207,19 +2213,21 @@ def _flimlabs_mean(
     if channel < 0:
         c = 0
         for channels in data:
+            mean_ = mean[c]
             i = 0
             for pixels in channels:
                 sum = 0.0
                 for h, count in pixels:
                     sum += <double> count
-                mean[c, i] = <float_t> (sum / 256.0)
+                mean_[i] = <float_t> (sum / 256.0)
                 i += 1
             c += 1
     else:
         i = 0
+        mean_ = mean[0]
         for pixels in data[channel]:
             sum = 0.0
             for h, count in pixels:
                 sum += <double> count
-            mean[0, i] = <float_t> (sum / 256.0)
+            mean_[i] = <float_t> (sum / 256.0)
             i += 1

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -366,6 +366,19 @@ def test_signal_from_flimlabs_json_channel():
         signal_from_flimlabs_json(filename, channel=1, dtype=numpy.int8)
 
 
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_phasor_from_flimlabs_json_channel():
+    """Test read FLIM LABS JSON image file."""
+    filename = private_file(
+        'FLIMLABS/convallaria-03_1742566249_phasor_ch1.json'
+    )
+    mean, real, imag, attrs = phasor_from_flimlabs_json(filename)
+    assert attrs['dims'] == ('Y', 'X')
+    assert mean.shape == (247, 245)
+    assert real.shape == (247, 245)
+    assert imag.shape == (247, 245)
+
+
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_signal_from_sdt():
     """Test read Becker & Hickl SDT file."""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -367,16 +367,33 @@ def test_signal_from_flimlabs_json_channel():
 
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
-def test_phasor_from_flimlabs_json_channel():
+@pytest.mark.parametrize('channel', (0, 1))
+def test_phasor_from_flimlabs_json_channel(channel):
     """Test read FLIM LABS JSON phasor file from multi-channel dataset."""
     filename = private_file(
-        'FLIMLABS/convallaria-03_1742566249_phasor_ch1.json'
+        f'FLIMLABS/convallaria-03_1742566249_phasor_ch{channel + 1}.json'
     )
-    mean, real, imag, attrs = phasor_from_flimlabs_json(filename)
-    assert attrs['dims'] == ('Y', 'X')
-    assert mean.shape == (247, 245)
-    assert real.shape == (247, 245)
-    assert imag.shape == (247, 245)
+    for c in (None, channel):
+        mean, real, imag, attrs = phasor_from_flimlabs_json(
+            filename, channel=c
+        )
+        assert attrs['dims'] == ('Y', 'X')
+        assert mean.shape == (247, 245)
+        assert real.shape == (247, 245)
+        assert imag.shape == (247, 245)
+        if channel == 0:
+            assert pytest.approx(mean.mean()) == 0.215034812
+            assert pytest.approx(numpy.nanmean(real)) == 0.5872460
+        else:
+            assert pytest.approx(mean.mean()) == 0.08891675
+            assert pytest.approx(numpy.nanmean(real)) == 0.61652845
+
+    with pytest.raises(IndexError):
+        phasor_from_flimlabs_json(filename, channel=-1)
+    with pytest.raises(IndexError):
+        phasor_from_flimlabs_json(filename, channel=channel + 1)
+    with pytest.raises(IndexError):
+        phasor_from_flimlabs_json(filename, channel=channel - 1)
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -343,7 +343,7 @@ def test_signal_from_flimlabs_json_old():
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
 def test_signal_from_flimlabs_json_channel():
-    """Test read FLIM LABS JSON image file."""
+    """Test read FLIM LABS JSON multi-channel image file."""
     filename = private_file('test03_1733492714_imaging.json')
     signal = signal_from_flimlabs_json(filename)
     assert signal.values.sum(dtype=numpy.uint64) == 4680256
@@ -368,7 +368,7 @@ def test_signal_from_flimlabs_json_channel():
 
 @pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
 def test_phasor_from_flimlabs_json_channel():
-    """Test read FLIM LABS JSON image file."""
+    """Test read FLIM LABS JSON phasor file from multi-channel dataset."""
     filename = private_file(
         'FLIMLABS/convallaria-03_1742566249_phasor_ch1.json'
     )


### PR DESCRIPTION
## Description

This PR fixes reading multi-channel FLIM LABS files containing only single-channel phasor coordinates. 

A multi-channel FLIM LABS dataset was provided, where the header of the "phasor" files indicated the presence of two channels, but the files contain only phasor data for a single channel each. A ValueError was raised in that case.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
