### PR TITLE
Add phasor_to_normal_lifetime function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -768,6 +768,33 @@ cdef (float_t, float_t) _phasor_from_apparent_lifetime(
 
 
 @cython.ufunc
+cdef float_t _phasor_to_normal_lifetime(
+    float_t real,
+    float_t imag,
+    float_t omega,
+) noexcept nogil:
+    """Return normal lifetimes from phasor coordinates."""
+    cdef:
+        double taunorm = INFINITY
+        double t
+
+    if isnan(real) or isnan(imag):
+        return <float_t> NAN
+
+    omega *= omega
+    if omega > 0.0:
+        t = 0.5 * (1.0 + cos(atan2(imag, real - 0.5)))
+        if t <= 0.0:
+            taunorm = INFINITY
+        elif t > 1.0:
+            taunorm = NAN
+        else:
+            taunorm = sqrt((1.0 - t) / (omega * t))
+
+    return <float_t> taunorm
+
+
+@cython.ufunc
 cdef (float_t, float_t) _phasor_from_single_lifetime(
     float_t lifetime,
     float_t omega,

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -30,6 +30,7 @@ from phasorpy.phasor import (
     phasor_threshold,
     phasor_to_apparent_lifetime,
     phasor_to_complex,
+    phasor_to_normal_lifetime,
     phasor_to_polar,
     phasor_to_principal_plane,
     phasor_to_signal,
@@ -370,6 +371,14 @@ def test_polar_to_apparent_lifetime_nan():
         [[1.086834, nan, 0.199609], [3.445806, nan, 19.794646]],
         atol=1e-3,
     )
+
+
+def test_phasor_to_normal_lifetime_nan():
+    """Test phasor_to_normal_lifetime function with NaN values."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        taunorm = phasor_to_normal_lifetime(*VALUES_WITH_NAN[1:], 80)
+    assert_allclose(taunorm, [1.989437, nan, 16.160405], atol=1e-3)
 
 
 def test_two_fractions_from_phasor_nan():

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -46,6 +46,7 @@ from phasorpy.phasor import (
     phasor_threshold,
     phasor_to_apparent_lifetime,
     phasor_to_complex,
+    phasor_to_normal_lifetime,
     phasor_to_polar,
     phasor_to_principal_plane,
     phasor_to_signal,
@@ -2011,6 +2012,50 @@ def test_phasor_calibrate_exceptions():
             harmonic=[1, 2, 3, 4],
             lifetime=4,
         )
+
+
+def test_phasor_to_normal_lifetime():
+    """Test phasor_to_normal_lifetime function."""
+    taunorm = phasor_to_normal_lifetime(
+        [0.5, 0.5, 0, 1, -1.1], [0.5, 0.45, 0, 0, 1.1], frequency=80
+    )
+    assert_allclose(
+        taunorm, [1.989437, 1.989437, math.inf, 0.0, 6.405351], atol=1e-3
+    )
+
+    # verify against phasor_to_apparent_lifetime
+    real, imag = phasor_semicircle(11)
+    expected = phasor_to_apparent_lifetime(real, imag, frequency=80)[0]
+    assert expected[0] == numpy.inf
+    assert expected[-1] == 0.0
+    assert_allclose(
+        phasor_to_normal_lifetime(real, imag, frequency=80),
+        expected,
+        atol=1e-3,
+    )
+
+    phase, modulation = phasor_to_polar(real - 0.5, imag)
+    real, imag = phasor_from_polar(phase, modulation * 0.6)
+    assert_allclose(
+        phasor_to_normal_lifetime(real + 0.5, imag, frequency=80),
+        expected,
+        atol=1e-3,
+    )
+
+    # broadcast, mix dtypes
+    taunorm = phasor_to_normal_lifetime(
+        0.5,
+        numpy.array([0.5, 0.45], dtype=numpy.float32),
+        frequency=numpy.array([[20], [40], [80]], dtype=numpy.int32),
+        #  dtype=numpy.float32
+    )
+    assert taunorm.shape == (3, 2)
+    assert taunorm.dtype == 'float64'
+    assert_allclose(
+        taunorm,
+        [[7.957747, 7.957747], [3.978874, 3.978874], [1.989437, 1.989437]],
+        atol=1e-3,
+    )
 
 
 def test_phasor_to_apparent_lifetime():


### PR DESCRIPTION
## Description

This PR adds the `phasor_to_normal_lifetime` function to the `phasor` module. The "normal lifetime" is another apparent single lifetime, mention first (?) in the [pawFLIM publication](https://pubmed.ncbi.nlm.nih.gov/28649965/).

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
