### PR TITLE
Fix signal_from_ptu function kwargs handling

### DIFF
--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -172,7 +172,8 @@ def signal_from_ptu(
     keepdims : bool, optional, default: False
         If true, return reduced axes as size-one dimensions.
     **kwargs
-        Additional arguments passed to :py:meth:`PtuFile.decode_image`.
+        Additional arguments passed to :py:meth:`PtuFile.decode_image`
+        or :py:meth:`PtuFile.decode_histogram`.
 
     Returns
     -------
@@ -219,8 +220,7 @@ def signal_from_ptu(
     import ptufile
     from xarray import DataArray
 
-    for key in {'pixel_time', 'bishift'}:
-        kwargs.pop(key, None)
+    kwargs.pop('records', None)
 
     with ptufile.PtuFile(filename, trimdims=trimdims) as ptu:
         if not ptu.is_t3:
@@ -242,7 +242,7 @@ def signal_from_ptu(
             if dtime == -1:
                 raise ValueError(f'{dtime=} not supported for point mode')
             data = ptu.decode_histogram(
-                dtype=dtype, dtime=dtime, asxarray=True
+                dtype=dtype, dtime=dtime, asxarray=True, **kwargs
             )
             assert isinstance(data, DataArray)
             if channel is not None:

--- a/tests/io/test_other.py
+++ b/tests/io/test_other.py
@@ -246,8 +246,9 @@ def test_signal_from_ptu():
         dtime=None,
         keepdims=True,
         trimdims='TC',
+        # pixel_time=6.331709817995386e-06  # requires ptufile 2025.7.30
     )
-    assert signal.values.sum(dtype=numpy.uint64) == 6065123
+    assert signal.values.sum(axis=(0, 3, 4))[128, 128] == 223
     assert signal.dtype == numpy.uint16
     assert signal.shape == (1, 256, 256, 1, 4096)
     assert signal.dims == ('T', 'Y', 'X', 'C', 'H')
@@ -278,6 +279,7 @@ def test_signal_from_ptu_irf():
     assert signal.attrs['ptu_tags']['HW_Type'] == 'PicoHarp 300'
 
     signal = signal_from_ptu(filename)
+    assert signal.values[0, 0, 100] == 130
     assert signal.values.sum(dtype=numpy.uint64) == 6984849
     assert signal.shape == (1, 1, 6250)
     assert signal.dims == ('Y', 'X', 'H')


### PR DESCRIPTION
## Description

Fix handling of `kwargs` in the `signal_from_ptu` function.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
