### PR TITLE
Add option to specify number of lifetimes in lifetime app

### DIFF
--- a/src/phasorpy/cli.py
+++ b/src/phasorpy/cli.py
@@ -86,6 +86,13 @@ def fret(hide: bool) -> None:
 
 
 @main.command(help='Start interactive lifetime plots.')
+@click.argument(
+    'number_lifetimes',
+    default=2,
+    type=click.IntRange(1, 5),
+    required=False,
+    # help='Number of preconfigured lifetimes.',
+)
 @click.option(
     '-f',
     '--frequency',
@@ -96,7 +103,7 @@ def fret(hide: bool) -> None:
 @click.option(
     '-l',
     '--lifetime',
-    default=(4.0, 1.0),
+    # default=(4.0, 1.0),
     type=float,
     multiple=True,
     required=False,
@@ -118,13 +125,24 @@ def fret(hide: bool) -> None:
     help='Do not show interactive plot.',
 )
 def lifetime(
+    number_lifetimes: int,
     frequency: float | None,
     lifetime: tuple[float, ...],
     fraction: tuple[float, ...],
     hide: bool,
 ) -> None:
     """Lifetime command group."""
+    from .lifetime import phasor_semicircle, phasor_to_normal_lifetime
     from .plot import LifetimePlots
+
+    if not lifetime:
+        if number_lifetimes == 2:
+            lifetime = (4.0, 1.0)
+        else:
+            real, imag = phasor_semicircle(number_lifetimes + 2)
+            lifetime = phasor_to_normal_lifetime(
+                real[1:-1], imag[1:-1], frequency if frequency else 80.0
+            )  # type: ignore[assignment]
 
     plot = LifetimePlots(
         frequency,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,8 @@ def test_lifetime():
     runner = CliRunner()
     result = runner.invoke(main, ['lifetime', '--hide'])
     assert result.exit_code == 0
+    result = runner.invoke(main, ['lifetime', '5', '--hide'])
+    assert result.exit_code == 0
     result = runner.invoke(main, ['lifetime', '-f 60', '-l 4.2', '--hide'])
     assert result.exit_code == 0
     result = runner.invoke(


### PR DESCRIPTION
## Description

This PR adds an argument to the lifetime app that allows to specify a number of predefined lifetimes to be plotted (instead of requiring to explicitly specify all lifetimes). For example, `python -m phasorpy lifetime 5` plots 5 lifetimes.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
