### PR TITLE
Add phasor_semicircle_intersect function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1522,7 +1522,7 @@ cdef (float_t, float_t, float_t) _segment_direction_and_length(
 
 
 @cython.ufunc
-cdef (float_t, float_t, float_t, float_t) _intersection_circle_circle(
+cdef (float_t, float_t, float_t, float_t) _intersect_circle_circle(
     float_t x0,  # circle 0
     float_t y0,
     float_t r0,
@@ -1568,7 +1568,7 @@ cdef (float_t, float_t, float_t, float_t) _intersection_circle_circle(
 
 
 @cython.ufunc
-cdef (float_t, float_t, float_t, float_t) _intersection_circle_line(
+cdef (float_t, float_t, float_t, float_t) _intersect_circle_line(
     float_t x,  # circle
     float_t y,
     float_t r,
@@ -1608,6 +1608,42 @@ cdef (float_t, float_t, float_t, float_t) _intersection_circle_line(
         x + <float_t> ((dd * dy - copysign(1.0, dy) * dx * rdd) / dr),
         y + <float_t> ((-dd * dx - fabs(dy) * rdd) / dr),
     )
+
+
+@cython.ufunc
+cdef (float_t, float_t, float_t, float_t) _intersect_semicircle_line(
+    float_t x0,  # line start
+    float_t y0,
+    float_t x1,  # line end
+    float_t y1,
+) noexcept nogil:
+    """Return coordinates of intersections of line and universal semicircle."""
+    cdef:
+        double dx, dy, dr, dd, rdd
+
+    if isnan(x0) or isnan(x1) or isnan(y0) or isnan(y1):
+        return NAN, NAN, NAN, NAN
+
+    dx = x1 - x0
+    dy = y1 - y0
+    dr = dx * dx + dy * dy
+    dd = (x0 - 0.5) * y1 - (x1 - 0.5) * y0
+    rdd = 0.25 * dr - dd * dd  # discriminant
+    if rdd < 0.0 or dr <= 0.0:
+        # no intersection
+        return NAN, NAN, NAN, NAN
+    rdd = sqrt(rdd)
+    x0 = <float_t> ((dd * dy - copysign(1.0, dy) * dx * rdd) / dr + 0.5)
+    y0 = <float_t> ((-dd * dx - fabs(dy) * rdd) / dr)
+    x1 = <float_t> ((dd * dy + copysign(1.0, dy) * dx * rdd) / dr + 0.5)
+    y1 = <float_t> ((-dd * dx + fabs(dy) * rdd) / dr)
+    if y0 < 0.0:
+        x0 = NAN
+        y0 = NAN
+    if y1 < 0.0:
+        x1 = NAN
+        y1 = NAN
+    return x0, y0, x1, y1
 
 
 ###############################################################################

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -95,6 +95,7 @@ __all__ = [
     'phasor_multiply',
     'phasor_normalize',
     'phasor_semicircle',
+    'phasor_semicircle_intersect',
     'phasor_threshold',
     'phasor_to_apparent_lifetime',
     'phasor_to_complex',
@@ -127,6 +128,7 @@ import numpy
 
 from ._phasorpy import (
     _gaussian_signal,
+    _intersect_semicircle_line,
     _median_filter_2d,
     _phasor_at_harmonic,
     _phasor_divide,
@@ -795,6 +797,65 @@ def phasor_semicircle(
     imag = numpy.sin(arange)
     imag *= 0.5
     return real, imag
+
+
+def phasor_semicircle_intersect(
+    real0: ArrayLike,
+    imag0: ArrayLike,
+    real1: ArrayLike,
+    imag1: ArrayLike,
+    /,
+    **kwargs: Any,
+) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any], NDArray[Any]]:
+    """Return intersection of line through phasors with universal semicircle.
+
+    Return the phasor coordinates of two intersections of the universal
+    semicircle with the line between two phasor coordinates.
+    Return NaN if the line does not intersect the semicircle.
+
+    Parameters
+    ----------
+    real0 : array_like
+        Real component of first set of phasor coordinates.
+    imag0 : array_like
+        Imaginary component of first set of phasor coordinates.
+    real1 : array_like
+        Real component of second set of phasor coordinates.
+    imag1 : array_like
+        Imaginary component of second set of phasor coordinates.
+    **kwargs
+        Optional `arguments passed to numpy universal functions
+        <https://numpy.org/doc/stable/reference/ufuncs.html#ufuncs-kwargs>`_.
+
+    Returns
+    -------
+    real0 : ndarray
+        Real component of first intersect of phasors with semicircle.
+    imag0 : ndarray
+        Imaginary component of first intersect of phasors with semicircle.
+    real0 : ndarray
+        Real component of second intersect of phasors with semicircle.
+    imag0 : ndarray
+        Imaginary component of second intersect of phasors with semicircle.
+
+    Examples
+    --------
+    Calculate two intersects of a line through two phasor coordinates
+    with the universal semicircle:
+
+    >>> phasor_semicircle_intersect(0.2, 0.25, 0.6, 0.25)  # doctest: +NUMBER
+    (0.066, 0.25, 0.933, 0.25)
+
+    The line between two phasor coordinates may not intersect the semicircle
+    at two points:
+
+    >>> phasor_semicircle_intersect(0.2, 0.0, 0.6, 0.25)  # doctest: +NUMBER
+    (nan, nan, 0.817, 0.386)
+
+    """
+    return _intersect_semicircle_line(  # type: ignore[no-any-return]
+        real0, imag0, real1, imag1, **kwargs
+    )
 
 
 def phasor_to_complex(

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -833,9 +833,9 @@ def phasor_semicircle_intersect(
         Real component of first intersect of phasors with semicircle.
     imag0 : ndarray
         Imaginary component of first intersect of phasors with semicircle.
-    real0 : ndarray
+    real1 : ndarray
         Real component of second intersect of phasors with semicircle.
-    imag0 : ndarray
+    imag1 : ndarray
         Imaginary component of second intersect of phasors with semicircle.
 
     Examples

--- a/src/phasorpy/plot.py
+++ b/src/phasorpy/plot.py
@@ -42,7 +42,7 @@ from matplotlib.path import Path
 from matplotlib.patheffects import AbstractPathEffect
 from matplotlib.widgets import Slider
 
-from ._phasorpy import _intersection_circle_circle, _intersection_circle_line
+from ._phasorpy import _intersect_circle_circle, _intersect_circle_line
 from ._utils import (
     dilate_coordinates,
     parse_kwargs,
@@ -790,11 +790,9 @@ class PhasorPlot:
             if _circle_only:
                 return None
             del kwargs['fill']
-            x0, y0, x1, y1 = _intersection_circle_line(
-                x, y, radius, 0, 0, x, y
-            )
+            x0, y0, x1, y1 = _intersect_circle_line(x, y, radius, 0, 0, x, y)
             ax.add_line(Line2D((x0, x1), (y0, y1), **kwargs))
-            x0, y0, x1, y1 = _intersection_circle_circle(
+            x0, y0, x1, y1 = _intersect_circle_circle(
                 0, 0, modulation, x, y, radius
             )
             ax.add_patch(

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -21,8 +21,8 @@ from phasorpy._phasorpy import (
     _distance_from_segment,
     _fraction_on_line,
     _fraction_on_segment,
-    _intersection_circle_circle,
-    _intersection_circle_line,
+    _intersect_circle_circle,
+    _intersect_circle_line,
     _is_inside_circle,
     _is_inside_ellipse,
     _is_inside_ellipse_,
@@ -225,30 +225,30 @@ def test_segment_direction_and_length(segment, expected):
     assert_allclose(_segment_direction_and_length(*segment), expected)
 
 
-def test_intersection_circle_circle():
-    """Test _intersection_circle_circle function."""
+def test_intersect_circle_circle():
+    """Test _intersect_circle_circle function."""
     assert_allclose(
-        _intersection_circle_circle(
+        _intersect_circle_circle(
             0.0, 0.0, math.hypot(0.6, 0.4), 0.6, 0.4, 0.2
         ),
         [0.686791, 0.219813, 0.467055, 0.549418],
         1e-3,
     )
     assert_array_equal(
-        _intersection_circle_circle(0.0, 0.0, 1.0, 0.6, 0.4, 0.2),
+        _intersect_circle_circle(0.0, 0.0, 1.0, 0.6, 0.4, 0.2),
         [nan, nan, nan, nan],
     )
 
 
-def test__intersection_circle_line():
-    """Test _intersection_circle_line function."""
+def test__intersect_circle_line():
+    """Test _intersect_circle_line function."""
     assert_allclose(
-        _intersection_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.4),
+        _intersect_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.4),
         [0.76641, 0.51094, 0.43359, 0.28906],
         1e-3,
     )
     assert_array_equal(
-        _intersection_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.1),
+        _intersect_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.1),
         [nan, nan, nan, nan],
     )
 

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -240,7 +240,7 @@ def test_intersect_circle_circle():
     )
 
 
-def test__intersect_circle_line():
+def test_intersect_circle_line():
     """Test _intersect_circle_line function."""
     assert_allclose(
         _intersect_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.4),

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -43,6 +43,7 @@ from phasorpy.phasor import (
     phasor_multiply,
     phasor_normalize,
     phasor_semicircle,
+    phasor_semicircle_intersect,
     phasor_threshold,
     phasor_to_apparent_lifetime,
     phasor_to_complex,
@@ -735,6 +736,64 @@ def test_phasor_semicircle():
     assert len(real) == 101
     with pytest.raises(ValueError):
         phasor_semicircle(0)
+
+
+def test_phasor_semicircle_intersect():
+    """Test phasor_semicircle_intersect function."""
+    assert_allclose(
+        phasor_semicircle_intersect(
+            [0.2, 0.2, math.nan], [0.25, 0.0, 0.25], 0.6, 0.25
+        ),
+        (
+            [0.066, numpy.nan, numpy.nan],
+            [0.25, numpy.nan, numpy.nan],
+            [0.933, 0.817, numpy.nan],
+            [0.25, 0.386, numpy.nan],
+        ),
+        atol=1e-3,
+    )
+    # reverse order
+    assert_allclose(
+        phasor_semicircle_intersect(
+            0.6, 0.25, [0.2, 0.2, math.nan], [0.25, 0.0, 0.25]
+        ),
+        (
+            [0.933, numpy.nan, numpy.nan],
+            [0.25, numpy.nan, numpy.nan],
+            [0.066, 0.817, numpy.nan],
+            [0.25, 0.386, numpy.nan],
+        ),
+        atol=1e-3,
+    )
+    # no intersection
+    assert_allclose(
+        phasor_semicircle_intersect(0.1, -0.1, 0.9, -0.1),
+        (numpy.nan, numpy.nan, numpy.nan, numpy.nan),
+        atol=1e-3,
+    )
+    # no line
+    assert_allclose(
+        phasor_semicircle_intersect(0.25, 0.25, 0.25, 0.25),
+        (numpy.nan, numpy.nan, numpy.nan, numpy.nan),
+        atol=1e-3,
+    )
+    # tangent
+    assert_allclose(
+        phasor_semicircle_intersect(0.4, 0.5, 0.6, 0.5),
+        (0.5, 0.5, 0.5, 0.5),
+        atol=1e-3,
+    )
+    # lifetime
+    assert_allclose(
+        phasor_semicircle_intersect(
+            *phasor_from_lifetime(80, 4.2),  # single component
+            *phasor_from_lifetime(80, [4.2, 1.1], [1, 1]),  # mixture
+        ),
+        numpy.array(
+            phasor_from_lifetime(80, [4.2, 1.1])  # two single components
+        ).T.flat,
+        atol=1e-4,
+    )
 
 
 def test_phasor_from_polar():

--- a/tutorials/phasorpy_lifetime_geometry.py
+++ b/tutorials/phasorpy_lifetime_geometry.py
@@ -287,16 +287,16 @@ plot.show()
 #   :math:`S` is the distance from the origin to the phasor coordinates.
 # - the **apparent single lifetime from phase** :math:`\tau_{\varphi}`
 #   of the component mixture is the single exponential lifetime corresponding
-#   to the intercept of the universal circle with a line through the origin
+#   to the intersection of the universal circle with a line through the origin
 #   and the phasor coordinates :math:`G` and :math:`S`.
 # - the **apparent single lifetime from modulation** :math:`\tau_{M}`
 #   of the component mixture is the single exponential lifetime corresponding
-#   to the intercept of the universal circle with a circle around the origin
+#   to the intersection of the universal circle with a circle around the origin
 #   of radius equal to the modulation :math:`M`.
 # - the **normal lifetime** :math:`\tau_{N}` of the component mixture
 #   is the single exponential lifetime corresponding to the nearest point on
 #   the universal circle to the phasor coordinates :math:`G` and :math:`S`,
-#   which is the intercept of the universal circle with the line through the
+#   which is the intersection of the universal circle with the line through the
 #   center of the universal circle and the phasor coordinates :math:`G` and
 #   :math:`S`.
 


### PR DESCRIPTION
## Description

This PR adds the `phasor_semicircle_intersect` helper function to the `phasorpy.phasor` module. The function calculates the intersection coordinates of the universal semicircle with the lines between two sets of phasor coordinates. It is implemented as a numpy ufunc in Cython. The function could be used, for example, to calculate a second single exponential lifetime component given the phasor coordinates of a first component and a mixture of both components (see tests).

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
