### PR TITLE
Drop support for numpy 1.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,3 +181,4 @@ norecursedirs = [
 skip = "pp* cp37* cp38* cp39* cp310* *musllinux* *i686 *ppc64le *s390x cp39*win*arm64"
 test-requires = ["scikit-learn", "lfdfiles", "sdtfile", "ptufile", "liffile", "pawflim", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
 test-command = "pytest {project}/tests"
+test-environment = "SKIP_FETCH=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dynamic = ["version"]
 dependencies = [
     # sync with requirements_min.txt
     # https://scientific-python.org/specs/spec-0000/
-    "numpy>=1.25.0",
+    "numpy>=1.26.0",
     "matplotlib>=3.8.0",
     "scipy>=1.11.0",
     "click",

--- a/requirements_min.txt
+++ b/requirements_min.txt
@@ -1,6 +1,6 @@
 # Minimum version requirements for the PhasorPy library
 #
-numpy==1.25.2; python_version == "3.11"
+numpy==1.26.4; python_version == "3.11"
 matplotlib==3.8.4; python_version == "3.11"
 pandas==2.1.4; python_version == "3.11"
 scipy==1.11.4; python_version == "3.11"


### PR DESCRIPTION
## Description

Drop support for numpy 1.25, conforming with [SPEC0](https://scientific-python.org/specs/spec-0000/).

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
