### PR TITLE
Add phasor_component_fit function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,6 +146,8 @@ class TutorialOrder:
         'fret',
         'lifetime_to_signal',
         'pca',
+        # applications
+        'component_fit',
         # benchmarks
         'phasor_from_signal',
     ]

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1615,6 +1615,17 @@ cdef (float_t, float_t, float_t, float_t) _intersection_circle_line(
 
 
 @cython.ufunc
+cdef float_t _blend_and(
+    float_t a,  # base layer
+    float_t b,  # blend layer
+) noexcept nogil:
+    """Return blended layers using `and` mode."""
+    if isnan(a):
+        return NAN
+    return b
+
+
+@cython.ufunc
 cdef float_t _blend_normal(
     float_t a,  # base layer
     float_t b,  # blend layer

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -327,6 +327,10 @@ def phasor_component_fit(
     linear matrix equation that relates phasor coordinates from one or
     multiple harmonics to component fractions according to [2]_.
 
+    Up to ``2 * number harmonics + 1`` components can be fit to multi-harmonic
+    phasor coordinates, that is up to three components for single harmonic
+    phasor coordinates.
+
     Parameters
     ----------
     mean : array_like

--- a/tutorials/api/phasorpy_components.py
+++ b/tutorials/api/phasorpy_components.py
@@ -126,7 +126,8 @@ plot_histograms(
 # When the phasor coordinates of multiple contributing components are known,
 # their fractional contributions to phasor coordinates can be obtained by
 # solving a linear system of equations, using multiple harmonics if necessary.
-# Fractions are fitted using
+#
+# Fractions of 2 components are fitted using
 # :py:func:`phasorpy.components.phasor_component_fit`
 # and plotted as histograms:
 
@@ -146,6 +147,10 @@ plot_histograms(
     labels=['A', 'B'],
 )
 
+# %%
+# Up to three components can be fit to single harmonics phasor coordinates.
+# The :ref:`sphx_glr_tutorials_applications_phasorpy_component_fit.py`
+# tutorial demonstrates how to fit 5 components using two-harmonics.
 
 # %%
 # Graphical analysis of two components

--- a/tutorials/applications/phasorpy_component_fit.py
+++ b/tutorials/applications/phasorpy_component_fit.py
@@ -1,0 +1,191 @@
+"""
+Multi-component fit
+===================
+
+Spectral unmixing using multi-component analysis in phasor space.
+
+The fluorescent components comprising a fluorescence spectrum can be unmixed
+if the spectra of the individual components are known.
+This can be achieved by solving a system of linear equations, fitting
+the fractional contributions of the phasor coordinates of the component spectra
+to the phasor coordinates of the mixture spectrum. Phasor coordinates
+at multiple harmonics may be used to ensure the linear system is not
+underdetermined.
+
+This analysis method is demonstrated using a hyperspectral imaging dataset
+containing five fluorescent markers as presented in:
+
+  Vallmitjana A, Lepanto P, Irigoin F, and Malacrida L.
+  Phasor-based multi-harmonic unmixing for in-vivo hyperspectral imaging.
+  *Methods Appl Fluoresc*, 11(1): 014001 (2022).
+
+The dataset is available at https://zenodo.org/records/13625087.
+
+The spectral unmixing of the five components is performed using phasor
+coordinates at two harmonics.
+
+"""
+
+# %%
+# Import required modules, functions, and classes:
+
+import numpy
+from matplotlib import pyplot
+
+from phasorpy.components import phasor_component_fit
+from phasorpy.datasets import fetch
+from phasorpy.io import signal_from_lsm
+from phasorpy.phasor import (
+    phasor_center,
+    phasor_filter_median,
+    phasor_from_signal,
+    phasor_threshold,
+)
+from phasorpy.plot import PhasorPlot, plot_image, plot_signal_image
+
+# %%
+# Define dataset and processing parameters:
+
+# hyperspectral image containing of all five components
+samplefile = '38_Hoechst_Golgi_Mito_Lyso_CellMAsk_404_488_561_633_SP.lsm'
+
+# hyperspectral images of individual components
+components = {
+    'Hoechst': 'spectral hoehst.lsm',
+    'LysoTracker': 'spectral lyso tracker green.lsm',
+    'Golgi': 'spectral golgi.lsm',
+    'MitoTracker': 'spectral mito tracker.lsm',
+    'CellMask': 'spectral cell mask.lsm',
+}
+
+# analysis parameters
+harmonic = [1, 2]  # which harmonics to use for analysis
+median_size = 5  # size of median filter window
+median_repeat = 3  # number of times to apply median filter
+threshold = 3  # minimum signal threshold
+
+# %%
+# Individual components
+# ---------------------
+#
+# Calculate and plot phasor coordinates for each component and harmonic.
+# For each component:
+#
+# 1. Load spectral data and calculate phasor coordinates
+# 2. Apply median filtering to reduce noise
+# 3. Apply threshold to remove low-intensity pixels
+# 4. Calculate center coordinates using mean method
+# 5. Plot in phasor space
+
+num_harmonics = len(harmonic)
+num_components = len(components)
+component_real = numpy.zeros((num_harmonics, num_components))
+component_imag = numpy.zeros((num_harmonics, num_components))
+component_mean = []
+
+fig, axs = pyplot.subplots(
+    num_harmonics, 1, figsize=(4.8, num_harmonics * 4.8)
+)
+fig.suptitle('Components')
+
+for i, (name, filename) in enumerate(components.items()):
+    mean, real, imag = phasor_from_signal(
+        signal_from_lsm(fetch(filename)), axis=0, harmonic=harmonic
+    )
+    mean, real, imag = phasor_filter_median(
+        mean, real, imag, size=median_size, repeat=median_repeat
+    )
+    mean, real, imag = phasor_threshold(mean, real, imag, mean_min=threshold)
+    mean, center_real, center_imag = phasor_center(
+        mean, real, imag, method='mean'
+    )
+    component_mean.append(mean)
+    component_real[:, i] = center_real
+    component_imag[:, i] = center_imag
+
+    for j in range(num_harmonics):
+        plot = PhasorPlot(
+            ax=axs[j], allquadrants=True, title=f'Harmonic {harmonic[j]}'
+        )
+        plot.hist2d(real[j], imag[j], cmap='Greys')
+        plot.plot(center_real[j], center_imag[j], label=name, markersize=10)
+        plot.ax.legend(loc='right').set_visible(j == 0)
+fig.tight_layout()
+fig.show()
+
+# %%
+# Component mixture
+# -----------------
+#
+# Read the mixture sample image containing all markers and visualize the
+# raw spectral data:
+
+signal = signal_from_lsm(fetch(samplefile))
+
+plot_signal_image(signal, title='Component mixture')
+
+# %%
+# Calculate and plot phasor coordinates for the component mixture:
+
+mean, real, imag = phasor_from_signal(signal, axis=0, harmonic=harmonic)
+mean, real, imag = phasor_filter_median(
+    mean, real, imag, size=median_size, repeat=median_repeat
+)
+# optional: apply threshold to remove low-intensity pixels
+# mean, real, imag = phasor_threshold(mean, real, imag, mean_min=threshold)
+
+fig, axs = pyplot.subplots(
+    num_harmonics, 1, figsize=(4.8, num_harmonics * 4.8)
+)
+fig.suptitle('Component mixture')
+for i in range(num_harmonics):
+    plot = PhasorPlot(
+        ax=axs[i], allquadrants=True, title=f'Harmonic {harmonic[i]}'
+    )
+    plot.hist2d(real[i], imag[i], cmap='Greys')
+    for j, name in enumerate(components):
+        plot.plot(
+            component_real[i, j],
+            component_imag[i, j],
+            label=name,
+            markersize=10,
+        )
+    plot.ax.legend(loc='right').set_visible(i == 0)
+fig.tight_layout()
+fig.show()
+
+# %%
+# Fractions of components in mixture
+# ----------------------------------
+#
+# Fit fractions of each component to the phasor coordinates at each pixel
+# of the mixture and plot the component fraction images:
+
+fractions = phasor_component_fit(
+    mean, real, imag, component_real, component_imag
+)
+
+plot_image(
+    mean / mean.max(),
+    *fractions,
+    title='Fractions of components in mixture',
+    labels=['Mixture'] + list(components.keys()),
+    vmin=0,
+    vmax=1,
+)
+
+# %%
+# Plot the intensity of each component in the mixture:
+
+plot_image(
+    mean,
+    *(f * mean for f in fractions),
+    title='Intensity of components in mixture',
+    labels=['Mixture'] + list(components.keys()),
+    vmin=0,
+    vmax=mean.max(),
+)
+
+# %%
+# sphinx_gallery_thumbnail_number = -2
+# mypy: allow-untyped-defs, allow-untyped-calls


### PR DESCRIPTION
## Description

This PR adds the `phasor_component_fit` function to the `phasorpy.components` module. 

The function implements the algebraic method to unmix spectra described in [Phasor-based multi-harmonic unmixing for in-vivo hyperspectral imaging](https://doi.org/10.1088/2050-6120/ac9ae9).

The functionality was proposed in #47 and incompletely implemented in #106. 

Compared to #106, this implementation is complete and provides tests and tutorials. The option to accept a pre-calculated `component_matrix` was removed since it complicates the API, exposes function internals, and it does not take significant time to re-create the matrix. I did not quite understand the reason for the special handling of infinite values in #106 and removed it for now.

In a followup PR, I will propose to rename the `two_fractions_from_phasor` and `graphical_component_analysis` functions to `phasor_component_fraction` and `phasor_component_graphical` in order to unify naming in the components module.

This supersedes #106.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
