### PR TITLE
Use only latest GitHub Actions runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2022]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       # - name: Set up QEMU

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04"]
+        os: ["ubuntu-latest"]
         python-version: ["3.12", "3.13"]
         # 3.11 tested with cibuildwheel
     steps:
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-2022", "macos-13"]
+        os: ["windows-latest", "macos-latest"]
         python-version: ["3.11"]
         # 3.12 tested with cibuildwheel
     steps:
@@ -84,7 +84,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-22.04", "windows-2022", "macos-13"]
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
       - uses: pypa/cibuildwheel@v3.0.1


### PR DESCRIPTION
## Description

This PR updates GitHub Actions workflows to use only the latest runners. This project doesn't use operating system version specific features. Hence there is no need to pin OS versions. macOS 13 runners are deprecated and are closing down later this year.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
