### PR TITLE
Build wheels for free-threaded Python

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -28,7 +28,7 @@ jobs:
       #   uses: docker/setup-qemu-action@v3
       #   with:
       #     platforms: all
-      - uses: pypa/cibuildwheel@v3.1.1
+      - uses: pypa/cibuildwheel@v3.1.2
         env:
           # Building and testing manylinux2014_aarch64 too is slow.
           # See https://github.com/phasorpy/phasorpy/pull/135

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: AMD64 ARM64
-          CIBW_TEST_SKIP: "cp314-*"
+          CIBW_TEST_SKIP: "cp314*"
           CIBW_BUILD_VERBOSITY: 2
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -87,7 +87,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
-      - uses: pypa/cibuildwheel@v3.1.1
+      - uses: pypa/cibuildwheel@v3.1.2
         env:
           # CIBW_ENVIRONMENT: "PIP_PRE=1"
           SKIP_FETCH: 1
@@ -117,7 +117,7 @@ jobs:
   #        uses: docker/setup-qemu-action@v3
   #        with:
   #          platforms: all
-  #      - uses: pypa/cibuildwheel@v3.1.1
+  #      - uses: pypa/cibuildwheel@v3.1.2
   #        env:
   #          CIBW_ARCHS_LINUX: aarch64
   #          CIBW_BUILD_VERBOSITY: 2
@@ -126,7 +126,7 @@ jobs:
   #      - uses: actions/upload-artifact@v4
   #        with:
   #          path: ./wheelhouse/*.whl
-  #          name: wheels-aarch64
+  #          name: wheels-${{ matrix.os }}
 
   static_analysis:
     name: Static code analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ norecursedirs = [
 ]
 
 [tool.cibuildwheel]
-skip = "pp* cp37* cp38* cp39* cp310* *musllinux* *i686 *ppc64le *s390x cp39*win*arm64 cp31?t-*"
+skip = "cp38* cp39* cp310* *musllinux* *i686 *ppc64le *s390x"
 test-requires = ["scikit-learn", "lfdfiles", "sdtfile", "ptufile", "liffile", "pawflim", "pytest", "pytest-cov", "pytest-runner", "pytest-doctestplus", "coverage"]
 test-command = "pytest {project}/tests"
 test-environment = "SKIP_FETCH=1"


### PR DESCRIPTION
## Description

Build wheels for [free-threaded Python](https://docs.python.org/3.14/howto/free-threading-python.html). Tests are currently disabled since not all dependencies are available yet for free-threaded Python:

- [x] numpy
- [x] scipy
- [x] matplotlib
- [x] ptufile
- [x] lfdfiles
- [ ] scikit-learn
- [ ] Pandas
- [ ] Pillow
- [ ] kiwisolver

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
