### PR TITLE
Remove numpy pin for static code analysis

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,6 +13,7 @@ on:
 
 env:
   MPLBACKEND: agg
+  SKIP_FETCH: 1
 
 jobs:
   build:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -29,7 +29,7 @@ jobs:
       #   uses: docker/setup-qemu-action@v3
       #   with:
       #     platforms: all
-      - uses: pypa/cibuildwheel@v3.0.0
+      - uses: pypa/cibuildwheel@v3.0.1
         env:
           # Building and testing manylinux2014_aarch64 too is slow.
           # See https://github.com/phasorpy/phasorpy/pull/135

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -87,7 +87,7 @@ jobs:
         os: ["ubuntu-22.04", "windows-2022", "macos-13"]
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.0.0
+      - uses: pypa/cibuildwheel@v3.0.1
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
           SKIP_FETCH: 1
@@ -116,7 +116,7 @@ jobs:
   #        uses: docker/setup-qemu-action@v3
   #        with:
   #          platforms: all
-  #      - uses: pypa/cibuildwheel@v3.0.0
+  #      - uses: pypa/cibuildwheel@v3.0.1
   #        env:
   #          CIBW_ARCHS_LINUX: aarch64
   #          CIBW_BUILD_VERBOSITY: 2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -90,6 +90,7 @@ jobs:
       - uses: pypa/cibuildwheel@v3.0.0
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
+          SKIP_FETCH: 1
           CIBW_BUILD_VERBOSITY: 3
           CIBW_BUILD: "cp311-manylinux_x86_64 cp312-win_amd64 cp312-macosx_x86_64"
           CIBW_SKIP:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -144,7 +144,6 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --editable .
           python -m pip install -r requirements_dev.txt
-          python -m pip install -U "numpy<2.2.0"
       - name: Test with black
         run: |
           python -m black --check src/phasorpy tutorials docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,13 +38,13 @@ repos:
       - id: codespell
 
   - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.16.6
+    rev: v0.16.7
     hooks:
       - id: cython-lint
         args: []
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.5.3
+    rev: v3.6.2
     hooks:
       - id: prettier
         args: [--end-of-line=auto]
@@ -72,20 +72,20 @@ repos:
       - id: black
 
   - repo: https://github.com/keewis/blackdoc
-    rev: v0.4.0
+    rev: v0.4.1
     hooks:
       - id: blackdoc
         additional_dependencies: ["black==25.1.0"]
       - id: blackdoc-autoupdate-black
 
 # - repo: https://github.com/PyCQA/flake8
-#   rev: 7.2.0
+#   rev: 7.3.0
 #   hooks:
 #   - id: flake8
 #     additional_dependencies: [flake8-typing-imports, flake8-docstrings]
 
 # - repo: https://github.com/astral-sh/ruff-pre-commit
-#   rev: v0.12.0
+#   rev: v0.12.2
 #   hooks:
 #   - id: ruff
 #     args: [--show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ ignore-words-list = "ba,compiletime,hist,nd,unparseable,HSI"
 [tool.mypy]
 packages = ["phasorpy"]
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
-plugins = ["numpy.typing.mypy_plugin"]
+plugins = []
 enable_error_code = ["ignore-without-code", "redundant-expr", "truthy-bool"]
 strict = true
 warn_unreachable = true

--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -464,7 +464,9 @@ def phasor_component_fit(
     # [real coordinates (for each harmonic)] +
     # [imaginary coordinates (for each harmonic)] +
     # [ones for intensity constraint]
-    coords = numpy.ones((2 * num_harmonics + 1,) + real.shape[1:])
+    coords = numpy.ones(
+        (2 * num_harmonics + 1,) + real.shape[1:]  # type: ignore[union-attr]
+    )
     coords[:num_harmonics] = real
     coords[num_harmonics : 2 * num_harmonics] = imag
 

--- a/src/phasorpy/experimental.py
+++ b/src/phasorpy/experimental.py
@@ -306,7 +306,7 @@ def spectral_vector_denoise(
         denoised, integrated, signal, spectral_vector, sigma, vmin, num_threads
     )
 
-    denoised = denoised.reshape(shape)
+    denoised = denoised.reshape(shape)  # type: ignore[assignment]
     if axis != -1:
         denoised = numpy.moveaxis(denoised, -1, axis)
     return denoised


### PR DESCRIPTION
## Description

This PR removes the `numpy<2.2.0` pin for static code analysis introduced in #159 (closes #158) and addresses some other maintenance issues:

- ignore two new mypy errors
- disable tests that fetch files when building wheels (this frequently caused failed tests)
- update dependencies in pre-commit
- remove deprecated `numpy.typing.mypy_plugin`
- update cibuildwheel to 3.0.1

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
