### PR TITLE
Add phasor_combine function

### DIFF
--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1012,75 +1012,7 @@ cdef (float_t, float_t) _phasor_divide(
 
 
 @cython.ufunc
-cdef (float_t, float_t, float_t) _phasor_combine_two_5(
-    float_t real0,
-    float_t imag0,
-    float_t real1,
-    float_t imag1,
-    float_t fraction0
-) noexcept nogil:
-    """Return linear combination of two phasor coordinates, 5 arguments."""
-    cdef:
-        float_t fraction1 = <float_t> 1.0 - fraction0
-
-    return (
-        1.0,
-        fraction0 * real0 + fraction1 * real1,
-        fraction0 * imag0 + fraction1 * imag1
-    )
-
-
-@cython.ufunc
-cdef (float_t, float_t, float_t) _phasor_combine_two_6(
-    float_t real0,
-    float_t imag0,
-    float_t real1,
-    float_t imag1,
-    float_t fraction0,
-    float_t fraction1
-) noexcept nogil:
-    """Return linear combination of two phasor coordinates, 6 arguments."""
-    fraction1 += fraction0
-    if fraction1 == 0.0:
-        return <float_t> 0.0, <float_t> NAN, <float_t> NAN
-    fraction0 /= fraction1
-    fraction1 = <float_t> 1.0 - fraction0
-
-    return (
-        1.0,
-        fraction0 * real0 + fraction1 * real1,
-        fraction0 * imag0 + fraction1 * imag1
-    )
-
-
-@cython.ufunc
-cdef (float_t, float_t, float_t) _phasor_combine_two_7(
-    float_t int0,
-    float_t real0,
-    float_t imag0,
-    float_t int1,
-    float_t real1,
-    float_t imag1,
-    float_t fraction0
-) noexcept nogil:
-    """Return linear combination of two phasor coordinates, 7 arguments."""
-    cdef:
-        float_t intensity
-
-    int0 *= fraction0
-    int1 *= <float_t> 1.0 - fraction0
-    intensity = int0 + int1
-
-    if intensity == 0.0:
-        return <float_t> 0.0, <float_t> NAN, <float_t> NAN
-
-    int0 /= intensity
-    int1 /= intensity
-    return intensity, int0 * real0 + int1 * real1, int0 * imag0 + int1 * imag1
-
-
-@cython.ufunc
-cdef (float_t, float_t, float_t) _phasor_combine_two_8(
+cdef (float_t, float_t, float_t) _phasor_combine(
     float_t int0,
     float_t real0,
     float_t imag0,
@@ -1090,7 +1022,7 @@ cdef (float_t, float_t, float_t) _phasor_combine_two_8(
     float_t fraction0,
     float_t fraction1,
 ) noexcept nogil:
-    """Return linear combination of two phasor coordinates, 8 arguments."""
+    """Return linear combination of two phasor coordinates."""
     cdef:
         float_t intensity
 

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -97,7 +97,7 @@ def phasor_from_component(
 
     See Also
     --------
-    phasorpy.phasor.phasor_combine_two
+    phasorpy.phasor.phasor_combine
 
     Examples
     --------

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -26,7 +26,7 @@ from phasorpy.component import phasor_from_component
 from phasorpy.lifetime import phasor_from_lifetime
 from phasorpy.phasor import (
     phasor_center,
-    phasor_combine_two,
+    phasor_combine,
     phasor_divide,
     phasor_from_polar,
     phasor_from_signal,
@@ -920,13 +920,13 @@ def test_phasor_transform_more():
 @pytest.mark.parametrize(
     'args, expected',
     [
-        ((0.1, 0.2, 0.3, 0.4, 0.5), (1.0, 0.2, 0.3)),
-        ((0.1, 0.2, 0.3, 0.4, 1.0, 1.0), (1.0, 0.2, 0.3)),
+        # same intensity, same fraction
         ((1.0, 0.1, 0.2, 1.0, 0.3, 0.4, 0.5), (1.0, 0.2, 0.3)),
         ((1.0, 0.1, 0.2, 1.0, 0.3, 0.4, 1.0, 1.0), (1.0, 0.2, 0.3)),
-        # broadcast
-        (([0.1, 0.9], 0.2, 0.3, 0.4, 0.5), (1.0, [0.2, 0.6], [0.3, 0.3])),
-        (([0.1, 0.9], 0.2, 0.3, 0.4, 1.0, 1.0), (1.0, [0.2, 0.6], [0.3, 0.3])),
+        # different intensity, different fraction
+        ((0.5, 0.1, 0.2, 0.6, 0.3, 0.4, 0.7), (0.53, 0.167925, 0.267925)),
+        ((0.5, 0.1, 0.2, 0.6, 0.3, 0.4, 1.4, 0.6), (0.53, 0.167925, 0.267925)),
+        # broadcast real
         (
             (1.0, [0.1, 0.9], 0.2, 1.0, 0.3, 0.4, 0.5),
             (1.0, [0.2, 0.6], [0.3, 0.3]),
@@ -935,24 +935,36 @@ def test_phasor_transform_more():
             (1.0, [0.1, 0.9], 0.2, 1.0, 0.3, 0.4, 1.0, 1.0),
             (1.0, [0.2, 0.6], [0.3, 0.3]),
         ),
+        # broadcast fraction
+        (
+            (1.0, 0.1, 0.2, 1.0, 0.3, 0.4, [0.0, 0.5, 1.0]),
+            ([1.0, 1.0, 1.0], [0.3, 0.2, 0.1], [0.4, 0.3, 0.2]),
+        ),
         # fraction0 + fraction1 == 0
-        ((0.1, 0.2, 0.3, 0.4, 0.5, -0.5), (0.0, NAN, NAN)),
         ((1.0, 0.1, 0.2, 1.0, 0.3, 0.4, 0.5, -0.5), (0.0, NAN, NAN)),
         # int0 + int1 == 0
-        ((0.5, 0.1, 0.2, -0.5, 0.3, 0.4, 0.5), (0.0, NAN, NAN)),
         ((0.5, 0.1, 0.2, -0.5, 0.3, 0.4, 1.0, 1.0), (0.0, NAN, NAN)),
+        # NAN input
+        ((NAN, 0.1, 0.2, 1.0, 0.3, 0.4, 0.5), (NAN, NAN, NAN)),
+        ((NAN, 0.1, 0.2, 1.0, 0.3, 0.4, 1.0, 1.0), (NAN, NAN, NAN)),
+        ((1.0, NAN, 0.2, 1.0, 0.3, 0.4, 0.5), (1.0, NAN, 0.3)),
+        ((1.0, NAN, 0.2, 1.0, 0.3, 0.4, 1.0, 1.0), (1.0, NAN, 0.3)),
+        ((1.0, 0.1, NAN, 1.0, 0.3, 0.4, 0.5), (1.0, 0.2, NAN)),
+        ((1.0, 0.1, NAN, 1.0, 0.3, 0.4, 1.0, 1.0), (1.0, 0.2, NAN)),
+        ((1.0, 0.1, 0.2, 1.0, 0.3, 0.4, NAN), (NAN, NAN, NAN)),
+        ((1.0, 0.1, 0.2, 1.0, 0.3, 0.4, 1.0, NAN), (NAN, NAN, NAN)),
     ],
 )
-def test_phasor_combine_two(args, expected):
-    """Test phasor_combine_two function."""
-    mean, real, imag = phasor_combine_two(*args)
-    assert_allclose(mean, expected[0])
-    assert_allclose(real, expected[1])
-    assert_allclose(imag, expected[2])
+def test_phasor_combine(args, expected):
+    """Test phasor_combine function."""
+    mean, real, imag = phasor_combine(*args)
+    assert_allclose(mean, expected[0], atol=1e-4)
+    assert_allclose(real, expected[1], atol=1e-4)
+    assert_allclose(imag, expected[2], atol=1e-4)
 
 
 def test_phasor_combine_more():
-    """Test phasor_combine_two function cases."""
+    """Test phasor_combine function additional cases."""
     # test against phasor_from_component
     real = [0.6, 0.4]
     imag = [0.3, 0.2]
@@ -961,8 +973,15 @@ def test_phasor_combine_more():
     real0, imag0 = phasor_from_component(
         real, imag, fraction, dtype=numpy.float32
     )
-    mean1, real1, imag1 = phasor_combine_two(
-        real[0], imag[0], real[1], imag[1], fraction[0], dtype=numpy.float32
+    mean1, real1, imag1 = phasor_combine(
+        1.0,
+        real[0],
+        imag[0],
+        1.0,
+        real[1],
+        imag[1],
+        fraction[0],
+        dtype=numpy.float32,
     )
     assert mean1.dtype == numpy.float32
     assert real1.dtype == numpy.float32
@@ -970,17 +989,11 @@ def test_phasor_combine_more():
     assert_allclose(real1, real0)
     assert_allclose(imag1, imag0)
 
-    mean1, real1, imag1 = phasor_combine_two(
-        real[0], imag[0], real[1], imag[1], *fraction
+    mean1, real1, imag1 = phasor_combine(
+        1.0, real[0], imag[0], 1.0, real[1], imag[1], *fraction
     )
     assert_allclose(real1, real0)
     assert_allclose(imag1, imag0)
-
-    with pytest.raises(TypeError):
-        phasor_combine_two(0.1, 0.2, 0.3, 0.4)
-
-    with pytest.raises(TypeError):
-        phasor_combine_two(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This PR adds the `phasor_combine` function to the `phasorpy.phasor` module. It returns the linear combination of two phasor coordinates, with weighting intensities and normalizing fractions.

In comparison with the similar `phasor_from_component` function, `phasor_combine` is specialized on two components and is implemented as a numpy universal functions in Cython, which supports broadcasting.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
