### PR TITLE
Fix test failing with numpy 2.3.0

### DIFF
--- a/tests/io/test_leica.py
+++ b/tests/io/test_leica.py
@@ -55,7 +55,7 @@ def test_lifetime_from_lif(format):
     for data in (intensity, lifetime, stddev):
         assert data.shape == (1024, 1024)
         assert data.dtype == numpy.float32
-    assert intensity.sum() == 19278548.0
+    assert intensity.sum(dtype=numpy.float64) == 19278552.0
     assert attrs['frequency'] == 19.505
     assert attrs['samples'] == 529
     assert 'harmonic' not in attrs


### PR DESCRIPTION

## Description

Fix a test failing with numpy 2.3.0, first noticed in #238:

```
  ================================== FAILURES ===================================
  _________________________ test_lifetime_from_lif[lif] _________________________
  
  format = 'lif'
  
      @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
      @pytest.mark.parametrize('format', ('lif', 'xlef'))
      def test_lifetime_from_lif(format):
          """Test read lifetime image from Leica LIF file."""
          filename = fetch(f'FLIM_testdata.{format}')
          lifetime, intensity, stddev, attrs = lifetime_from_lif(filename)
          for data in (intensity, lifetime, stddev):
              assert data.shape == (1024, 1024)
              assert data.dtype == numpy.float32
  >       assert intensity.sum() == 19278548.0
  E       assert np.float32(1.9278552e+07) == 19278548.0
  E        +  where np.float32(1.9278552e+07) = <built-in method sum of numpy.ndarray object at 0x000002A03A76A610>()
  E        +    where <built-in method sum of numpy.ndarray object at 0x000002A03A76A610> = array([[ 3.,  0.,  1., ...,  5.,  3., 11.],\n       [ 2.,  6.,  3., ...,  4.,  3.,  2.],\n       [ 1.,  0.,  0., ...,  5....,  0.,  4., ...,  6.,  5.,  6.],\n       [ 1.,  1.,  0., ...,  2.,  1.,  2.]],\n      shape=(1024, 1024), dtype=float32).sum
  
```

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
