### PR TITLE
Add signal_from_pqbin function

### DIFF
--- a/src/phasorpy/io/__init__.py
+++ b/src/phasorpy/io/__init__.py
@@ -8,6 +8,7 @@ The ``phasorpy.io`` module provides functions to:
   - :py:func:`signal_from_lif` - Leica LIF and XLEF
   - :py:func:`signal_from_lsm` - Zeiss LSM
   - :py:func:`signal_from_ptu` - PicoQuant PTU
+  - :py:func:`signal_from_pqbin` - PicoQuant BIN
   - :py:func:`signal_from_sdt` - Becker & Hickl SDT
   - :py:func:`signal_from_fbd` - FLIMbox FBD
   - :py:func:`signal_from_flimlabs_json` - FLIM LABS JSON

--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -8,11 +8,13 @@ __all__ = [
     'phasor_from_ifli',
     'signal_from_imspector_tiff',
     'signal_from_lsm',
+    'signal_from_pqbin',
     'signal_from_ptu',
     'signal_from_sdt',
 ]
 
 import os
+import struct
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree
 
@@ -783,6 +785,101 @@ def signal_from_flif(
         attrs['ref_mod'] = float(flif.header.measured_mod)
         attrs['ref_tauphase'] = float(flif.header.ref_tauphase)
         attrs['ref_taumod'] = float(flif.header.ref_taumod)
+
+    from xarray import DataArray
+
+    return DataArray(data, **metadata)
+
+
+def signal_from_pqbin(
+    filename: str | PathLike[Any],
+    /,
+) -> DataArray:
+    """Return TCSPC histogram and metadata from PicoQuant BIN file.
+
+    PicoQuant BIN files contain TCSPC histograms with limited metadata.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of PicoQuant BIN file to read.
+
+    Returns
+    -------
+    xarray.DataArray
+        TCSPC histogram with :ref:`axes codes <axes>` ``'YXH'``,
+        and type ``uint32``.
+
+        - ``coords['H']``: delay-times of histogram bins in ns.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+          This assumes that the histogram contains exactly one period.
+
+    Raises
+    ------
+    ValueError
+        File is not a PicoQuant BIN file.
+
+    Examples
+    --------
+    >>> signal = signal_from_pqbin('picoquant.bin')  # doctest: +SKIP
+    >>> signal.values  # doctest: +SKIP
+    array(...)
+    >>> signal.dtype  # doctest: +SKIP
+    dtype('uint32')
+    >>> signal.shape  # doctest: +SKIP
+    (256, 256, 2000)
+    >>> signal.dims  # doctest: +SKIP
+    ('Y', 'X', 'H')
+    >>> signal.coords['H'].data  # doctest: +SKIP
+    array([0, ..., 50.0])
+    >>> signal.attrs['frequency']  # doctest: +SKIP
+    19.99
+
+    """
+    with open(filename, 'rb') as fh:
+        header = fh.read(20)
+        if len(header) != 20:
+            raise ValueError(
+                f'invalid PicoQuant BIN header length {len(header)} != 20'
+            )
+        (size_x, size_y, pixel_resolution, size_h, tcspc_resolution) = (
+            struct.unpack('<IIfIf', header)
+        )
+        size = size_y * size_x * size_h * 4
+
+        # check the header values against arbitrary but reasonable limits
+        # to detect invalid files and prevent memory errors
+        if (
+            size <= 0
+            or size > 2**35 - 1  # 32 GiB
+            or size_x > 16384
+            or size_y > 16384
+            or size_h > 16384
+            or pixel_resolution < 0.0
+            or pixel_resolution > 1.0
+            or tcspc_resolution <= 0.0
+            or tcspc_resolution > 1.0
+        ):
+            raise ValueError('invalid PicoQuant BIN file header')
+
+        shape = size_y, size_x, size_h
+        data = numpy.empty(shape, '<u4')
+        if fh.readinto(data) != size:
+            raise ValueError('invalid PicoQuant BIN data size')
+
+    metadata = xarray_metadata(
+        ('Y', 'X', 'H'),
+        shape,
+        filename,
+        attrs={
+            'frequency': 1000.0 / (size_h * tcspc_resolution),  # MHz
+            'pixel_resolution': pixel_resolution,  # um
+            'tcspc_resolution': tcspc_resolution,  # ns
+        },
+        Y=numpy.linspace(0, size_y * pixel_resolution * 1e-6, size_y),  # m
+        X=numpy.linspace(0, size_x * pixel_resolution * 1e-6, size_x),  # m
+        H=numpy.linspace(0, size_h * tcspc_resolution, size_h),  # ns
+    )
 
     from xarray import DataArray
 

--- a/tests/io/test_other.py
+++ b/tests/io/test_other.py
@@ -14,6 +14,7 @@ from phasorpy.io import (
     signal_from_flif,
     signal_from_imspector_tiff,
     signal_from_lsm,
+    signal_from_pqbin,
     signal_from_ptu,
     signal_from_sdt,
 )
@@ -299,6 +300,27 @@ def test_signal_from_ptu_irf():
     assert_almost_equal(
         signal.coords['H'].data[[1, -1]], [0.007999, 32.759999], decimal=4
     )
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_signal_from_pqbin():
+    """Test read PicoQuant BIN file."""
+    filename = private_file('picoquant.bin')
+    signal = signal_from_pqbin(filename)
+    assert signal.values.sum(dtype=numpy.uint64) == 43071870
+    assert signal.dtype == numpy.uint32
+    assert signal.shape == (256, 256, 2000)
+    assert signal.dims == ('Y', 'X', 'H')
+    assert signal.attrs['frequency'] == pytest.approx(19.999999, abs=1e-6)
+    assert signal.attrs['pixel_resolution'] == 0.078125
+    assert signal.attrs['tcspc_resolution'] == pytest.approx(0.025, abs=1e-6)
+    assert_almost_equal(signal.coords['H'][[0, -1]], [0.0, 50.0], decimal=4)
+    assert_almost_equal(signal.coords['X'][[0, -1]], [0.0, 2.0e-05], decimal=9)
+    assert_almost_equal(signal.coords['Y'][[0, -1]], [0.0, 2.0e-05], decimal=9)
+
+    filename = fetch('simfcs.r64')
+    with pytest.raises(ValueError):
+        signal_from_pqbin(filename)
 
 
 # mypy: allow-untyped-defs, allow-untyped-calls


### PR DESCRIPTION
## Description

This PR adds the `signal_from_pqbin` function to the `phasorpy.io` module. The function returns TCSPC histograms from PicoQuant BIN files. No public data file is available and the files are quite large, so the tests are disabled on CI. No official specification of the format is available.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
