### PR TITLE
Raise minimum version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=68",
     "numpy",
-    "cython>=3.1.0",
+    "cython>=3.1.3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -14,16 +14,16 @@ dynamic = ["version"]
 dependencies = [
     # sync with requirements_min.txt
     # https://scientific-python.org/specs/spec-0000/
-    "numpy>=1.26.0",
-    "matplotlib>=3.8.0",
-    "scipy>=1.11.0",
+    "numpy>=2.0.0",
+    "matplotlib>=3.9.0",
+    "scipy>=1.12.0",
     "click",
     "pooch",
     "tqdm",
     "scikit-learn>=1.5.0",
-    # "scikit-image>=0.21.0",
-    # "pandas>=2.1.0",
-    "xarray>=2023.4.0",
+    # "scikit-image>=0.22.0",
+    # "pandas>=2.2.0",
+    "xarray>=2023.10.0",
     "tifffile>=2024.8.30",
 ]
 requires-python = ">=3.11"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,9 @@
 # Requirements for developing the PhasorPy library
+# The latest versions are generally recommended
+# python -m pip install -U -r requirements_dev.txt
 #
 # runtime requirements
-numpy
+numpy>=2.0.0
 scipy
 matplotlib
 click
@@ -18,7 +20,7 @@ wheel
 twine
 packaging
 cibuildwheel
-cython>=3.1.0
+cython>=3.1.3
 # meson-python
 #
 # documentation requirements

--- a/requirements_min.txt
+++ b/requirements_min.txt
@@ -1,12 +1,12 @@
 # Minimum version requirements for the PhasorPy library
 #
-numpy==1.26.4; python_version == "3.11"
-matplotlib==3.8.4; python_version == "3.11"
-pandas==2.1.4; python_version == "3.11"
-scipy==1.11.4; python_version == "3.11"
-scikit-image==0.21.0; python_version == "3.11"
+numpy==2.0.2; python_version == "3.11"
+matplotlib==3.9.4; python_version == "3.11"
+pandas==2.2.3; python_version == "3.11"
+scipy==1.12.0; python_version == "3.11"
+scikit-image==0.22.0; python_version == "3.11"
 scikit-learn==1.5.0; python_version == "3.11"
