### PR TITLE
Add phasor_from_component function

### DIFF
--- a/src/phasorpy/components.py
+++ b/src/phasorpy/components.py
@@ -103,7 +103,7 @@ def phasor_from_component(
     if dtype.char not in {'f', 'd'}:
         raise ValueError(f'{dtype=} is not a floating point type')
 
-    fraction = numpy.asarray(fraction, dtype=dtype, copy=True)
+    fraction = numpy.array(fraction, dtype=dtype, copy=True)
     if fraction.ndim < 1:
         raise ValueError(f'{fraction.ndim=} < 1')
     if fraction.shape[axis] < 2:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -8,9 +8,68 @@ from phasorpy.components import (
     phasor_component_fit,
     phasor_component_fraction,
     phasor_component_graphical,
+    phasor_from_component,
 )
+from phasorpy.phasor import phasor_from_lifetime
 
 numpy.random.seed(42)
+
+
+def test_phasor_from_component():
+    """Test phasor_from_component function."""
+    frequency = 40.0
+    lifetime = [0.5, 4.2, 12.0]
+    fraction = numpy.asarray(
+        [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [0.3, 0.5, 0.2],
+            [0.0, 0.6, 0.4],
+            [0.0, 0.0, 0.0],  # NaN
+        ]
+    )
+    known_real, known_imag = phasor_from_lifetime(
+        frequency, lifetime, fraction
+    )
+
+    real, imag = phasor_from_component(
+        known_real[:3], known_imag[:3], fraction, axis=-1
+    )
+    assert_allclose(real, known_real, atol=1e-6)
+    assert_allclose(imag, known_imag, atol=1e-6)
+
+    real, imag = phasor_from_component(
+        known_real[:3], known_imag[:3], fraction, axis=-1, dtype=numpy.float32
+    )
+    assert real.dtype == numpy.float32
+    assert_allclose(real, known_real, atol=1e-6)
+    assert_allclose(imag, known_imag, atol=1e-6)
+
+    with pytest.raises(ValueError):
+        real, imag = phasor_from_component(
+            known_real[:3], known_imag[:3], fraction, axis=-1, dtype='int32'
+        )
+    with pytest.raises(ValueError):
+        phasor_from_component(
+            numpy.ones((2, 2)), numpy.ones((2, 2)), numpy.ones((2, 2))
+        )
+    with pytest.raises(ValueError):
+        phasor_from_component(known_real[:3], known_imag[:3], fraction[0, 0])
+    with pytest.raises(ValueError):
+        phasor_from_component(
+            known_real[:3], known_imag[:3], fraction[:, :1], axis=-1
+        )
+    with pytest.raises(ValueError):
+        phasor_from_component(known_real[:3], known_imag[:3], fraction)
+    with pytest.raises(ValueError):
+        phasor_from_component(
+            known_real[:3], known_imag[:2], fraction, axis=-1
+        )
+    with pytest.raises(ValueError):
+        phasor_from_component(
+            known_real[:2], known_imag[:2], fraction, axis=-1
+        )
 
 
 def test_phasor_component_fraction():

--- a/tutorials/applications/phasorpy_component_fit.py
+++ b/tutorials/applications/phasorpy_component_fit.py
@@ -187,5 +187,17 @@ plot_image(
 )
 
 # %%
+# Assert that the experimental phasor coordinates can approximately be
+# restored from the components' coordinates and fitted fractions:
+
+from phasorpy.components import phasor_from_component
+
+restored_real, restored_imag = phasor_from_component(
+    component_real[0], component_imag[0], fractions, axis=0
+)
+numpy.testing.assert_allclose(restored_real, real[0], atol=1e-3)
+numpy.testing.assert_allclose(restored_imag, imag[0], atol=1e-3)
+
+# %%
 # sphinx_gallery_thumbnail_number = -2
 # mypy: allow-untyped-defs, allow-untyped-calls


### PR DESCRIPTION
## Description

This PR adds a `phasor_from_component` function to the `phasorpy.components` module. The function calculates phasor coordinates from fractional intensities of components using dot product. It is useful for testing/verification and to complement the component API.

Multi-dimensional component arrays (such as would be returned by a `phasor_component_blind` function) are currently not implemented.

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [x] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
