### PR TITLE
Support reading variants of SimFCS referenced files

### DIFF
--- a/src/phasorpy/io/_simfcs.py
+++ b/src/phasorpy/io/_simfcs.py
@@ -184,13 +184,13 @@ def phasor_from_simfcs_referenced(
     SimFCS referenced REF and R64 files contain square-shaped phasor
     coordinate images (encoded as phase and modulation) for two harmonics.
     Phasor coordinates from lifetime-resolved signals are calibrated.
-    Variants of referenced files (RE#) written by other software may contain
-    up to eight harmonics and may be uncalibrated.
+    Variants of referenced files (RE<n>) written by other software may
+    contain up to eight harmonics and may be uncalibrated.
 
     Parameters
     ----------
     filename : str or Path
-        Name of SimFCS REF, R64, or RE# file to read.
+        Name of SimFCS REF, R64, or RE<n> file to read.
     harmonic : int or sequence of int, optional
         Harmonic(s) to include in returned phasor coordinates.
         By default, only the first harmonic is returned.
@@ -214,7 +214,7 @@ def phasor_from_simfcs_referenced(
     Raises
     ------
     lfdfiles.LfdfileError
-        File is not a SimFCS REF, R64, or RE# file.
+        File is not a SimFCS REF, R64, or RE<n> file.
 
     See Also
     --------
@@ -241,7 +241,7 @@ def phasor_from_simfcs_referenced(
 
         with lfdfiles.SimfcsR64(filename) as r64:
             data = r64.asarray()
-    elif ext[:3] == '.re':
+    elif ext.startswith('.re') and len(ext) == 4:
         if ext[-1] == 'f':
             num_images = 5
         elif ext[-1].isdigit():
@@ -249,7 +249,7 @@ def phasor_from_simfcs_referenced(
             num_images = int(ext[-1]) * 2 + 1
         else:
             raise ValueError(
-                f'file extension must be .ref, .re#, .r64, not {ext!r}'
+                f'file extension must be .ref, .r64, or .re<n>, not {ext!r}'
             )
         size = os.path.getsize(filename)
         if (
@@ -262,7 +262,7 @@ def phasor_from_simfcs_referenced(
         data = numpy.fromfile(filename, dtype='<f4').reshape((-1, size, size))
     else:
         raise ValueError(
-            f'file extension must be .ref, .re#, .r64, not {ext!r}'
+            f'file extension must be .ref, .r64, or .re<n>, not {ext!r}'
         )
 
     harmonic, keep_harmonic_dim = parse_harmonic(harmonic, data.shape[0] // 2)

--- a/src/phasorpy/io/_simfcs.py
+++ b/src/phasorpy/io/_simfcs.py
@@ -12,6 +12,7 @@ __all__ = [
     'signal_from_z64',
 ]
 
+import math
 import os
 import struct
 import zlib
@@ -180,14 +181,16 @@ def phasor_from_simfcs_referenced(
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any], dict[str, Any]]:
     """Return phasor coordinates and metadata from SimFCS REF or R64 file.
 
-    SimFCS referenced REF and R64 files contain phasor coordinate images
-    (encoded as phase and modulation) for two harmonics.
+    SimFCS referenced REF and R64 files contain square-shaped phasor
+    coordinate images (encoded as phase and modulation) for two harmonics.
     Phasor coordinates from lifetime-resolved signals are calibrated.
+    Variants of referenced files (RE#) written by other software may contain
+    up to eight harmonics and may be uncalibrated.
 
     Parameters
     ----------
     filename : str or Path
-        Name of SimFCS REF or R64 file to read.
+        Name of SimFCS REF, R64, or RE# file to read.
     harmonic : int or sequence of int, optional
         Harmonic(s) to include in returned phasor coordinates.
         By default, only the first harmonic is returned.
@@ -211,7 +214,7 @@ def phasor_from_simfcs_referenced(
     Raises
     ------
     lfdfiles.LfdfileError
-        File is not a SimFCS REF or R64 file.
+        File is not a SimFCS REF, R64, or RE# file.
 
     See Also
     --------
@@ -219,7 +222,7 @@ def phasor_from_simfcs_referenced(
 
     Notes
     -----
-    The implementation is based on the
+    The implementation for reading R64 files is based on the
     `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
 
     Examples
@@ -232,17 +235,35 @@ def phasor_from_simfcs_referenced(
     array([[...]], dtype=float32)
 
     """
-    import lfdfiles
-
     ext = os.path.splitext(filename)[-1].lower()
     if ext == '.r64':
+        import lfdfiles
+
         with lfdfiles.SimfcsR64(filename) as r64:
             data = r64.asarray()
-    elif ext == '.ref':
-        with lfdfiles.SimfcsRef(filename) as ref:
-            data = ref.asarray()
+    elif ext[:3] == '.re':
+        if ext[-1] == 'f':
+            num_images = 5
+        elif ext[-1].isdigit():
+            # non-SimFCS referenced files containing other number of harmonics
+            num_images = int(ext[-1]) * 2 + 1
+        else:
+            raise ValueError(
+                f'file extension must be .ref, .re#, .r64, not {ext!r}'
+            )
+        size = os.path.getsize(filename)
+        if (
+            size > 4294967295
+            or size % (num_images * 4)
+            or not math.sqrt(size // (num_images * 4)).is_integer()
+        ):
+            raise ValueError(f'{filename!r} is not a valid referenced file')
+        size = int(math.sqrt(size // (num_images * 4)))
+        data = numpy.fromfile(filename, dtype='<f4').reshape((-1, size, size))
     else:
-        raise ValueError(f'file extension must be .ref or .r64, not {ext!r}')
+        raise ValueError(
+            f'file extension must be .ref, .re#, .r64, not {ext!r}'
+        )
 
     harmonic, keep_harmonic_dim = parse_harmonic(harmonic, data.shape[0] // 2)
 

--- a/tests/io/test_simfcs.py
+++ b/tests/io/test_simfcs.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 import lfdfiles
 import numpy
 import pytest
-from _conftest import SKIP_FETCH, TempFileName
+from _conftest import SKIP_FETCH, SKIP_PRIVATE, TempFileName, private_file
 from numpy.testing import assert_allclose, assert_almost_equal
 
 from phasorpy.datasets import fetch
@@ -177,6 +177,20 @@ def test_phasor_from_simfcs_referenced_ref():
     with pytest.raises(ValueError):
         phasor_from_simfcs_referenced(filename)
 
+    # wrong extension
+    with TempFileName('empty.ret') as filename:
+        with open(filename, 'wb') as fh:
+            fh.write(b'')
+        with pytest.raises(ValueError):
+            phasor_from_simfcs_referenced(filename)
+
+    # empty file
+    with TempFileName('empty.ref') as filename:
+        with open(filename, 'wb') as fh:
+            fh.write(b'')
+        with pytest.raises(ValueError):
+            phasor_from_simfcs_referenced(filename)
+
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')
 def test_phasor_from_simfcs_referenced_r64():
@@ -205,6 +219,38 @@ def test_phasor_from_simfcs_referenced_r64():
     assert_allclose(
         numpy.nanmean(imag, axis=(1, 2)), [0.32413888, 0.38899058], atol=1e-3
     )
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_phasor_from_simfcs_referenced_re2():
+    """Test phasor_from_simfcs_referenced with RE2 file."""
+    filename = private_file(
+        'Mosaic04_10x3_FOV600_z95_32A1_t06_uncalibrated.re2'
+    )
+    mean, real, imag, attrs = phasor_from_simfcs_referenced(filename)
+    assert mean.dtype == numpy.float32
+    assert mean.shape == (1200, 1200)
+    assert real.shape == (1200, 1200)
+    assert imag.shape == (1200, 1200)
+    assert attrs['dims'] == ('Y', 'X')
+    assert_allclose(numpy.nanmean(mean), 93.36889, atol=1e-3)
+    assert_allclose(numpy.nanmean(real), 0.289324, atol=1e-3)
+    assert_allclose(numpy.nanmean(imag), 0.363937, atol=1e-3)
+
+    for harmonic in ('all', [1, 2]):
+        mean, real, imag, attrs = phasor_from_simfcs_referenced(
+            filename, harmonic=harmonic
+        )
+        assert mean.shape == (1200, 1200)
+        assert real.shape == (2, 1200, 1200)
+        assert imag.shape == (2, 1200, 1200)
+        assert_allclose(numpy.nanmean(mean), 93.36889)
+        assert_allclose(
+            numpy.nanmean(real, axis=(1, 2)), [0.289324, 0.119052], atol=1e-3
+        )
+        assert_allclose(
+            numpy.nanmean(imag, axis=(1, 2)), [0.363937, 0.293647], atol=1e-3
+        )
 
 
 def test_phasor_to_simfcs_referenced():

--- a/tests/io/test_simfcs.py
+++ b/tests/io/test_simfcs.py
@@ -187,7 +187,7 @@ def test_phasor_from_simfcs_referenced_ref():
     # empty file
     with TempFileName('empty.ref') as filename:
         with open(filename, 'wb') as fh:
-            fh.write(b'')
+            fh.write(b'0')
         with pytest.raises(ValueError):
             phasor_from_simfcs_referenced(filename)
 


### PR DESCRIPTION
## Description

The [FLIM and Spectral dataset for GSLab on figshare](https://figshare.com/articles/dataset/FLIM_dataset_for_GSLab/28067108) contains a `.REF` file, `Mosaic04_10x3_FOV600_z95_32A1_t06_uncalibrated.ref`, that stores non-256x256 sized images. Turns out there are [other variants of the SimFCS referenced format](https://github.com/AlexVallmitjana/GSLab/blob/0d450773861393b6a0b407a3390ee06fd706a533/scripts/refread.m#L58-L110) that contain up to 8 harmonics. The harmonics may be uncalibrated, which defeats the purpose of "referenced" files.

This PR adds support for reading such variants. Only a single test file is available. Writing such files will not be implemented. These files are incompatible with SimFCS.

Decoding `.REF` files no longer requires the `lfdfiles` library.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
