### PR TITLE
Add private _distance_from_semicircle function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1536,6 +1536,22 @@ cdef float_t _distance_from_line(
 
 
 @cython.ufunc
+cdef float_t _distance_from_semicircle(
+    float_t x,  # point
+    float_t y,
+) noexcept nogil:
+    """Return distance from universal semicircle."""
+    if isnan(x) or isnan(y):
+        return NAN
+    if y < 0.0:
+        # distance to endpoints
+        if x > 0.5:
+            x -= <float_t> 1.0
+        return <float_t> hypot(x, y)
+    return <float_t> fabs(hypot(x - 0.5, y) - 0.5)
+
+
+@cython.ufunc
 cdef (float_t, float_t, float_t) _segment_direction_and_length(
     float_t x0,  # segment start
     float_t y0,

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -19,6 +19,7 @@ from phasorpy._phasorpy import (
     _distance_from_line,
     _distance_from_point,
     _distance_from_segment,
+    _distance_from_semicircle,
     _fraction_on_line,
     _fraction_on_segment,
     _intersect_circle_circle,
@@ -197,6 +198,18 @@ def test_distance_from_segment():
     )
 
 
+def test_distance_from_semicircle():
+    """Test _distance_from_semicircle function."""
+    assert_allclose(
+        _distance_from_semicircle(
+            [0.0, 0.5, 1.0, 0.5, 0.5, 0.0, -0.5, 1.0, nan],
+            [0.0, 0.5, 0.0, 0.25, 0.0, -0.5, 0.0, -0.5, 0.0],
+        ),
+        [0.0, 0.0, 0.0, 0.25, 0.5, 0.5, 0.5, 0.5, nan],
+        atol=1e-6,
+    )
+
+
 def test_fraction_on_line():
     """Test _fraction_on_line function."""
     assert_allclose(
@@ -345,10 +358,13 @@ def test_geometric_ufunc_on_grid():
 
     _, ax = pyplot.subplots(9, 2, figsize=(4, 13), layout='constrained')
 
-    plot_points(real, imag, title='grid', ax=ax[0, 0])
+    # plot_points(real, imag, title='grid', ax=ax[0, 0])
 
     distance = _distance_from_point(real, imag, 0.5, 0.5)
-    plot_image(distance, title='_distance_from_point', ax=ax[0, 1])
+    plot_image(distance, title='_distance_from_point', ax=ax[0, 0])
+
+    distance = _distance_from_semicircle(real, imag)
+    plot_image(distance, title='_distance_from_semicircle', ax=ax[0, 1])
 
     distance = _distance_from_line(real, imag, *line)
     plot_image(distance, title='_distance_from_line', ax=ax[1, 0])


### PR DESCRIPTION
## Description

This PR adds a private `_distance_from_semicircle` function. See also #242.

![image](https://github.com/user-attachments/assets/ca7cb6de-566a-4192-ab55-5bac9d8ac2e4)

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
