### PR TITLE
Fix PhasorPlot.polar_cursor at origin

### DIFF
--- a/src/phasorpy/plot/_phasorplot.py
+++ b/src/phasorpy/plot/_phasorplot.py
@@ -791,6 +791,8 @@ class PhasorPlot:
             ax.add_patch(Circle((x, y), radius, **kwargs))
             if _circle_only:
                 return None
+            if abs(x) < 1e-6 and abs(y) < 1e-6:
+                return None
             del kwargs['fill']
             x0, y0, x1, y1 = _intersect_circle_line(x, y, radius, 0, 0, x, y)
             ax.add_line(Line2D((x0, x1), (y0, y1), **kwargs))

--- a/tests/plot/test_phasorplot.py
+++ b/tests/plot/test_phasorplot.py
@@ -238,6 +238,7 @@ class TestPhasorPlot:
         plot.polar_cursor(0.5236, 0.6, 0.1963, 0.8, color='tab:orange')
         plot.polar_cursor(0.3233, 0.9482, radius=0.05, color='tab:green')
         plot.polar_cursor(0.3, color='tab:red', linestyle='--')
+        plot.polar_cursor(0.0, 0.0, radius=0.1, linestyle='-')
         self.show(plot)
 
     def test_polar_cursor_allquadrants(self):


### PR DESCRIPTION
## Description

This PR fixes an exception when a `PhasorPlot.polar_cursor` is positioned at the origin:

```Python traceback
>>> PhasorPlot().polar_cursor(0, 0, radius=1)
Traceback (most recent call last):
  File "<python-input-3>", line 1, in <module>
    PhasorPlot().polar_cursor(0, 0, radius=1)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "X:\Python313\Lib\site-packages\phasorpy\plot\_phasorplot.py", line 776, in polar_cursor
    Arc(
    ~~~^
        (0, 0),
        ^^^^^^^
    ...<5 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "X:\Python313\Lib\site-packages\matplotlib\patches.py", line 2064, in __init__
    self._path = Path.arc(self._theta1, self._theta2)
                 ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "X:\Python313\Lib\site-packages\matplotlib\path.py", line 982, in arc
    n = int(2 ** np.ceil((eta2 - eta1) / halfpi))
ValueError: cannot convert float NaN to integer
```

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
