### PR TITLE
Rename build_manylinux scripts

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,6 +14,10 @@ recursive-include tutorials *.rst
 exclude *.cmd
 exclude docs/sg_execution_times.rst
 
+include tools/*.py
+include tools/*.sh
+include tools/*.cmd
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 recursive-exclude * *Copy*

--- a/tools/build_manylinux.cmd
+++ b/tools/build_manylinux.cmd
@@ -1,11 +1,11 @@
-:: Build PhasorPy manylinux2014 wheels on Windows using Docker
+:: Build PhasorPy manylinux wheels on Windows using Docker
 
 setlocal
 set PATH=C:\Windows;C:\Windows\System32;C:\Program Files\Docker\Docker\resources\bin
 set CIBW_ARCHS_LINUX=auto
-set CIBW_SKIP=pp* cp37* cp38* cp39* cp310* *musllinux*
-:: set CIBW_TEST_SKIP=*
-set CIBW_TEST_COMMAND=python -m pytest {project}/tests
+set CIBW_SKIP=cp38* cp39* cp310* *musllinux*
+set CIBW_TEST_SKIP=cp314*
+set CIBW_TEST_COMMAND=pytest {project}/tests
 set CIBW_BUILD_VERBOSITY=3
 
 docker version

--- a/tools/build_manylinux.sh
+++ b/tools/build_manylinux.sh
@@ -1,8 +1,8 @@
-# Build PhasorPy manylinux2014 wheels on Linux or macOS using Docker
+# Build PhasorPy manylinux wheels on Linux or macOS using Docker
 
 export CIBW_ARCHS_LINUX=auto
-export CIBW_SKIP="pp* cp37* cp38* cp39* cp310* *musllinux*"
-# export CIBW_TEST_SKIP="*"
+export CIBW_SKIP="cp38* cp39* cp310* *musllinux*"
+export CIBW_TEST_SKIP=cp314*
 export CIBW_TEST_COMMAND="pytest {project}/tests"
 export CIBW_BUILD_VERBOSITY=3
 


### PR DESCRIPTION
## Description

This PR renames the `build_manylinux2014.*` scripts to `build_manylinux.*`to reflect that wheels are no longer built for `manylinux_2014` but `manylinux_2_17`.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
