### PR TITLE
Add phasor_component_mvc function

### DIFF
--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -133,7 +133,7 @@ def sort_coordinates(
     real: ArrayLike,
     imag: ArrayLike,
     /,
-    origin: tuple[float, float] | None = None,
+    origin: ArrayLike | None = None,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
     """Return cartesian coordinates sorted counterclockwise around origin.
 
@@ -141,8 +141,9 @@ def sort_coordinates(
     ----------
     real, imag : array_like
         Coordinates to be sorted.
-    origin : (float, float)
+    origin : array_like, optional
         Coordinates around which to sort by angle.
+        By default, sort around the mean of `real` and `imag`.
 
     Returns
     -------
@@ -150,6 +151,7 @@ def sort_coordinates(
         Coordinates sorted by angle.
     indices : ndarray
         Indices used to reorder coordinates.
+        Use ``indices.argsort()`` to get original order.
 
     Examples
     --------
@@ -160,11 +162,15 @@ def sort_coordinates(
     x, y = numpy.atleast_1d(real, imag)
     if x.ndim != 1 or x.shape != y.shape:
         raise ValueError(f'invalid {x.shape=} or {y.shape=}')
-    if x.size < 4:
+    if x.size < 3:
         return x, y, numpy.arange(x.size)
     if origin is None:
-        origin = x.mean(), y.mean()
-    indices = numpy.argsort(numpy.arctan2(y - origin[1], x - origin[0]))
+        ox, oy = x.mean(), y.mean()
+    else:
+        origin = numpy.asarray(origin, dtype=numpy.float64)
+        ox = origin[0]
+        oy = origin[1]
+    indices = numpy.argsort(numpy.arctan2(y - oy, x - ox))
     return x[indices], y[indices], indices
 
 

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -2420,7 +2420,7 @@ def phasor_from_lifetime(
         fraction = numpy.ones_like(lifetime)  # not really used
     else:
         fraction = numpy.atleast_1d(
-            numpy.asarray(fraction, dtype=numpy.float64)
+            numpy.ascontiguousarray(fraction, dtype=numpy.float64)
         )
         if fraction.ndim > 2:
             raise ValueError('fraction must be one- or two-dimensional array')

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -108,9 +108,9 @@ def test_sort_coordinates():
     assert_allclose(i, [2, 3, 1, 0])
 
     x, y, i = sort_coordinates([0, 1, 2], [0, 1, -1])
-    assert_allclose(x, [0, 1, 2])
-    assert_allclose(y, [0, 1, -1])
-    assert_allclose(i, [0, 1, 2])
+    assert_allclose(x, [2, 1, 0])
+    assert_allclose(y, [-1, 1, 0])
+    assert_allclose(i, [2, 1, 0])
 
     with pytest.raises(ValueError):
         sort_coordinates([0, 1, 2, 3], [0, 1, -1])

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -107,6 +107,11 @@ def test_sort_coordinates():
     assert_allclose(y, [-1, 0, 1, 0])
     assert_allclose(i, [2, 3, 1, 0])
 
+    x, y, i = sort_coordinates([0, 1, 2, 3], [0, 1, -1, 0], origin=(3, 0))
+    assert_allclose(x, [2, 3, 1, 0])
+    assert_allclose(y, [-1, 0, 1, 0])
+    assert_allclose(i, [2, 3, 1, 0])
+
     x, y, i = sort_coordinates([0, 1, 2], [0, 1, -1])
     assert_allclose(x, [2, 1, 0])
     assert_allclose(y, [-1, 1, 0])


### PR DESCRIPTION
## Description

This PR adds a `phasor_component_mvc` function to the `phasorpy.components` module. The function calculates mean value coordinates of phasor coordinates for three or more components according to Fuda C and Hormann K. [A new stable method to compute mean value coordinates](https://doi.org/10.1016/j.cagd.2024.102310), *Computer Aided Geometric Design*, 111: 102310 (2024). The core algorithm is implemented in Cython.

For three components, this function returns the same result (the barycentric coordinates) as `phasor_component_fit`. For more than three components, the system is underdetermined and the mean value coordinates represent one of multiple solutions. However, the special properties of the mean value coordinates make them particularly useful for interpolating and visualizing multi-component data. I added the function to the components module even though it is not limited to component analysis of phasor coordinates.

For example, these are the fractions for the 5 component test:

<img width="2000" height="400" alt="Figure_1" src="https://github.com/user-attachments/assets/394bbe99-1ab0-4105-98d3-112c9ff9f97b" />



## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
