### PR TITLE
Use importlib to get package versions

### DIFF
--- a/src/phasorpy/version.py
+++ b/src/phasorpy/version.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 __all__ = ['__version__', 'versions']
 
-__version__ = '0.6.dev'
+__version__ = '0.6.dev0'
 
 
 def versions(
@@ -36,6 +36,7 @@ def versions(
     ...
 
     """
+    import importlib.metadata
     import os
     import sys
 
@@ -68,7 +69,11 @@ def versions(
             version_strings.append(f'{module.lower()}{dash}n/a')
             continue
         lib = sys.modules[module]
-        ver = f"{module.lower()}{dash}{getattr(lib, '__version__', 'unknown')}"
+        try:
+            ver = importlib.metadata.version(module)
+        except importlib.metadata.PackageNotFoundError:
+            ver = getattr(lib, '__version__', 'unknown')
+        ver = f'{module.lower()}{dash}{ver}'
         if verbose:
             try:
                 path = getattr(lib, '__file__')


### PR DESCRIPTION
## Description

Use [`importlib.metadata.version`](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.version) to get versions of installed packages. Use package `__version__` attribute as fallback.

Fixes `DeprecationWarning: The '__version__' attribute is deprecated and will be removed in Click 9.1. Use feature detection or 'importlib.metadata.version("click")' instead.`

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
