### PR TITLE
Add phasor_to_lifetime_search function for two components

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "macos-latest"]
-        python-version: ["3.12"]
+        python-version: ["3.13"]
         # 3.13 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "macos-latest"]
-        python-version: ["3.11"]
+        python-version: ["3.12"]
         # 3.13 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,7 +72,7 @@ jobs:
           python -m pip install -r requirements_min.txt
       - name: Test with pytest
         run: |
-          python -X dev -m pytest tests/test_lifetime.py
+          python -X dev -m pytest
       - name: Build docs
         run: |
           cd docs

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["windows-latest", "macos-latest"]
-        python-version: ["3.13"]
+        python-version: ["3.11"]
         # 3.13 tested with cibuildwheel
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
           python -m pip install -r requirements_min.txt
       - name: Test with pytest
         run: |
-          python -X dev -m pytest
+          python -m pytest
       - name: Build docs
         run: |
           cd docs

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "macos-13"]
+        os: ["windows-latest", "macos-14"]
         python-version: ["3.11"]
         # 3.13 tested with cibuildwheel
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "macos-14"]
+        os: ["windows-latest", "macos-15"]
         python-version: ["3.11"]
         # 3.13 tested with cibuildwheel
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -72,7 +72,7 @@ jobs:
           python -m pip install -r requirements_min.txt
       - name: Test with pytest
         run: |
-          python -m pytest
+          python -X dev -m pytest
       - name: Build docs
         run: |
           cd docs

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Editable install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --editable .
+          python -m pip install -v -v -v --editable .
           python -m pip install -r requirements_dev.txt
           python -m pip install -r requirements_min.txt
       - name: Print dependency versions
@@ -67,7 +67,7 @@ jobs:
       - name: Editable install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --editable .
+          python -m pip install -v -v -v --editable .
           python -m pip install -r requirements_dev.txt
           python -m pip install -r requirements_min.txt
       - name: Test with pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Editable install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -v -v -v --editable .
+          python -m pip install -v --editable .
           python -m pip install -r requirements_dev.txt
           python -m pip install -r requirements_min.txt
       - name: Print dependency versions
@@ -67,9 +67,8 @@ jobs:
       - name: Editable install
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -v -v -v --editable .
+          python -m pip install -v --editable .
           python -m pip install -r requirements_dev.txt
-          python -m pip install -r requirements_min.txt
       - name: Test with pytest
         run: |
           python -X dev -m pytest

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "macos-latest"]
+        os: ["windows-latest", "macos-13"]
         python-version: ["3.11"]
         # 3.13 tested with cibuildwheel
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "macos-15"]
+        os: ["windows-latest", "macos-latest"]
         python-version: ["3.11"]
         # 3.13 tested with cibuildwheel
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,9 +69,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -v --editable .
           python -m pip install -r requirements_dev.txt
+          python -m pip install -r requirements_min.txt
       - name: Test with pytest
         run: |
