### PR TITLE
Update reference phasor_from_signal benchmark results

### DIFF
--- a/tutorials/benchmarks/phasorpy_phasor_from_signal.py
+++ b/tutorials/benchmarks/phasorpy_phasor_from_signal.py
@@ -91,7 +91,8 @@ for harmonic in ([1], [1, 2, 3, 4, 5, 6, 7, 8]):
             print_(f'{fft_name}', t)
 
 # %%
-# For reference, the results on a Core i7-14700K CPU, Windows 11::
+# For reference, the results on a Core i7-14700K CPU, Windows 11,
+# Python 3.13.3, numpy 2.2.6, scipy 1.15.3, mkl-fft 1.3.14::
 #
 #     harmonics 1
 #       axis -1


### PR DESCRIPTION
## Description

Update reference phasor_from_signal benchmark results for Python 3.13.3, numpy 2.2.6, scipy 1.15.3, mkl-fft 1.3.14.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
