### PR TITLE
Rename functions in components module

### DIFF
--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -3,28 +3,29 @@
 The ``phasorpy.components`` module provides functions to:
 
 - calculate fractions of two known components by projecting onto the
-  line between the components (:py:func:`two_fractions_from_phasor`)
+  line between the components (:py:func:`phasor_component_fraction`)
 
 - calculate phasor coordinates of second component if only one is
   known (not implemented)
 
-- calculate fractions of three or four known components by using higher
+- calculate fractions of multiple known components by using higher
   harmonic information (:py:func:`phasor_component_fit`)
 
 - calculate fractions of two or three known components by resolving
-  graphically with histogram (:py:func:`graphical_component_analysis`)
+  graphically with histogram (:py:func:`phasor_component_graphical`)
 
-- blindly resolve fractions of `n` components by using harmonic
-  information (not implemented)
+- blindly resolve fractions of multiple components by using harmonic
+  information (:py:func:`phasor_component_blind`, not implemented)
 
 """
 
 from __future__ import annotations
 
 __all__ = [
-    'two_fractions_from_phasor',
-    'graphical_component_analysis',
+    # phasor_component_blind,
     'phasor_component_fit',
+    'phasor_component_fraction',
+    'phasor_component_graphical',
 ]
 
 import numbers
@@ -45,11 +46,11 @@ from ._phasorpy import (
 from .phasor import phasor_threshold
 
 
-def two_fractions_from_phasor(
+def phasor_component_fraction(
     real: ArrayLike,
     imag: ArrayLike,
-    components_real: ArrayLike,
-    components_imag: ArrayLike,
+    component_real: ArrayLike,
+    component_imag: ArrayLike,
     /,
 ) -> NDArray[Any]:
     """Return fraction of first of two components from phasor coordinates.