-          python -X dev -m pytest
+          python -X dev -m pytest tests/test_lifetime.py
       - name: Build docs
         run: |
           cd docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,4 @@ norecursedirs = [
 skip = "pp* cp37* cp38* cp39* cp310* *musllinux* *i686 *ppc64le *s390x cp39*win*arm64"
 test-requires = ["scikit-learn", "lfdfiles", "sdtfile", "ptufile", "liffile", "pawflim", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
 test-command = "pytest {project}/tests"
+test-environment = "SKIP_FETCH=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,4 +181,3 @@ norecursedirs = [
 skip = "pp* cp37* cp38* cp39* cp310* *musllinux* *i686 *ppc64le *s390x cp39*win*arm64"
 test-requires = ["scikit-learn", "lfdfiles", "sdtfile", "ptufile", "liffile", "pawflim", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
 test-command = "pytest {project}/tests"
-test-environment = "SKIP_FETCH=1"

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1,6 +1,6 @@
 # distutils: language = c
 # cython: language_level = 3
-# cython: boundscheck = False
+# cython: boundscheck = True
 # cython: wraparound = False
 # cython: cdivision = True
 # cython: nonecheck = False
@@ -1801,7 +1801,7 @@ def _lifetime_search_2(
                 g1h1 = (dd * dy + copysign(1.0, dy) * dx * rdd) / dr + 0.5
                 s1h1 = (-dd * dx + fabs(dy) * rdd) / dr
 
-                if s0h1 < 0 or s1h1 < 0:
+                if s0h1 < 0.0 or s1h1 < 0.0:
                     # no other intersection with semicircle
                     break
 

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1,6 +1,6 @@
 # distutils: language = c
 # cython: language_level = 3
-# cython: boundscheck = True
+# cython: boundscheck = False
 # cython: wraparound = False
 # cython: cdivision = True
 # cython: nonecheck = False
@@ -1849,7 +1849,7 @@ def _lifetime_search_2(
             fraction[1, u] = <float_t> f
 
 
-cdef inline double phasor_to_single_lifetime(
+cdef double phasor_to_single_lifetime(
     const double real,
     const double omega_sqr,
 ) noexcept nogil:

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1802,9 +1802,9 @@ def _lifetime_search_2(
                 s1h1 = (-dd * dx + fabs(dy) * rdd) / dr
 
                 # this check is numerically unstable if candidate=1.0
-                # if s0h1 < 0.0 or s1h1 < 0.0:
-                #     # no other intersection with semicircle
-                #     break
+                if s0h1 < 0.0 or s1h1 < 0.0:
+                    # no other intersection with semicircle
+                    continue
 
                 if g0h1 < g1h1:
                     t = g0h1

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1763,8 +1763,8 @@ def _lifetime_search_2(
                 or re2 > 1.0
                 or im1 < 0.0
                 or im2 < 0.0
-                or im1 * im1 > re1 - re1 * re1 + 1e-6
-                or im2 * im2 > re2 - re2 * re2 + 1e-6
+                or im1 * im1 > re1 - re1 * re1 + 1e-9
+                or im2 * im2 > re2 - re2 * re2 + 1e-9
             ):
                 lifetime[0, u] = NAN
                 lifetime[1, u] = NAN

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1763,8 +1763,8 @@ def _lifetime_search_2(
                 or re2 > 1.0
                 or im1 < 0.0
                 or im2 < 0.0
-                or im1 * im1 > re1 - re1 * re1 + 1e-9
-                or im2 * im2 > re2 - re2 * re2 + 1e-9
+                or im1 * im1 > re1 - re1 * re1 + 1e-6
+                or im2 * im2 > re2 - re2 * re2 + 1e-6
             ):
                 lifetime[0, u] = NAN
                 lifetime[1, u] = NAN

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1801,9 +1801,10 @@ def _lifetime_search_2(
                 g1h1 = (dd * dy + copysign(1.0, dy) * dx * rdd) / dr + 0.5
                 s1h1 = (-dd * dx + fabs(dy) * rdd) / dr
 
-                if s0h1 < 0.0 or s1h1 < 0.0:
-                    # no other intersection with semicircle
-                    break
+                # this check is numerically unstable if candidate=1.0
+                # if s0h1 < 0.0 or s1h1 < 0.0:
+                #     # no other intersection with semicircle
+                #     break
 
                 if g0h1 < g1h1:
                     t = g0h1

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1849,7 +1849,7 @@ def _lifetime_search_2(
             fraction[1, u] = <float_t> f
 
 
-cdef double phasor_to_single_lifetime(
+cdef inline double phasor_to_single_lifetime(
     const double real,
     const double omega_sqr,
 ) noexcept nogil:

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -488,10 +488,10 @@ cdef (double, double) _phasor_from_fret_donor(
         return 1.0, 0.0
 
     # phasor of pure donor at frequency
-    real, imag = phasor_from_lifetime(donor_lifetime, omega)
+    real, imag = phasor_from_single_lifetime(donor_lifetime, omega)
 
     # phasor of quenched donor
-    quenched_real, quenched_imag = phasor_from_lifetime(
+    quenched_real, quenched_imag = phasor_from_single_lifetime(
         donor_lifetime * (1.0 - fret_efficiency), omega
     )
 
@@ -555,14 +555,14 @@ cdef (double, double) _phasor_from_fret_acceptor(
         acceptor_background = 0.0
 
     # phasor of pure donor at frequency
-    donor_real, donor_imag = phasor_from_lifetime(donor_lifetime, omega)
+    donor_real, donor_imag = phasor_from_single_lifetime(donor_lifetime, omega)
 
     if fret_efficiency == 0.0:
         quenched_real = donor_real
         quenched_imag = donor_imag
     else:
         # phasor of quenched donor
-        quenched_real, quenched_imag = phasor_from_lifetime(
+        quenched_real, quenched_imag = phasor_from_single_lifetime(
             donor_lifetime * (1.0 - fret_efficiency), omega
         )
 
@@ -580,7 +580,7 @@ cdef (double, double) _phasor_from_fret_acceptor(
         )
 
     # phasor of acceptor at frequency
-    acceptor_real, acceptor_imag = phasor_from_lifetime(
+    acceptor_real, acceptor_imag = phasor_from_single_lifetime(
         acceptor_lifetime, omega
     )
 
@@ -646,9 +646,9 @@ cdef inline (double, double) linear_combination(
     )
 
 
-cdef inline (float_t, float_t) phasor_from_lifetime(
-    float_t lifetime,
-    float_t omega,
+cdef inline (double, double) phasor_from_single_lifetime(
+    const double lifetime,
+    const double omega,
 ) noexcept nogil:
     """Return phasor coordinates from single lifetime component."""
     cdef:
@@ -656,7 +656,7 @@ cdef inline (float_t, float_t) phasor_from_lifetime(
         double mod = 1.0 / sqrt(1.0 + t * t)
         double phi = atan(t)
 
-    return <float_t> (mod * cos(phi)), <float_t> (mod * sin(phi))
+    return mod * cos(phi), mod * sin(phi)
 
 
 ###############################################################################
@@ -1707,7 +1707,159 @@ cdef (float_t, float_t, float_t, float_t) _intersect_semicircle_line(
 
 
 ###############################################################################
-# Special functions
+# Search functions
+
+
+def _lifetime_search_2(
+    float_t[:, ::] lifetime,  # (num_components, pixels)
+    float_t[:, ::] fraction,  # (num_components, pixels)
+    const float_t[:, ::] real,  # (num_components, pixels)
+    const float_t[:, ::] imag,  # (num_components, pixels)
+    const double[::] candidate,  # real coordinates to scan
+    const double omega_sqr,
+    const int num_threads
+):
+    """Find two lifetime components and fractions in harmonic coordinates.
+
+    https://doi.org/10.1021/acs.jpcb.0c06946
+
+    """
+    cdef:
+        ssize_t i, u
+        double re1, im1, re2, im2
+        double g0, g1, g0h1, s0h1, g1h1, s1h1, g0h2, s0h2, g1h2, s1h2
+        double x, y, dx, dy, dr, dd, rdd
+        double dmin, d, f, t
+        ssize_t samples
+
+    if lifetime.shape[0] != 2 or lifetime.shape[1] != real.shape[1]:
+        raise ValueError('lifetime shape invalid')
+    if fraction.shape[0] != 2 or fraction.shape[1] != real.shape[1]:
+        raise ValueError('fraction shape invalid')
+    if real.shape[0] != imag.shape[0] != 2:
+        raise ValueError('phasor harmonics invalid')
+    if real.shape[1] != imag.shape[1]:
+        raise ValueError('phasor size invalid')
+    if candidate.shape[0] < 1:
+        raise ValueError('candidate size < 1')
+
+    samples = candidate.shape[0]
+
+    with nogil, parallel(num_threads=num_threads):
+
+        for u in prange(real.shape[1]):
+            # loop over phasor coordinates
+            re1 = real[0, u]
+            re2 = real[1, u]
+            im1 = imag[0, u]
+            im2 = imag[1, u]
+
+            if (
+                isnan(re1)
+                or isnan(im1)
+                or isnan(re2)
+                or isnan(im2)
+                # outside semicircle?
+                or im1 < 0.0
+                or im2 < 0.0
+                or im1 * im1 > re1 - re1 * re1 + 1e-9
+                or im2 * im2 > re2 - re2 * re2 + 1e-9
+            ):
+                lifetime[0, u] = NAN
+                lifetime[1, u] = NAN
+                fraction[0, u] = NAN
+                fraction[1, u] = NAN
+                continue
+
+            dmin = INFINITY
+            g0 = NAN
+            g1 = NAN
+            f = NAN
+
+            for i in range(samples):
+                # scan first component
+                g0h1 = candidate[i]
+                s0h1 = sqrt(g0h1 - g0h1 * g0h1)
+
+                # second component is intersection of semicircle with line
+                # between first component and phasor coordinate
+                dx = re1 - g0h1
+                dy = im1 - s0h1
+                dr = dx * dx + dy * dy
+                dd = (g0h1 - 0.5) * im1 - (re1 - 0.5) * s0h1
+                rdd = 0.25 * dr - dd * dd  # discriminant
+                if rdd < 0.0 or dr <= 0.0:
+                    # no intersection
+                    g0 = g0h1
+                    g1 = g0h1  # NAN?
+                    f = 1.0
+                    break
+                rdd = sqrt(rdd)
+                g0h1 = (dd * dy - copysign(1.0, dy) * dx * rdd) / dr + 0.5
+                s0h1 = (-dd * dx - fabs(dy) * rdd) / dr
+                g1h1 = (dd * dy + copysign(1.0, dy) * dx * rdd) / dr + 0.5
+                s1h1 = (-dd * dx + fabs(dy) * rdd) / dr
+
+                if s0h1 < 0 or s1h1 < 0:
+                    # no other intersection with semicircle
+                    break
+
+                if g0h1 < g1h1:
+                    t = g0h1
+                    g0h1 = g1h1
+                    g1h1 = t
+                    t = s0h1
+                    s0h1 = s1h1
+                    s1h1 = t
+
+                # second harmonic component coordinates on semicircle
+                g0h2 = g0h1 / (4.0 - 3.0 * g0h1)
+                s0h2 = sqrt(g0h2 - g0h2 * g0h2)
+                g1h2 = g1h1 / (4.0 - 3.0 * g1h1)
+                s1h2 = sqrt(g1h2 - g1h2 * g1h2)
+
+                # distance of phasor coordinates to line between
+                # components at second harmonic
+                # normalize line coordinates
+                dx = g1h2 - g0h2
+                dy = s1h2 - s0h2
+                x = re2 - g0h2
+                y = im2 - s0h2
+                # square of line length
+                t = dx * dx + dy * dy
+                if t == 0.0:
+                    continue
+                # projection of point on line using dot product
+                t = (x * dx + y * dy) / t
+                # square of distance of point to line
+                dx = x - t * dx
+                dy = y - t * dy
+                d = dx * dx + dy * dy
+
+                if d < dmin:
+                    dmin = d
+                    g0 = g0h1
+                    g1 = g1h1
+                    f = t
+
+            lifetime[0, u] = <float_t> phasor_to_single_lifetime(g0, omega_sqr)
+            lifetime[1, u] = <float_t> phasor_to_single_lifetime(g1, omega_sqr)
+            fraction[0, u] = <float_t> (1.0 - f)
+            fraction[1, u] = <float_t> f
+
+
+cdef inline double phasor_to_single_lifetime(
+    const double real,
+    const double omega_sqr,
+) noexcept nogil:
+    """Return single exponential lifetime from real coordinate."""
+    cdef:
+        double t
+
+    if isnan(real) or real < 0.0 or real > 1.0:
+        return NAN
+    t = real * omega_sqr
+    return sqrt((1.0 - real) / t) if t > 0.0 else INFINITY
 
 
 def _nearest_neighbor_2d(
@@ -1757,6 +1909,10 @@ def _nearest_neighbor_2d(
                     dmin = x
                     index = j
             indices[i] = -1 if dmin > distance_max_squared else <int_t> index
+
+
+###############################################################################
+# Interpolation functions
 
 
 def _mean_value_coordinates(

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1730,7 +1730,6 @@ def _lifetime_search_2(
         double g0, g1, g0h1, s0h1, g1h1, s1h1, g0h2, s0h2, g1h2, s1h2
         double x, y, dx, dy, dr, dd, rdd
         double dmin, d, f, t
-        ssize_t samples
 
     if lifetime.shape[0] != 2 or lifetime.shape[1] != real.shape[1]:
         raise ValueError('lifetime shape invalid')
@@ -1742,8 +1741,6 @@ def _lifetime_search_2(
         raise ValueError('phasor size invalid')
     if candidate.shape[0] < 1:
         raise ValueError('candidate size < 1')
-
-    samples = candidate.shape[0]
 
     with nogil, parallel(num_threads=num_threads):
 
@@ -1760,6 +1757,10 @@ def _lifetime_search_2(
                 or isnan(re2)
                 or isnan(im2)
                 # outside semicircle?
+                or re1 < 0.0
+                or re2 < 0.0
+                or re1 > 1.0
+                or re2 > 1.0
                 or im1 < 0.0
                 or im2 < 0.0
                 or im1 * im1 > re1 - re1 * re1 + 1e-9
@@ -1776,7 +1777,7 @@ def _lifetime_search_2(
             g1 = NAN
             f = NAN
 
-            for i in range(samples):
+            for i in range(candidate.shape[0]):
                 # scan first component
                 g0h1 = candidate[i]
                 s0h1 = sqrt(g0h1 - g0h1 * g0h1)

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1609,12 +1609,6 @@ def test_phasor_component_search_exceptions():
 @pytest.mark.parametrize(
     'real, imag, expected_real, expected_imag, expected_fraction',
     [
-        # inside semicircle
-        (
-            *phasor_from_lifetime([80, 160], [0.5, 4.2], [0.3, 0.7]),
-            *phasor_from_lifetime(80, [0.5, 4.2]),
-            [0.3, 0.7],
-        ),
         # infinite lifetime
         ([0, 0], [0, 0], [1, 0], [0, 0], [0, 1]),
         # zero lifetime
@@ -1627,6 +1621,12 @@ def test_phasor_component_search_exceptions():
         # NAN
         ([NAN, 0], [0, 0], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
         ([0, 0], [0, NAN], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
+        # inside semicircle
+        (
+            *phasor_from_lifetime([80, 160], [0.5, 4.2], [0.3, 0.7]),
+            *phasor_from_lifetime(80, [0.5, 4.2]),
+            [0.3, 0.7],
+        ),
     ],
 )
 def test_phasor_to_lifetime_search_two(

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1637,10 +1637,8 @@ def test_phasor_to_lifetime_search_two(
         expected_real, expected_imag, frequency=80.0
     )
     lifetime, fraction = phasor_to_lifetime_search(real, imag, 80.0)
-    print(lifetime)
-    print(fraction)
-    assert_allclose(fraction, expected_fraction, atol=1e-6)
     assert_allclose(lifetime, expected_lifetime, atol=1e-6)
+    assert_allclose(fraction, expected_fraction, atol=1e-6)
 
 
 @pytest.mark.parametrize('exact', [True, False])

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -26,6 +26,7 @@ from phasorpy.lifetime import (
     phasor_semicircle,
     phasor_semicircle_intersect,
     phasor_to_apparent_lifetime,
+    phasor_to_lifetime_search,
     phasor_to_normal_lifetime,
     polar_from_apparent_lifetime,
     polar_from_reference,
@@ -1553,6 +1554,160 @@ def test_phasor_at_harmonic():
         phasor_at_harmonic(0.5, 0, 1)
     with pytest.raises(ValueError):
         phasor_at_harmonic(0.5, 1, 0)
+
+
+def test_phasor_component_search_exceptions():
+    """Test exceptions in phasor_to_lifetime_search function."""
+    real = [0.1, 0.2]
+    imag = [0.4, 0.3]
+    frequency = 60.0
+    phasor_to_lifetime_search(real, imag, frequency)
+
+    # shape mismatch
+    with pytest.raises(ValueError):
+        phasor_to_lifetime_search(real, imag[0], frequency)
+
+    # no harmonics
+    with pytest.raises(ValueError):
+        phasor_to_lifetime_search(real[0], imag[0], frequency)
+
+    # number of components < 2
+    # with pytest.raises(ValueError):
+    #     phasor_to_lifetime_search(real, imag, 1, frequency)
+
+    # number of components does not match harmonics
+    # with pytest.raises(ValueError):
+    #     phasor_to_lifetime_search(real, imag, 3, frequency)
+
+    # samples < 1
+    with pytest.raises(ValueError):
+        phasor_to_lifetime_search(
+            real, imag, frequency, lifetime_range=(0, 1, 2)
+        )
+
+    # samples < 3 for 3 components
+    # with pytest.raises(ValueError):
+    #     phasor_to_lifetime_search(
+    #         [0.1, 0.2, 0.3],
+    #         [0.1, 0.2, 0.3],
+    #         3,
+    #         frequency,
+    #         lifetime_range=(0, 1, 0.5),
+    #     )
+
+    # dtype not float
+    with pytest.raises(ValueError):
+        phasor_to_lifetime_search(real, imag, frequency, dtype=numpy.int32)
+
+    # too many components
+    # with pytest.raises(ValueError):
+    #     phasor_to_lifetime_search(
+    #         [0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1], 4, frequency
+    #     )
+
+
+@pytest.mark.parametrize(
+    'real, imag, expected_real, expected_imag, expected_fraction',
+    [
+        # inside semicircle
+        (
+            *phasor_from_lifetime([80, 160], [0.5, 4.2], [0.3, 0.7]),
+            *phasor_from_lifetime(80, [0.5, 4.2]),
+            [0.3, 0.7],
+        ),
+        # infinite lifetime
+        ([0, 0], [0, 0], [1, 0], [0, 0], [0, 1]),
+        # zero lifetime
+        ([1, 1], [0, 0], [1, 1], [0, 0], [0, 1]),
+        # on semicircle
+        ([0.5, 0.2], [0.5, 0.4], [1, 0.5], [0, 0.5], [0, 1]),
+        # outside semicircle
+        ([0.5, 0.2], [0.6, 10], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
+        ([0.5, 0.2], [0.5, -1], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
+        # NAN
+        ([NAN, 0], [0, 0], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
+        ([0, 0], [0, NAN], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
+    ],
+)
+def test_phasor_to_lifetime_search_two(
+    real, imag, expected_real, expected_imag, expected_fraction
+):
+    """Test phasor_to_lifetime_search function with two components."""
+    expected_lifetime = phasor_to_normal_lifetime(
+        expected_real, expected_imag, frequency=80.0
+    )
+    lifetime, fraction = phasor_to_lifetime_search(real, imag, 80.0)
+    assert_allclose(lifetime, expected_lifetime, atol=1e-6)
+    assert_allclose(fraction, expected_fraction, atol=1e-6)
+
+
+@pytest.mark.parametrize('exact', [True, False])
+def test_phasor_to_lifetime_search_two_distribution(exact):
+    """Test phasor_to_lifetime_search function with two components."""
+    # test that two lifetime components can be recovered from a distribution
+    shape = (256, 256)
+    frequency = 60.0
+    lifetime = [0.5, 4.2]
+    fraction = numpy.empty((*shape, 2))
+    fraction[..., 0] = numpy.random.normal(0.3, 0.01, shape)
+    fraction[..., 1] = 1.0 - fraction[..., 0]
+    fraction = numpy.clip(fraction, 0.0, 1.0)
+
+    real, imag = phasor_from_lifetime(
+        [frequency, 2 * frequency], lifetime, fraction.reshape(-1, 2)
+    )
+    real = real.reshape(2, *shape)
+    imag = imag.reshape(2, *shape)
+    if not exact:
+        # add noise to the imaginary parts
+        imag += numpy.random.normal(0.0, 0.005, (2, *shape))
+        dtype = 'float32'
+        atol = 5e-2
+    else:
+        dtype = 'float64'
+        atol = 1e-3
+
+    lifetimes, fractions = phasor_to_lifetime_search(
+        real,
+        imag,
+        frequency=frequency,
+        lifetime_range=(0.4, 2.0, 0.01),
+        dtype=dtype,
+        num_threads=2,
+    )
+
+    component_real, component_imag = phasor_from_lifetime(
+        frequency, lifetimes.reshape(-1)
+    )
+    component_real = component_real.reshape(2, *shape)
+    component_imag = component_imag.reshape(2, *shape)
+    # _plot(frequency, real, imag, component_real, component_imag)
+
+    assert_allclose(lifetimes[0].mean(), lifetime[0], atol=atol)
+    assert_allclose(lifetimes[1].mean(), lifetime[1], atol=atol)
+    assert_allclose(fractions[0].mean(), 0.3, atol=1e-3)
+    assert_allclose(fractions[1].mean(), 0.7, atol=1e-3)
+
+
+def _plot(frequency, real, imag, component_real=None, component_imag=None):
+    # helper function to visualize lifetime component distribution results
+    from phasorpy.plot import PhasorPlot
+
+    pp = PhasorPlot(frequency=frequency, allquadrants=False)
+    if real.size > 100:
+        for i in range(real.shape[0]):
+            pp.hist2d(real[i], imag[i], cmap='Greys')
+    else:
+        pp.plot(real, imag)
+    if component_real is not None and component_imag is not None:
+        cmap = 'Reds', 'Greens', 'Blues'
+        for i in range(component_real.shape[0]):
+            pp.hist2d(component_real[i], component_imag[i], cmap=cmap[i])
+            pp.plot(
+                numpy.nanmean(component_real[i]),
+                numpy.nanmean(component_imag[i]),
+            )
+    pp.show()
 
 
 # mypy: allow-untyped-defs, allow-untyped-calls

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1609,6 +1609,12 @@ def test_phasor_component_search_exceptions():
 @pytest.mark.parametrize(
     'real, imag, expected_real, expected_imag, expected_fraction',
     [
+        # inside semicircle
+        (
+            *phasor_from_lifetime([80, 160], [0.5, 4.2], [0.3, 0.7]),
+            *phasor_from_lifetime(80, [0.5, 4.2]),
+            [0.3, 0.7],
+        ),
         # infinite lifetime
         ([0, 0], [0, 0], [1, 0], [0, 0], [0, 1]),
         # zero lifetime
@@ -1621,12 +1627,6 @@ def test_phasor_component_search_exceptions():
         # NAN
         ([NAN, 0], [0, 0], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
         ([0, 0], [0, NAN], [NAN, NAN], [NAN, NAN], [NAN, NAN]),
-        # inside semicircle
-        (
-            *phasor_from_lifetime([80, 160], [0.5, 4.2], [0.3, 0.7]),
-            *phasor_from_lifetime(80, [0.5, 4.2]),
-            [0.3, 0.7],
-        ),
     ],
 )
 def test_phasor_to_lifetime_search_two(
@@ -1637,8 +1637,10 @@ def test_phasor_to_lifetime_search_two(
         expected_real, expected_imag, frequency=80.0
     )
     lifetime, fraction = phasor_to_lifetime_search(real, imag, 80.0)
-    assert_allclose(lifetime, expected_lifetime, atol=1e-6)
+    print(lifetime)
+    print(fraction)
     assert_allclose(fraction, expected_fraction, atol=1e-6)
+    assert_allclose(lifetime, expected_lifetime, atol=1e-6)
 
 
 @pytest.mark.parametrize('exact', [True, False])


### PR DESCRIPTION
## Description

This PR adds a `phasor_to_lifetime_search` function to the `phasorpy.lifetime` module.

It is an alternative implementation to #251. See also #47.

The function returns phasor coordinates and fractional intensities of two single lifetime components from a set of multi-harmonic phasor coordinates using the graphical approach described in:

Vallmitjana A, Torrado B, Dvornikov A, Ranjit S, and Gratton E. 
[Blind resolution of lifetime components in individual pixels of fluorescence lifetime images using the phasor approach](https://doi.org/10.1021/acs.jpcb.0c06946).
J Phys Chem B, 124(45): 10126-10137 (2020)

Currently only the two component graphical method is implemented. A straightforward implementation of the three component method (part of #251) was found impractical and needs to be revised (in another PR).

## Checklist

- [x] The pull request title and description are concise.
- [x] Related issues are linked in the description.
- [x] New dependencies are explained.
- [x] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [x] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [x] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [x] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [x] No files other than source code, documentation, and project settings are added to the repository.
