### PR TITLE
Sort clusters returned by phasor_cluster_gmm

### DIFF
--- a/src/phasorpy/cluster.py
+++ b/src/phasorpy/cluster.py
@@ -46,8 +46,6 @@ def phasor_cluster_gmm(
     extract the parameters of ellipses that represent each cluster according
     to [1]_.
 
-    Clusters are returned in descending order of their elliptic area.
-
     Parameters
     ----------
     real : array_like

--- a/src/phasorpy/cluster.py
+++ b/src/phasorpy/cluster.py
@@ -45,6 +45,8 @@ def phasor_cluster_gmm(
     extract the parameters of ellipses that represent each cluster according
     to [1]_.
 
+    Clusters are returned in descending order of their elliptic area.
+
     Parameters
     ----------
     real : array_like
@@ -161,10 +163,15 @@ def phasor_cluster_gmm(
         radius_major.append(sigma * math.sqrt(2 * eigenvalues[0]))
         radius_minor.append(sigma * math.sqrt(2 * eigenvalues[1]))
 
+    def area(i: int) -> float:
+        return radius_major[i] * radius_minor[i]  # * math.pi
+
+    argsort = sorted(range(len(center_real)), key=area, reverse=True)
+
     return (
-        tuple(center_real),
-        tuple(center_imag),
-        tuple(radius_major),
-        tuple(radius_minor),
-        tuple(angle),
+        tuple(center_real[i] for i in argsort),
+        tuple(center_imag[i] for i in argsort),
+        tuple(radius_major[i] for i in argsort),
+        tuple(radius_minor[i] for i in argsort),
+        tuple(angle[i] for i in argsort),
     )

--- a/src/phasorpy/cluster.py
+++ b/src/phasorpy/cluster.py
@@ -16,7 +16,7 @@ __all__ = ['phasor_cluster_gmm']
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ._typing import Any, ArrayLike
+    from ._typing import Any, ArrayLike, Literal
 
 import math
 
@@ -31,6 +31,7 @@ def phasor_cluster_gmm(
     *,
     sigma: float = 2.0,
     clusters: int = 1,
+    sort: Literal['polar', 'phasor', 'area'] | None = None,
     **kwargs: Any,
 ) -> tuple[
     tuple[float, ...],
@@ -60,6 +61,13 @@ def phasor_cluster_gmm(
     clusters : int, optional
         Number of Gaussian distributions to fit to phasor coordinates.
         Defaults to 1.
+    sort: {'polar', 'phasor', 'area'}, optional
+        Sorting method for output clusters. Defaults to 'polar'.
+
+        - 'polar': Sort by polar coordinates (phase, then modulation).
+        - 'phasor': Sort by phasor coordinates (real, then imaginary).
+        - 'area': Sort by inverse area of ellipse (-major * minor).
+
     **kwargs
         Additional keyword arguments passed to
         :py:class:`sklearn.mixture.GaussianMixture`.
@@ -163,10 +171,33 @@ def phasor_cluster_gmm(
         radius_major.append(sigma * math.sqrt(2 * eigenvalues[0]))
         radius_minor.append(sigma * math.sqrt(2 * eigenvalues[1]))
 
-    def area(i: int) -> float:
-        return radius_major[i] * radius_minor[i]  # * math.pi
+    if clusters == 1:
+        argsort = [0]
+    else:
+        if sort is None or sort == 'polar':
 
-    argsort = sorted(range(len(center_real)), key=area, reverse=True)
+            def sort_key(i: int) -> Any:
+                return (
+                    math.atan2(center_imag[i], center_real[i]),
+                    math.hypot(center_real[i], center_imag[i]),
+                )
+
+        elif sort == 'phasor':
+
+            def sort_key(i: int) -> Any:
+                return center_imag[i], center_real[i]
+
+        elif sort == 'area':
+
+            def sort_key(i: int) -> Any:
+                return -radius_major[i] * radius_minor[i]
+
+        else:
+            raise ValueError(
+                f"invalid {sort=!r} != 'phasor', 'polar', or 'area'"
+            )
+
+        argsort = sorted(range(len(center_real)), key=sort_key)
 
     return (
         tuple(center_real[i] for i in argsort),

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -10,17 +10,18 @@ numpy.random.seed(42)
 
 
 @pytest.mark.parametrize('clusters', [1, 2, 3])
-def test_phasor_cluster_gmm_basic(clusters):
+@pytest.mark.parametrize('sort', ['polar', 'phasor', 'area'])
+def test_phasor_cluster_gmm_basic(clusters, sort):
     real1, imag1 = numpy.random.multivariate_normal(
         [0.2, 0.3], [[3e-3, 1e-3], [1e-3, 1e-3]], 2**15
     ).T
     real2, imag2 = numpy.random.multivariate_normal(
-        [0.4, 0.5], [[2e-3, -1e-3], [-1e-3, 3e-3]], 2**14
+        [0.3, 0.5], [[1e-3, -0.5e-3], [-0.5e-3, 1e-3]], 2**14
     ).T
     real = numpy.concatenate([real1, real2])
     imag = numpy.concatenate([imag1, imag2])
     centers_real, centers_imag, radius_major, radius_minor, angle = (
-        phasor_cluster_gmm(real, imag, clusters=clusters)
+        phasor_cluster_gmm(real, imag, clusters=clusters, sort=sort)
     )
     assert len(centers_real) == clusters
     assert len(centers_imag) == clusters
@@ -28,16 +29,19 @@ def test_phasor_cluster_gmm_basic(clusters):
     assert len(radius_minor) == clusters
     assert len(angle) == clusters
     if clusters == 2:
-        assert_allclose(centers_real, [0.4, 0.2], atol=0.01)
-        assert_allclose(centers_imag, [0.5, 0.3], atol=0.01)
-        assert_allclose(radius_major, [0.17, 0.17], atol=0.01)
-        assert_allclose(radius_minor, [0.105, 0.068], atol=0.01)
-        assert_allclose(angle, [2.11, 0.54], atol=0.2)
+        assert_allclose(centers_real, [0.2, 0.3], atol=0.01)
+        assert_allclose(centers_imag, [0.3, 0.5], atol=0.01)
+        assert_allclose(radius_major, [0.165, 0.108], atol=0.02)
+        assert_allclose(radius_minor, [0.068, 0.063], atol=0.02)
+        assert_allclose(angle, [0.396, 2.369], atol=0.2)
 
 
 def test_phasor_cluster_gmm_invalid_shapes():
     with pytest.raises(ValueError):
         phasor_cluster_gmm([1, 2, 3], [1, 2])
+
+    with pytest.raises(ValueError):
+        phasor_cluster_gmm([1, 2], [1, 2], clusters=2, sort='invalid')
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -12,7 +12,7 @@ numpy.random.seed(42)
 @pytest.mark.parametrize('clusters', [1, 2, 3])
 def test_phasor_cluster_gmm_basic(clusters):
     real1, imag1 = numpy.random.multivariate_normal(
-        [0.2, 0.3], [[3e-3, 1e-3], [1e-3, 2e-3]], 2**15
+        [0.2, 0.3], [[3e-3, 1e-3], [1e-3, 1e-3]], 2**15
     ).T
     real2, imag2 = numpy.random.multivariate_normal(
         [0.4, 0.5], [[2e-3, -1e-3], [-1e-3, 3e-3]], 2**14
@@ -31,7 +31,7 @@ def test_phasor_cluster_gmm_basic(clusters):
         assert_allclose(centers_real, [0.4, 0.2], atol=0.01)
         assert_allclose(centers_imag, [0.5, 0.3], atol=0.01)
         assert_allclose(radius_major, [0.17, 0.17], atol=0.01)
-        assert_allclose(radius_minor, [0.105, 0.105], atol=0.01)
+        assert_allclose(radius_minor, [0.105, 0.068], atol=0.01)
         assert_allclose(angle, [2.11, 0.54], atol=0.2)
 
 


### PR DESCRIPTION
## Description

This PR fixes the order in which clusters are returned by the `phasor_cluster_gmm` function. Clusters are now returned in sorted order, by polar coordinates (default), phasor coordinates, or inverse ellipse area.

In #235, the `test_phasor_cluster_gmm_basic[2]` test started failing because the order of clusters returned by  `phasor_cluster_gmm` changed for unknown reason. 

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
