### PR TITLE
Add private helper functions to mask universal semicircle

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1232,6 +1232,44 @@ _is_near_segment = _is_inside_stadium
 
 
 @cython.ufunc
+cdef unsigned char _is_inside_semicircle(
+    float_t x,  # point
+    float_t y,
+    float_t r,  # distance
+) noexcept nogil:
+    """Return whether point is inside universal semicircle."""
+    if r < 0.0 or isnan(x) or isnan(y):
+        return False
+    if y < -r:
+        return False
+    if y <= 0.0:
+        if x >= 0.0 and x <= 1.0:
+            return True
+        # near endpoints?
+        if x > 0.5:
+            x -= <float_t> 1.0
+        return x * x + y * y <= r * r
+    return hypot(x - 0.5, y) <= r + 0.5
+
+
+@cython.ufunc
+cdef unsigned char _is_near_semicircle(
+    float_t x,  # point
+    float_t y,
+    float_t r,  # distance
+) noexcept nogil:
+    """Return whether point is near universal semicircle."""
+    if r < 0.0 or isnan(x) or isnan(y):
+        return False
+    if y < 0.0:
+        # near endpoints?
+        if x > 0.5:
+            x -= <float_t> 1.0
+        return x * x + y * y <= r * r
+    return fabs(hypot(x - 0.5, y) - 0.5) <= r
+
+
+@cython.ufunc
 cdef unsigned char _is_near_line(
     float_t x,  # point
     float_t y,

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -29,8 +29,10 @@ from phasorpy._phasorpy import (
     _is_inside_polar_rectangle,
     _is_inside_range,
     _is_inside_rectangle,
+    _is_inside_semicircle,
     _is_inside_stadium,
     _is_near_line,
+    _is_near_semicircle,
     _point_on_line,
     _point_on_segment,
     _segment_direction_and_length,
@@ -122,6 +124,42 @@ def test_is_inside_stadium():
         [False],
     )
     assert _is_near_segment is _is_near_segment
+
+
+def test_is_inside_semicircle():
+    """Test _is_inside_semicircle function."""
+    real = [0.0, 0.5, 1.0, 0.5, -0.01, 1.01, 0.5, -0.015, math.nan]
+    imag = [0.0, 0.5, 0.0, 0.25, -0.01, -0.01, -1.0, -0.015, 0.0]
+    assert_array_equal(
+        _is_inside_semicircle(real, imag, 0.02).astype(bool),
+        [True, True, True, True, True, True, False, False, False],
+    )
+    assert_array_equal(
+        _is_inside_semicircle(real, imag, 0.0).astype(bool),
+        [True, True, True, True, False, False, False, False, False],
+    )
+    assert_array_equal(
+        _is_inside_semicircle(real, imag, -0.1).astype(bool),
+        [False, False, False, False, False, False, False, False, False],
+    )
+
+
+def test_is_near_semicircle():
+    """Test _is_near_semicircle function."""
+    real = [0.0, 0.5, 1.0, 0.5, -0.01, 1.01, 0.5, -0.015, math.nan]
+    imag = [0.0, 0.5, 0.0, 0.25, -0.01, -0.01, -1.0, -0.015, 0.0]
+    assert_array_equal(
+        _is_near_semicircle(real, imag, 0.02).astype(bool),
+        [True, True, True, False, True, True, False, False, False],
+    )
+    assert_array_equal(
+        _is_near_semicircle(real, imag, 0.0).astype(bool),
+        [True, True, True, False, False, False, False, False, False],
+    )
+    assert_array_equal(
+        _is_near_semicircle(real, imag, -0.1).astype(bool),
+        [False, False, False, False, False, False, False, False, False],
+    )
 
 
 def test_is_near_line():
@@ -267,8 +305,8 @@ def test_geometric_ufunc_on_grid():
         mask = mask.astype(bool)
         ax.set(
             aspect='equal',
-            xlim=[0, 1],
-            ylim=[0, 1],
+            xlim=[-0.05, 1.05],
+            ylim=[-0.05, 1.05],
             xticks=[],
             yticks=[],
             **kwargs,
@@ -282,8 +320,8 @@ def test_geometric_ufunc_on_grid():
         ax = kwargs.pop('ax') if not show else pyplot.subplot()
         ax.set(
             aspect='equal',
-            xlim=[0, 1],
-            ylim=[0, 1],
+            xlim=[-0.05, 1.05],
+            ylim=[-0.05, 1.05],
             xticks=[],
             yticks=[],
             **kwargs,
@@ -302,10 +340,10 @@ def test_geometric_ufunc_on_grid():
             pyplot.show()
 
     line = (0.25, 0.75, 0.75, 0.25)
-    coords = numpy.linspace(0.0, 1.0, 501)
+    coords = numpy.linspace(-0.05, 1.05, 501)
     real, imag = numpy.meshgrid(coords, coords)
 
-    _, ax = pyplot.subplots(8, 2, figsize=(6.4, 12), layout='constrained')
+    _, ax = pyplot.subplots(9, 2, figsize=(4, 13), layout='constrained')
 
     plot_points(real, imag, title='grid', ax=ax[0, 0])
 
@@ -356,6 +394,12 @@ def test_geometric_ufunc_on_grid():
     plot_mask(real, imag, mask, title='_is_inside_range', ax=ax[7, 0])
 
     plot_points([], [], title='', ax=ax[7, 1])
+
+    mask = _is_near_semicircle(real, imag, 0.02)
+    plot_mask(real, imag, mask, title='_is_near_semicircle', ax=ax[8, 0])
+
+    mask = _is_inside_semicircle(real, imag, 0.02)
+    plot_mask(real, imag, mask, title='_is_inside_semicircle', ax=ax[8, 1])
 
     if show:
         pyplot.show()


### PR DESCRIPTION
## Description

This PR adds two private helper functions (implemented as numpy ufuncs in Cython) to mask phasor coordinates inside or near the universal semicircle with some tolerance:

- _is_inside_semicircle
- _is_near_semicircle

The `test_geometric_ufunc_on_grid` test now produced the following figure:

![Figure_1](https://github.com/user-attachments/assets/9caa3119-5891-43eb-b1c3-196f5d39a8de)


## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