@@ -64,9 +65,9 @@ def two_fractions_from_phasor(
         Real component of phasor coordinates.
     imag : array_like
         Imaginary component of phasor coordinates.
-    components_real : array_like, shape (2,)
+    component_real : array_like, shape (2,)
         Real coordinates of first and second components.
-    components_imag : array_like, shape (2,)
+    component_imag : array_like, shape (2,)
         Imaginary coordinates of first and second components.
 
     Returns
@@ -94,39 +95,39 @@ def two_fractions_from_phasor(
 
     Examples
     --------
-    >>> two_fractions_from_phasor(
+    >>> phasor_component_fraction(
     ...     [0.6, 0.5, 0.4], [0.4, 0.3, 0.2], [0.2, 0.9], [0.4, 0.3]
     ... )  # doctest: +NUMBER
     array([0.44, 0.56, 0.68])
 
     """
-    components_real = numpy.asarray(components_real)
-    components_imag = numpy.asarray(components_imag)
-    if components_real.shape != (2,):
-        raise ValueError(f'{components_real.shape=} != (2,)')
-    if components_imag.shape != (2,):
-        raise ValueError(f'{components_imag.shape=} != (2,)')
+    component_real = numpy.asarray(component_real)
+    component_imag = numpy.asarray(component_imag)
+    if component_real.shape != (2,):
+        raise ValueError(f'{component_real.shape=} != (2,)')
+    if component_imag.shape != (2,):
+        raise ValueError(f'{component_imag.shape=} != (2,)')
     if (
-        components_real[0] == components_real[1]
-        and components_imag[0] == components_imag[1]
+        component_real[0] == component_real[1]
+        and component_imag[0] == component_imag[1]
     ):
         raise ValueError('components must have different coordinates')
 
     return _fraction_on_segment(  # type: ignore[no-any-return]
         real,
         imag,
-        components_real[0],
-        components_imag[0],
-        components_real[1],
-        components_imag[1],
+        component_real[0],
+        component_imag[0],
+        component_real[1],
+        component_imag[1],
     )
 
 
-def graphical_component_analysis(
+def phasor_component_graphical(
     real: ArrayLike,
     imag: ArrayLike,
-    components_real: ArrayLike,
-    components_imag: ArrayLike,
+    component_real: ArrayLike,
+    component_imag: ArrayLike,
     /,
     *,
     radius: float = 0.05,
@@ -144,9 +145,9 @@ def graphical_component_analysis(
         Real component of phasor coordinates.
     imag : array_like
         Imaginary component of phasor coordinates.
-    components_real : array_like, shape (2,) or (3,)
+    component_real : array_like, shape (2,) or (3,)
         Real coordinates for two or three components.
-    components_imag : array_like, shape (2,) or (3,)
+    component_imag : array_like, shape (2,) or (3,)
         Imaginary coordinates for two or three components.
     radius : float, optional, default: 0.05
         Radius of cursor.
@@ -168,8 +169,8 @@ def graphical_component_analysis(
     Raises
     ------
     ValueError
-        The array shapes of `real` and `imag`, or `components_real` and
-        `components_imag` do not match.
+        The array shapes of `real` and `imag`, or `component_real` and
+        `component_imag` do not match.
         The number of components is not 2 or 3.
         Fraction values are out of range [0.0, 1.0].
 
@@ -212,14 +213,14 @@ def graphical_component_analysis(
     --------
     Count the number of phasors between two components:
 
-    >>> graphical_component_analysis(
+    >>> phasor_component_graphical(
     ...     [0.6, 0.3], [0.35, 0.38], [0.2, 0.9], [0.4, 0.3], fractions=6
     ... )  # doctest: +NUMBER
     (array([0, 0, 1, 0, 1, 0], dtype=uint64),)
 
     Count the number of phasors between the combinations of three components:
 
-    >>> graphical_component_analysis(
+    >>> phasor_component_graphical(
     ...     [0.4, 0.5],
     ...     [0.2, 0.3],
     ...     [0.0, 0.2, 0.9],
@@ -233,30 +234,30 @@ def graphical_component_analysis(
     """
     real = numpy.asarray(real)
     imag = numpy.asarray(imag)
-    components_real = numpy.asarray(components_real)
-    components_imag = numpy.asarray(components_imag)
+    component_real = numpy.asarray(component_real)
+    component_imag = numpy.asarray(component_imag)
     if (
         real.shape != imag.shape
-        or components_real.shape != components_imag.shape
+        or component_real.shape != component_imag.shape
     ):
         raise ValueError('input array shapes must match')
-    if components_real.ndim != 1:
+    if component_real.ndim != 1:
         raise ValueError(
             'component arrays are not one-dimensional: '
-            f'{components_real.ndim} dimensions found'
+            f'{component_real.ndim} dimensions found'
         )
-    num_components = len(components_real)
+    num_components = len(component_real)
     if num_components not in {2, 3}:
         raise ValueError('number of components must be 2 or 3')
 
     if fractions is None:
         longest_distance = 0
         for i in range(num_components):
-            a_real = components_real[i]
-            a_imag = components_imag[i]
+            a_real = component_real[i]
+            a_imag = component_imag[i]
             for j in range(i + 1, num_components):
-                b_real = components_real[j]
-                b_imag = components_imag[j]
+                b_real = component_real[j]
+                b_imag = component_imag[j]
                 _, _, length = _segment_direction_and_length(
                     a_real, a_imag, b_real, b_imag
                 )
@@ -273,11 +274,11 @@ def graphical_component_analysis(
 
     counts = []
     for i in range(num_components):
-        a_real = components_real[i]
-        a_imag = components_imag[i]
+        a_real = component_real[i]
+        a_imag = component_imag[i]
         for j in range(i + 1, num_components):
-            b_real = components_real[j]
-            b_imag = components_imag[j]
+            b_real = component_real[j]
+            b_imag = component_imag[j]
             ab_real = a_real - b_real
             ab_imag = a_imag - b_imag
 
@@ -300,8 +301,8 @@ def graphical_component_analysis(
                         imag,
                         b_real + f * ab_real,  # cursor_real
                         b_imag + f * ab_imag,  # cursor_imag
-                        components_real[3 - i - j],  # c_real
-                        components_imag[3 - i - j],  # c_imag
+                        component_real[3 - i - j],  # c_real
+                        component_imag[3 - i - j],  # c_imag
                         radius,
                     )
                 fraction_counts = numpy.sum(mask, dtype=numpy.uint64)

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -5,18 +5,18 @@ import pytest
 from numpy.testing import assert_allclose
 
 from phasorpy.components import (
-    graphical_component_analysis,
     phasor_component_fit,
-    two_fractions_from_phasor,
+    phasor_component_fraction,
+    phasor_component_graphical,
 )
 
 numpy.random.seed(42)
 
 
-def test_two_fractions_from_phasor():
-    """Test two_fractions_from_phasor function."""
+def test_phasor_component_fraction():
+    """Test phasor_component_fraction function."""
     assert_allclose(
-        two_fractions_from_phasor(
+        phasor_component_fraction(
             [0.0, 0.5, 0.6, 0.75, 1.0, 1.5],
             [0.0, 0.5, 0.6, 0.75, 1.0, 1.5],
             [0.5, 1.0],
@@ -26,7 +26,7 @@ def test_two_fractions_from_phasor():
         1e-6,
     )
     assert_allclose(
-        two_fractions_from_phasor(
+        phasor_component_fraction(
             [0.2, 0.5, 0.7],
             [0.2, 0.4, 0.3],
             [0.0582399, 0.79830002],
@@ -36,7 +36,7 @@ def test_two_fractions_from_phasor():
         1e-6,
     )
     assert_allclose(
-        two_fractions_from_phasor(
+        phasor_component_fraction(
             [0.0, 0.5, 0.9],
             [0.4, 0.4, 0.6],
             [0.0582399, 0.79830002],
@@ -47,22 +47,22 @@ def test_two_fractions_from_phasor():
     )
 
     with pytest.raises(ValueError):
-        two_fractions_from_phasor([0], [0], [0.1, 0.1], [0.2, 0.2])
+        phasor_component_fraction([0], [0], [0.1, 0.1], [0.2, 0.2])
     with pytest.raises(ValueError):
-        two_fractions_from_phasor([0], [0], [0.3], [0.1, 0.2])
+        phasor_component_fraction([0], [0], [0.3], [0.1, 0.2])
     with pytest.raises(ValueError):
-        two_fractions_from_phasor([0], [0], [0.1, 0.2], [0.3])
+        phasor_component_fraction([0], [0], [0.1, 0.2], [0.3])
     with pytest.raises(ValueError):
-        two_fractions_from_phasor([0], [0], [0.1], [0.3])
+        phasor_component_fraction([0], [0], [0.1], [0.3])
     with pytest.raises(ValueError):
-        two_fractions_from_phasor([0], [0], [0.1, 0.1, 0, 1], [0.1, 0, 2])
+        phasor_component_fraction([0], [0], [0.1, 0.1, 0, 1], [0.1, 0, 2])
 
 
 @pytest.mark.xfail
-def test_two_fractions_from_phasor_channels():
-    """Test two_fractions_from_phasor function for multiple channels."""
+def test_phasor_component_fraction_channels():
+    """Test phasor_component_fraction function for multiple channels."""
     assert_allclose(
-        two_fractions_from_phasor(
+        phasor_component_fraction(
             [[[0.1, 0.2, 0.3]]],
             [[[0.1, 0.2, 0.3]]],
             [[0.2, 0.2, 0.2], [0.9, 0.9, 0.9]],
@@ -77,7 +77,7 @@ def test_two_fractions_from_phasor_channels():
 
 @pytest.mark.parametrize(
     """real, imag,
-    components_real, components_imag,
+    component_real, component_imag,
     radius, fractions,
     expected_counts""",
     [
@@ -177,21 +177,21 @@ def test_two_fractions_from_phasor_channels():
         ),
     ],
 )
-def test_graphical_component_analysis(
+def test_phasor_component_graphical(
     real,
     imag,
-    components_real,
-    components_imag,
+    component_real,
+    component_imag,
     radius,
     fractions,
     expected_counts,
 ):
-    """Test graphical_component_analysis function."""
-    actual_counts = graphical_component_analysis(
+    """Test phasor_component_graphical function."""
+    actual_counts = phasor_component_graphical(
         real,
         imag,
-        components_real,
-        components_imag,
+        component_real,
+        component_imag,
         radius=radius,
         fractions=fractions,
     )
@@ -201,7 +201,7 @@ def test_graphical_component_analysis(
 
 @pytest.mark.parametrize(
     """real, imag,
-    components_real, components_imag,
+    component_real, component_imag,
     fractions
     """,
     [
@@ -209,7 +209,7 @@ def test_graphical_component_analysis(
         ([0], [0, 0], [0, 1], [0, 1], 10),
         # real.shape != imag.shape
         ([0, 0], [0], [0, 1], [0, 1], 10),
-        # components_imag.shape != components_real.shape
+        # component_imag.shape != component_real.shape
         (
             0,
             0,
@@ -217,7 +217,7 @@ def test_graphical_component_analysis(
             [0, 1],
             10,
         ),
-        # components_real.shape != components_imag.shape
+        # component_real.shape != component_imag.shape
         (
             0,
             0,
@@ -251,13 +251,13 @@ def test_graphical_component_analysis(
         ([0, 0], [0, 0], [0, 1], [0, 1], [[0.5], [-0.5]]),
     ],
 )
-def test_errors_graphical_component_analysis(
-    real, imag, components_real, components_imag, fractions
+def test_errors_phasor_component_graphical(
+    real, imag, component_real, component_imag, fractions
 ):
-    """Test errors in graphical_component_analysis function."""
+    """Test errors in phasor_component_graphical function."""
     with pytest.raises(ValueError):
-        graphical_component_analysis(
-            real, imag, components_real, components_imag, fractions=fractions
+        phasor_component_graphical(
+            real, imag, component_real, component_imag, fractions=fractions
         )
 
 

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -9,8 +9,8 @@ from numpy import nan
 from numpy.testing import assert_allclose, assert_array_equal
 
 from phasorpy.components import (
-    graphical_component_analysis,
-    two_fractions_from_phasor,
+    phasor_component_fraction,
+    phasor_component_graphical,
 )
 from phasorpy.cursors import (
     mask_from_circular_cursor,
@@ -381,21 +381,21 @@ def test_phasor_to_normal_lifetime_nan():
     assert_allclose(taunorm, [1.989437, nan, 16.160405], atol=1e-3)
 
 
-def test_two_fractions_from_phasor_nan():
-    """Test two_fractions_from_phasor function with NaN values."""
+def test_phasor_component_fraction_nan():
+    """Test phasor_component_fraction function with NaN values."""
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        fractions = two_fractions_from_phasor(
+        fractions = phasor_component_fraction(
             *VALUES_WITH_NAN[1:], [0.5, 1.0], [0.5, 1.0]
         )
     assert_allclose(fractions, [1.0, nan, 1.0])
 
 
-def test_graphical_component_analysis_nan():
-    """Test graphical_component_analysis function with NaN values."""
+def test_phasor_component_graphical_nan():
+    """Test phasor_component_graphical function with NaN values."""
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        counts = graphical_component_analysis(
+        counts = phasor_component_graphical(
             *VALUES_WITH_NAN[1:],
             [0.0, 0.0, 1.0],
             [0.0, 1.0, 0.0],

--- a/tutorials/api/phasorpy_components.py
+++ b/tutorials/api/phasorpy_components.py
@@ -16,9 +16,9 @@ import numpy
 from matplotlib import pyplot
 
 from phasorpy.components import (
-    graphical_component_analysis,
     phasor_component_fit,
-    two_fractions_from_phasor,
+    phasor_component_fraction,
+    phasor_component_graphical,
 )
 from phasorpy.phasor import phasor_from_lifetime
 from phasorpy.plot import PhasorPlot, plot_histograms
@@ -68,7 +68,7 @@ real, imag = phasor_from_lifetime(
     frequency, component_lifetimes, component_fractions
 )
 
-fraction_of_first_component = two_fractions_from_phasor(
+fraction_of_first_component = phasor_component_fraction(
     real, imag, component_real, component_imag
 )
 
@@ -99,10 +99,10 @@ plot.show()
 # their fractional contributions to phasor coordinates can be calculated by
 # projecting the phasor coordinate onto the line connecting the components.
 # Fractions are calculated using
-# :py:func:`phasorpy.components.two_fractions_from_phasor`
+# :py:func:`phasorpy.components.phasor_component_fraction`
 # and plotted as histograms:
 
-fraction_of_first_component = two_fractions_from_phasor(
+fraction_of_first_component = phasor_component_fraction(
     real, imag, component_real, component_imag
 )
 
@@ -156,7 +156,7 @@ plot_histograms(
 # Graphical analysis of two components
 # ------------------------------------
 #
-# The :py:func:`phasorpy.components.graphical_component_analysis`
+# The :py:func:`phasorpy.components.phasor_component_graphical`
 # function for two components counts the number of phasor coordinates
 # that fall within a radius at given fractions along the line between
 # the components.
@@ -165,7 +165,7 @@ plot_histograms(
 radius = 0.025
 fractions = numpy.linspace(0.0, 1.0, 20)
 
-counts = graphical_component_analysis(
+counts = phasor_component_graphical(
     real,
     imag,
     component_real,
@@ -207,7 +207,7 @@ plot.show()
 # The results of the graphical component analysis are plotted as
 # histograms for each component pair:
 
-counts = graphical_component_analysis(
+counts = phasor_component_graphical(
     real,
     imag,
     component_real,


### PR DESCRIPTION
## Description

This PR proposes to rename two functions in the `phasorpy.components` module as suggested/discussed many times, for example in #206, #215, and #106:

- `two_fractions_from_phasor` -> `phasor_component_fraction`
- `graphical_component_analysis` -> `phasor_component_graphical`

This makes function naming more consistent with other parts of the library, which is especially important when moving to a flat namespace. The `two_fractions_from_phasor` name was misleading since the function returns only a single fraction.

The functions were also changed to use `component_real` and `component_imag` parameter names throughout.

If there are better names for the functions/parameter names in the components module, let's discuss and settle this in this PR.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