-xarray==2023.4.0; python_version == "3.11"
+xarray==2023.10.1; python_version == "3.11"
 tifffile==2024.8.30; python_version == "3.11"
 lfdfiles==2024.5.24; python_version == "3.11"
 sdtfile==2024.5.24; python_version == "3.11"

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -110,7 +110,7 @@ def phasor_from_component(
     if dtype.char not in {'f', 'd'}:
         raise ValueError(f'{dtype=} is not a floating point type')
 
-    fraction = numpy.array(fraction, dtype=dtype, copy=True)
+    fraction = numpy.asarray(fraction, dtype=dtype, copy=True)
     if fraction.ndim < 1:
         raise ValueError(f'{fraction.ndim=} < 1')
     if fraction.shape[axis] < 2:
@@ -362,7 +362,7 @@ def phasor_component_graphical(
 
     dtype = numpy.min_scalar_type(real.size)
     counts = numpy.empty(
-        (1 if num_components == 2 else 3, fractions.size), dtype
+        (1 if num_components == 2 else 3, fractions.size), dtype=dtype
     )
 
     c = 0

--- a/src/phasorpy/io/_flimlabs.py
+++ b/src/phasorpy/io/_flimlabs.py
@@ -157,9 +157,9 @@ def phasor_from_flimlabs_json(
 
     shape: tuple[int, ...] = nharmonics, nchannels, height, width
     axes: str = 'CYX'
-    mean = numpy.zeros(shape[1:], dtype)
-    real = numpy.zeros(shape, dtype)
-    imag = numpy.zeros(shape, dtype)
+    mean = numpy.zeros(shape[1:], dtype=dtype)
+    real = numpy.zeros(shape, dtype=dtype)
+    imag = numpy.zeros(shape, dtype=dtype)
 
     for d in phasor_data:
         h = d['harmonic']
@@ -173,8 +173,8 @@ def phasor_from_flimlabs_json(
         else:
             c = channels.index(d['channel'])
 
-        real[h, c] = numpy.asarray(d['g_data'], dtype)
-        imag[h, c] = numpy.asarray(d['s_data'], dtype)
+        real[h, c] = numpy.asarray(d['g_data'], dtype=dtype)
+        imag[h, c] = numpy.asarray(d['s_data'], dtype=dtype)
 
     if 'intensities_data' in data:
         from .._phasorpy import _flimlabs_mean
@@ -327,7 +327,7 @@ def signal_from_flimlabs_json(
 
     from .._phasorpy import _flimlabs_signal
 
-    signal = numpy.zeros((nchannels, height * width, 256), dtype)
+    signal = numpy.zeros((nchannels, height * width, 256), dtype=dtype)
     _flimlabs_signal(
         signal,
         intensities_data,

--- a/src/phasorpy/io/_ometiff.py
+++ b/src/phasorpy/io/_ometiff.py
@@ -135,9 +135,9 @@ def phasor_to_ometiff(
     if dtype.kind != 'f':
         raise ValueError(f'{dtype=} not a floating point type')
 
-    mean = numpy.asarray(mean, dtype)
-    real = numpy.asarray(real, dtype)
-    imag = numpy.asarray(imag, dtype)
+    mean = numpy.asarray(mean, dtype=dtype)
+    real = numpy.asarray(real, dtype=dtype)
+    imag = numpy.asarray(imag, dtype=dtype)
     datasize = mean.nbytes + real.nbytes + imag.nbytes
 
     if real.shape != imag.shape:
@@ -166,7 +166,9 @@ def phasor_to_ometiff(
             raise ValueError('invalid harmonic')
 
     if frequency is not None:
-        frequency_array = numpy.atleast_2d(frequency).astype(numpy.float64)
+        frequency_array = numpy.array(
+            frequency, dtype=numpy.float64, ndmin=2, copy=None
+        )
         if frequency_array.size > 1:
             raise ValueError('frequency must be scalar')
 
@@ -226,7 +228,7 @@ def phasor_to_ometiff(
 
         if harmonic is not None:
             tif.write(
-                numpy.atleast_2d(harmonic).astype(numpy.uint32),
+                numpy.array(harmonic, dtype=numpy.uint32, ndmin=2),
                 metadata={'Name': 'Phasor harmonic'},
             )
 

--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -863,7 +863,7 @@ def signal_from_pqbin(
             raise ValueError('invalid PicoQuant BIN file header')
 
         shape = size_y, size_x, size_h
-        data = numpy.empty(shape, '<u4')
+        data = numpy.empty(shape, dtype='<u4')
         if fh.readinto(data) != size:
             raise ValueError('invalid PicoQuant BIN data size')
 

--- a/src/phasorpy/io/_simfcs.py
+++ b/src/phasorpy/io/_simfcs.py
@@ -97,7 +97,7 @@ def phasor_to_simfcs_referenced(
         raise ValueError(f'file extension {ext} != .r64')
 
     # TODO: delay conversions to numpy arrays to inner loop
-    mean = numpy.asarray(mean, numpy.float32)
+    mean = numpy.asarray(mean, dtype=numpy.float32)
     phi, mod = phasor_to_polar(real, imag, dtype=numpy.float32)
     del real
     del imag
@@ -272,7 +272,7 @@ def phasor_from_simfcs_referenced(
     harmonic, keep_harmonic_dim = parse_harmonic(harmonic, data.shape[0] // 2)
 
     mean = data[0].copy()
-    real = numpy.empty((len(harmonic),) + mean.shape, numpy.float32)
+    real = numpy.empty((len(harmonic),) + mean.shape, dtype=numpy.float32)
     imag = numpy.empty_like(real)
     for i, h in enumerate(harmonic):
         h = (h - 1) * 2 + 1

--- a/src/phasorpy/lifetime.py
+++ b/src/phasorpy/lifetime.py
@@ -276,13 +276,13 @@ def phasor_from_lifetime(
     """
     if unit_conversion < 1e-16:
         raise ValueError(f'{unit_conversion=} < 1e-16')
-    frequency = numpy.atleast_1d(
-        numpy.ascontiguousarray(frequency, dtype=numpy.float64)
+    frequency = numpy.array(
+        frequency, dtype=numpy.float64, ndmin=1, order='C', copy=None
     )
     if frequency.ndim != 1:
         raise ValueError('frequency is not one-dimensional array')
-    lifetime = numpy.atleast_1d(
-        numpy.ascontiguousarray(lifetime, dtype=numpy.float64)
+    lifetime = numpy.array(
+        lifetime, dtype=numpy.float64, ndmin=1, order='C', copy=None
     )
     if lifetime.ndim > 2:
         raise ValueError('lifetime must be one- or two-dimensional array')
@@ -296,8 +296,8 @@ def phasor_from_lifetime(
         lifetime = lifetime.reshape(-1, 1)  # move components to last axis
         fraction = numpy.ones_like(lifetime)  # not really used
     else:
-        fraction = numpy.atleast_1d(
-            numpy.ascontiguousarray(fraction, dtype=numpy.float64)
+        fraction = numpy.array(
+            fraction, dtype=numpy.float64, ndmin=1, order='C', copy=None
         )
         if fraction.ndim > 2:
             raise ValueError('fraction must be one- or two-dimensional array')
@@ -1021,8 +1021,8 @@ def phasor_to_lifetime_search(
     if dtype.char not in {'f', 'd'}:
         raise ValueError(f'{dtype=} is not a floating point type')
 
-    real = numpy.ascontiguousarray(real, dtype)
-    imag = numpy.ascontiguousarray(imag, dtype)
+    real = numpy.ascontiguousarray(real, dtype=dtype)
+    imag = numpy.ascontiguousarray(imag, dtype=dtype)
 
     if real.shape != imag.shape:
         raise ValueError(f'{real.shape=} != {imag.shape=}')
@@ -1134,7 +1134,7 @@ def phasor_to_apparent_lifetime(
     (array([inf, 0]), array([inf, 0]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     return _phasor_to_apparent_lifetime(  # type: ignore[no-any-return]
         real, imag, omega, **kwargs
@@ -1218,7 +1218,7 @@ def phasor_from_apparent_lifetime(
     (array([1, 0.0]), array([0, 0.0]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     if modulation_lifetime is None:
         return _phasor_from_single_lifetime(  # type: ignore[no-any-return]
@@ -1302,7 +1302,7 @@ def phasor_to_normal_lifetime(
     array([1.989, 1.989])
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     return _phasor_to_normal_lifetime(  # type: ignore[no-any-return]
         real, imag, omega, **kwargs
@@ -1445,7 +1445,7 @@ def lifetime_fraction_to_amplitude(
     array([0.2, 0.2])
 
     """
-    t = numpy.array(fraction, dtype=numpy.float64)  # makes copy
+    t = numpy.asarray(fraction, dtype=numpy.float64, copy=True)
     t /= numpy.sum(t, axis=axis, keepdims=True)
     numpy.true_divide(t, lifetime, out=t)
     return t
@@ -1757,7 +1757,7 @@ def polar_to_apparent_lifetime(
     (array([1.989, 1.989]), array([1.989, 2.411]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     return _polar_to_apparent_lifetime(  # type: ignore[no-any-return]
         phase, modulation, omega, **kwargs
@@ -1829,7 +1829,7 @@ def polar_from_apparent_lifetime(
     (array([0.7854, 0.7854]), array([0.7071, 0.6364]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     if modulation_lifetime is None:
         return _polar_from_single_lifetime(  # type: ignore[no-any-return]
@@ -1923,7 +1923,7 @@ def phasor_from_fret_donor(
     (array([0.1766, 0.2737, 0.1466]), array([0.3626, 0.4134, 0.2534]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     return _phasor_from_fret_donor(  # type: ignore[no-any-return]
         omega,
@@ -2041,7 +2041,7 @@ def phasor_from_fret_acceptor(
     (array([0.1996, 0.05772, 0.2867]), array([0.3225, 0.3103, 0.4292]))
 
     """
-    omega = numpy.array(frequency, dtype=numpy.float64)  # makes copy
+    omega = numpy.asarray(frequency, dtype=numpy.float64, copy=True)
     omega *= math.pi * 2.0 * unit_conversion
     return _phasor_from_fret_acceptor(  # type: ignore[no-any-return]
         omega,

--- a/src/phasorpy/plot/_phasorplot.py
+++ b/src/phasorpy/plot/_phasorplot.py
@@ -1201,14 +1201,14 @@ class PhasorPlot:
         elif labels is None:
             # use tick values as labels
             assert ticks is not None
-            ticks = numpy.array(ticks, copy=True, ndmin=1)
+            ticks = numpy.array(ticks, ndmin=1, copy=True)
             if tick_format is None:
                 tick_format = '{}'
             labels = [tick_format.format(t) for t in ticks]
             ticks = ticks.astype(numpy.float64)
         else:
             # ticks and labels
-            ticks = numpy.array(ticks, dtype=numpy.float64, copy=True, ndmin=1)
+            ticks = numpy.array(ticks, dtype=numpy.float64, ndmin=1, copy=True)
             if ticks.size != len(labels):
                 raise ValueError(f'{ticks.size=} != {len(labels)=}')
 

--- a/tests/plot/test_phasorplot.py
+++ b/tests/plot/test_phasorplot.py
@@ -84,7 +84,7 @@ class TestPhasorPlot:
         plot = PhasorPlot(title='legend')
         plot.ax.plot(0.6, 0.4, 'o', label='label')
         plot.legend(loc='upper right')
-        plot.show()
+        plot.show(plot)
 
     def test_plot(self):
         """Test plot method."""

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -238,7 +238,7 @@ def test_phasor_from_signal_param(use_fft, shape, axis, dtype, dtype_out):
     """Test phasor_from_signal function parameters."""
     samples = shape[axis]
     dtype = numpy.dtype(dtype)
-    signal = numpy.empty(shape, dtype)
+    signal = numpy.empty(shape, dtype=dtype)
     sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
     if not use_fft:
         sample_phase[0] = sample_phase[-1]  # out of order
@@ -281,7 +281,7 @@ def test_phasor_from_signal_noncontig(use_fft, dtype):
     """Test phasor_from_signal functions with non-contiguous input."""
     dtype = numpy.dtype(dtype)
     samples = 31
-    signal = numpy.empty((7, 19, samples, 11), dtype)
+    signal = numpy.empty((7, 19, samples, 11), dtype=dtype)
     sample_phase = numpy.linspace(0, 2 * math.pi, samples, endpoint=False)
     sig = 2.1 * (numpy.cos(sample_phase - 0.46364761) * 2 * 0.44721359 + 1)
     sig = sig.astype(dtype)


### PR DESCRIPTION
## Description

This PR raises minimum version requirements in accordance with [SPEC 0](https://scientific-python.org/specs/spec-0000/), most notably `numpy>=2`.

- `numpy` 1.26.0 -> 2.0.0
- `matplotlib` 3.8.0 -> 3.9.0
- `scipy` 1.11.0 -> 1.12.0
- `pandas` 2.1.0 - 2.2.0
- `xarray` 2023.4.0 -> 2023.10.0
- Prefer `numpy.asarray` over `numpy.array`
- Simplify some array creations
- Always pass `dtype` by name

We may also want to update (in another PR) the numpy legacy print option.

https://github.com/phasorpy/phasorpy/blob/d6f1729f6a6b2e84dbf92fbd92414bdbac23a46b/src/phasorpy/conftest.py#L18-L20

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
