### PR TITLE
Return component fractions as single array

### DIFF
--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -148,7 +148,7 @@ def test_phasor_component_fraction_channels():
             [0.4, 0.3],
             0.05,
             6,
-            ([0, 0, 1, 0, 0, 0],),
+            [0, 0, 1, 0, 0, 0],
         ),
         # Two components, phasors as list. Increase cursor radius.
         (
@@ -158,7 +158,7 @@ def test_phasor_component_fraction_channels():
             [0.4, 0.3],
             0.15,
             [0, 0.2, 0.4, 0.6, 0.8, 1],
-            ([0, 0, 1, 2, 1, 0],),
+            [0, 0, 1, 2, 1, 0],
         ),
         # Two components, phasors as list. Increase number of steps.
         (
@@ -168,7 +168,7 @@ def test_phasor_component_fraction_channels():
             [0.4, 0.3],
             0.05,
             11,
-            ([0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],),
+            [0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 0],
         ),
         # Three components, phasor as scalar
         (
@@ -178,7 +178,7 @@ def test_phasor_component_fraction_channels():
             [0.0, 0.4, 0.3],
             0.05,
             [0, 0.2, 0.4, 0.6, 0.8, 1],
-            ([0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0], [0, 0, 1, 1, 0, 0]),
+            [[0, 0, 0, 1, 0, 0], [0, 0, 0, 1, 0, 0], [0, 0, 1, 1, 0, 0]],
         ),
         # Three components, phasors as list
         (
@@ -188,7 +188,7 @@ def test_phasor_component_fraction_channels():
             [0.0, 0.4, 0.3],
             0.05,
             6,
-            ([0, 1, 1, 1, 0, 0], [0, 1, 0, 1, 0, 0], [0, 0, 2, 1, 0, 0]),
+            [[0, 1, 1, 1, 0, 0], [0, 1, 0, 1, 0, 0], [0, 0, 2, 1, 0, 0]],
         ),
         # Phasor outside semicircle but inside cursor of component 1
         (
@@ -198,7 +198,7 @@ def test_phasor_component_fraction_channels():
             [0.4, 0.4, 0.2],
             0.05,
             5,
-            ([0, 0, 1, 0, 1], [0, 0, 0, 1, 2], [1, 1, 2, 2, 2]),
+            [[0, 0, 1, 0, 1], [0, 0, 0, 1, 2], [1, 1, 2, 2, 2]],
         ),
         # Phasor outside semicircle and outside cursor of component 1
         (
@@ -208,7 +208,7 @@ def test_phasor_component_fraction_channels():
             [0.4, 0.4, 0.2],
             0.05,
             [0, 0.25, 0.5, 0.75, 1],
-            ([0, 0, 1, 0, 0], [0, 0, 0, 1, 1], [0, 0, 1, 1, 1]),
+            [[0, 0, 1, 0, 0], [0, 0, 0, 1, 1], [0, 0, 1, 1, 1]],
         ),
         # Two components no fractions provided
         (
@@ -218,7 +218,7 @@ def test_phasor_component_fraction_channels():
             [0, 0.2],
             0.05,
             None,
-            ([0, 0, 0, 0, 0, 0, 1, 1, 1],),
+            [0, 0, 0, 0, 0, 0, 1, 1, 1],
         ),
         # Three components no fractions provided
         (
@@ -228,11 +228,11 @@ def test_phasor_component_fraction_channels():
             [0, 0.1, 0.2],
             0.05,
             None,
-            (
+            [
                 [0, 0, 0, 0, 0, 0, 1, 1, 1],
                 [0, 0, 0, 0, 0, 0, 1, 1, 1],
                 [1, 1, 1, 1, 1, 1, 1, 1, 1],
-            ),
+            ],
         ),
     ],
 )
@@ -254,8 +254,7 @@ def test_phasor_component_graphical(
         radius=radius,
         fractions=fractions,
     )
-    for actual_count, expected_count in zip(actual_counts, expected_counts):
-        assert_allclose(actual_count, expected_count)
+    assert_allclose(actual_counts, expected_counts)
 
 
 @pytest.mark.parametrize(

--- a/tutorials/api/phasorpy_components.py
+++ b/tutorials/api/phasorpy_components.py
@@ -175,7 +175,7 @@ counts = phasor_component_graphical(
 )
 
 fig, ax = pyplot.subplots()
-ax.plot(fractions, counts[0], '-', label='A vs B')
+ax.plot(fractions, counts, '-', label='A vs B')
 ax.set_title('Graphical analysis of two components')
 ax.set_xlabel('Fraction')
 ax.set_ylabel('Count')


### PR DESCRIPTION
## Description

This PR changes functions in the `phasorpy.components` module to return component fractions/counts as single arrays instead of tuple of arrays, as suggested in #257. This makes the API more symmetric with the `phasor_from_lifetime` and `phasor_from_component` functions. Practically, the only breaking change is that the return value from `phasor_component_graphical` function no longer has an "edge" dimension in case of two components (which is probably an improvement). The PR also improves the dtype of the counts array returned by `phasor_component_graphical` to save memory.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
