### PR TITLE
Update to mkl_fft 2.0

### DIFF
--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -134,7 +134,8 @@ def phasor_from_signal(
         calculated, or `rfft` is specified.
     rfft : callable, optional
         Drop-in replacement function for ``numpy.fft.rfft``.
-        For example, ``scipy.fft.rfft`` or ``mkl_fft._numpy_fft.rfft``.
+        For example, ``scipy.fft.rfft`` or
+        ``mkl_fft.interfaces.numpy_fft.rfft``.
         Used to calculate the real forward FFT.
     dtype : dtype_like, optional
         Data type of output arrays. Either float32 or float64.
@@ -378,7 +379,8 @@ def phasor_to_signal(
         The default is the last axis (-1).
     irfft : callable, optional
         Drop-in replacement function for ``numpy.fft.irfft``.
-        For example, ``scipy.fft.irfft`` or ``mkl_fft._numpy_fft.irfft``.
+        For example, ``scipy.fft.irfft`` or
+        ``mkl_fft.interfaces.numpy_fft.irfft``.
         Used to calculate the real inverse FFT.
 
     Returns

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -18,7 +18,7 @@ except ImportError:
     scipy_fft = None
 
 try:
-    import mkl_fft._numpy_fft as mkl_fft
+    from mkl_fft.interfaces import numpy_fft as mkl_fft
 except ImportError:
     mkl_fft = None
 

--- a/tutorials/misc/phasorpy_phasor_from_signal.py
+++ b/tutorials/misc/phasorpy_phasor_from_signal.py
@@ -12,7 +12,7 @@ coordinates from time-resolved or spectral signals can operate in two modes:
 
 - using a real forward Fast Fourier Transform (FFT), ``numpy.fft.rfft`` or
   a drop-in replacement function like ``scipy.fft.rfft``
-  or ``mkl_fft._numpy_fft.rfft``.
+  or ``mkl_fft.interfaces.numpy_fft.rfft``.
 
 This tutorial compares the performance of the two modes.
 
@@ -34,7 +34,7 @@ except ImportError:
     scipy_fft = None
 
 try:
-    from mkl_fft._numpy_fft import rfft as mkl_fft
+    from mkl_fft.interfaces.numpy_fft import rfft as mkl_fft
 except ImportError:
     mkl_fft = None
 


### PR DESCRIPTION
## Description

Update docstrings, tests, and tutorial to `mkl_fft` 2.0, which changed location of the `numpy_fft` interface.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
