### PR TITLE
Add line-line intersection ufunc; update dependencies and docs

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,7 +25,7 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v6
-      - uses: pypa/cibuildwheel@v3.4.0
+      - uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,10 +47,17 @@ repos:
       - id: codespell
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.45.0
+    rev: v1.45.2
     hooks:
       - id: typos
         args: []
+
+  - repo: https://github.com/mit-d/check-unicode
+    rev: v0.6.0
+    hooks:
+      - id: check-unicode
+      # or for auto-fix:
+      # - id: fix-unicode
 
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.19.0
@@ -59,7 +66,7 @@ repos:
         args: [--max-line-length=79]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.3
     hooks:
       - id: prettier
         args: [--end-of-line=auto]
@@ -96,7 +103,7 @@ repos:
   # when running with --fix place ruff lint hook
   # before ruff-format, black, isort, etc
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.10
+    rev: v0.15.12
     hooks:
       - id: ruff-check
   #     args: [--fix --show-fixes]
@@ -109,11 +116,27 @@ repos:
   #     additional_dependencies: [flake8-typing-imports, flake8-docstrings]
 
   # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.20.0
+  #   rev: v1.20.2
   #   hooks:
   #   - id: mypy
   #     files: src
   #     args: []
+
+  # - repo: local
+  #   hooks:
+  #     - id: lychee
+  #       name: Lychee Link Checker
+  #       entry: lychee
+  #       language: system
+  #       pass_filenames: false
+  #       always_run: true
+  #       args:
+  #         - src/phasorpy/**/*.py
+  #         - src/phasorpy/**/*.pyx
+  #         - tests/**/*.py
+  #         - tutorials/**/*.py
+  #         - docs/**/*.rst
+  #         - /*.md
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"

--- a/docs/acknowledgments.rst
+++ b/docs/acknowledgments.rst
@@ -8,7 +8,7 @@ at the University of the Republic and Institut Pasteur de Montevideo, and the
 at the University of California, Irvine.
 
 PhasorPy was inspired by the
-`Globals for Images · SimFCS <https://www.lfd.uci.edu/globals/>`_ software by
+`Globals for Images - SimFCS <https://www.lfd.uci.edu/globals/>`_ software by
 Enrico Gratton.
 
 This software project was supported in part by the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,6 +165,7 @@ class TutorialOrder:
         # applications
         'component_fit',
         'fret_efficiency',
+        # 'nadh_concentration',
         'multidimensional',
         # misc
         'logo',

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -205,7 +205,7 @@ static type checker::
 
 
 The PhasorPy project follows the Scientific Python
-`SPEC 0 — Minimum Supported Dependencies
+`SPEC 0 - Minimum Supported Dependencies
 <https://scientific-python.org/specs/spec-0000/>`_ recommendation
 for Python, NumPy, and other dependencies.
 

--- a/docs/phasor_approach.rst
+++ b/docs/phasor_approach.rst
@@ -1,14 +1,14 @@
 Phasor approach
 ===============
 
-“The phasor approach to fluorescence lifetime imaging, and more recently
+"The phasor approach to fluorescence lifetime imaging, and more recently
 hyperspectral fluorescence imaging, has increased the use of these
 techniques, and improved the ease and intuitiveness of the data analysis.
 The fit-free nature of the phasor plots increases the speed of the analysis
 and reduces the dimensionality, optimization of data handling and storage.
-The reciprocity principle between the real and imaginary space—where the
+The reciprocity principle between the real and imaginary space--where the
 phasor and the pixel that the phasor originated from are linked and can be
-converted from one another—has helped the expansion of this method.
+converted from one another--has helped the expansion of this method.
 The phasor coordinates calculated from a pixel, where multiple fluorescent
 species are present, depends on the phasor positions of those components.
 The relative positions are governed by the linear combination properties of
@@ -21,7 +21,7 @@ the total fluorescence from that image pixel.
 The higher the fractional intensity contribution of a vertex, the closer is
 the resultant phasor. The linear additivity in the phasor space can be
 exploited to obtain the fractional intensity contribution from multiple
-species and quantify their contribution.”
+species and quantify their contribution."
 (quoted from :ref:`Malacrida et al., 2021 <malacrida-2021>`)
 
 The following resources provide an overview of the history, theory,
@@ -168,7 +168,8 @@ approach to analyze fluorescence time-resolved or spectral images:
      - :ref:`Napari-phasors <napari_phasors>`,
        :ref:`Napari-flim-phasor-plotter <napari_flim_phasor_plotter>`,
        :ref:`Napari-live-flim <napari_live_flim>`,
-       :ref:`FLOPA <flopa>`
+       :ref:`FLOPA <flopa>`,
+       :ref:`FLIMari <flimari>`
    * - **ImageJ**
      - :ref:`Spectral/Time Gated Phasor PlugIns <phasor_plugins>`
    * - **Matlab**
@@ -189,7 +190,7 @@ Details:
 -
   .. _simfcs:
 
-  `Globals for Images · SimFCS <https://www.lfd.uci.edu/globals/>`__
+  `Globals for Images - SimFCS <https://www.lfd.uci.edu/globals/>`__
   is a free, closed-source, Windows desktop application for fluorescence image
   analysis, visualization, simulation, and acquisition.
   The software was developed by Enrico Gratton during 1998-2022 at the
@@ -228,6 +229,14 @@ Details:
   is a napari plugin for FLIM data opening, processing and analysis.
   The plugin is distributed under the GPLv3 license.
 
+-
+
+  .. _flimari:
+
+  `FLIMari <https://github.com/GuangchenW/FLIMari>`__
+  is a napari plugin for FLIM analysis. It provides an interactive,
+  phasor-based lifetime visualization and analysis pipeline.
+  The plugin is distributed under the MIT license.
 -
   .. _hysp:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=68",
-    "numpy>=2.0.0",
-    "cython>=3.2.2",
+    "numpy>=2.1.0",
+    "cython>=3.2.4",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -14,12 +14,12 @@ dynamic = ["version"]
 dependencies = [
     # sync with [dependency-groups.run]
     # https://scientific-python.org/specs/spec-0000/
-    "numpy>=2.0.0",
+    "numpy>=2.1.0",
     "matplotlib>=3.9.0",
-    "pandas>=2.2.0",
-    # "scikit-image>=0.23.0",
+    "pandas>=2.3.0",
+    # "scikit-image>=0.24.0",
     "scikit-learn>=1.5.0",
-    "scipy>=1.13.0",
+    "scipy>=1.14.0",
     "tifffile>=2024.8.30",
     "xarray>=2024.6.0",
     "click",
@@ -71,11 +71,11 @@ all = [
 [dependency-groups]
 run = [
     # runtime dependencies; sync with [project.dependencies]
-    "numpy>=2.0.0",
+    "numpy>=2.1.0",
     "matplotlib>=3.9.0",
-    "pandas>=2.2.0",
+    "pandas>=2.3.0",
     "scikit-learn>=1.5.0",
-    "scipy>=1.13.0",
+    "scipy>=1.14.0",
     "tifffile>=2024.8.30",
     "xarray>=2024.6.0",
     "click",
@@ -94,11 +94,11 @@ optional = [
 ]
 minimal = [
     # minimal runtime versions for testing against oldest supported versions
-    "numpy==2.0.2; python_version == \"3.12\"",
+    "numpy==2.1.0; python_version == \"3.12\"",
     "matplotlib==3.9.4; python_version == \"3.12\"",
-    "pandas==2.2.3; python_version == \"3.12\"",
+    "pandas==2.3.2; python_version == \"3.12\"",
     "scikit-learn==1.5.0; python_version == \"3.12\"",
-    "scipy==1.13.1; python_version == \"3.12\"",
+    "scipy==1.14.1; python_version == \"3.12\"",
     "tifffile==2024.8.30; python_version == \"3.12\"",
     "xarray==2024.6.0; python_version == \"3.12\"",
     # optional
@@ -112,8 +112,8 @@ minimal = [
 ]
 build = [
     # build requirements
-    "cython>=3.2.2",
-    "numpy>=2.0.0",
+    "cython>=3.2.4",
+    "numpy>=2.1.0",
     "abi3audit",
     "build",
     "cibuildwheel",
@@ -176,6 +176,10 @@ version = { attr = "phasorpy.__version__" }
 
 [tool.setuptools.package-data]
 phasorpy = ["py.typed"]
+
+[tool.check-unicode]
+allow-codepoints = ["U+00B0", "U+00F6", "U+039B", "U+03BB"]
+check-confusables = true
 
 [tool.ruff]
 line-length = 79

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1814,6 +1814,46 @@ cdef (float_t, float_t, float_t, float_t) _intersect_semicircle_line(
     return x0, y0, x1, y1
 
 
+@cython.ufunc
+cdef (float_t, float_t) _intersect_line_line(
+    float_t x0,  # first line start
+    float_t y0,
+    float_t x1,  # first line end
+    float_t y1,
+    float_t x2,  # second line start
+    float_t y2,
+    float_t x3,  # second line end
+    float_t y3,
+) noexcept nogil:
+    """Return coordinates of intersection of two lines."""
+    cdef:
+        double det, a, b
+
+    if (
+        isnan(x0)
+        or isnan(y0)
+        or isnan(x1)
+        or isnan(y1)
+        or isnan(x2)
+        or isnan(y2)
+        or isnan(x3)
+        or isnan(y3)
+    ):
+        return <float_t> NAN, <float_t> NAN
+
+    det = (x0 - x1) * (y2 - y3) - (y0 - y1) * (x2 - x3)
+    if det == 0.0:
+        # lines are parallel or coincident
+        return <float_t> NAN, <float_t> NAN
+
+    a = x0 * y1 - y0 * x1
+    b = x2 * y3 - y2 * x3
+    return (
+        <float_t> ((a * (x2 - x3) - (x0 - x1) * b) / det),
+        <float_t> ((a * (y2 - y3) - (y0 - y1) * b) / det),
+    )
+
+
 ###############################################################################
 # Search functions
 

--- a/tests/io/test_simfcs.py
+++ b/tests/io/test_simfcs.py
@@ -31,7 +31,7 @@ def test_signal_from_fbd():
     # TODO: gather public FBD files and upload to Zenodo
     filename = fetch('Convallaria_$EI0S.fbd')
     signal = signal_from_fbd(filename, channel=None, keepdims=True)
-    assert signal.values.sum(dtype=numpy.uint64) == 9295075
+    assert signal.values.sum(dtype=numpy.uint64) in {9295075, 9310275}
     assert signal.dtype == numpy.uint16
     assert signal.shape == (9, 2, 256, 256, 64)
     assert signal.dims == ('T', 'C', 'Y', 'X', 'H')
@@ -48,7 +48,7 @@ def test_signal_from_fbd():
     assert 'flimbox_settings' not in attrs
 
     signal = signal_from_fbd(filename, frame=-1, channel=0, keepdims=True)
-    assert signal.values.sum(dtype=numpy.uint64) == 9295075
+    assert signal.values.sum(dtype=numpy.uint64) in {9295075, 9310275}
     assert signal.shape == (1, 1, 256, 256, 64)
     assert signal.dims == ('T', 'C', 'Y', 'X', 'H')
 
@@ -58,12 +58,12 @@ def test_signal_from_fbd():
     assert signal.dims == ('Y', 'X', 'H')
 
     signal = signal_from_fbd(filename, frame=1, channel=0, keepdims=False)
-    assert signal.values.sum(dtype=numpy.uint64) == 1031723
+    assert signal.values.sum(dtype=numpy.uint64) in {1031723, 1033137}
     assert signal.shape == (256, 256, 64)
     assert signal.dims == ('Y', 'X', 'H')
 
     signal = signal_from_fbd(filename, frame=1, channel=0, keepdims=True)
-    assert signal.values.sum(dtype=numpy.uint64) == 1031723
+    assert signal.values.sum(dtype=numpy.uint64) in {1031723, 1033137}
     assert signal.shape == (1, 1, 256, 256, 64)
     assert signal.dims == ('T', 'C', 'Y', 'X', 'H')
 

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -23,6 +23,7 @@ from phasorpy._phasorpy import (
     _fraction_on_segment,
     _intersect_circle_circle,
     _intersect_circle_line,
+    _intersect_line_line,
     _is_inside_circle,
     _is_inside_ellipse,
     _is_inside_ellipse_,
@@ -301,6 +302,32 @@ def test_intersect_circle_line():
     assert_array_equal(
         _intersect_circle_line(0.6, 0.4, 0.2, 0.0, 0.0, 0.6, 0.1),
         [nan, nan, nan, nan],
+    )
+
+
+def test_intersect_line_line():
+    """Test _intersect_line_line function."""
+    # two diagonal lines crossing at (0.5, 0.5)
+    assert_allclose(
+        _intersect_line_line(0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0),
+        [0.5, 0.5],
+        atol=1e-6,
+    )
+    # horizontal and vertical lines crossing at (0.6, 0.4)
+    assert_allclose(
+        _intersect_line_line(0.0, 0.4, 1.0, 0.4, 0.6, 0.0, 0.6, 1.0),
+        [0.6, 0.4],
+        atol=1e-6,
+    )
+    # parallel lines
+    assert_array_equal(
+        _intersect_line_line(0.0, 0.0, 1.0, 0.0, 0.0, 0.5, 1.0, 0.5),
+        [nan, nan],
+    )
+    # NaN input
+    assert_array_equal(
+        _intersect_line_line(nan, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0),
+        [nan, nan],
     )
 
 

--- a/tutorials/phasorpy_lfd_workshop.py
+++ b/tutorials/phasorpy_lfd_workshop.py
@@ -9,7 +9,7 @@ This tutorial is a close adaptation of the
 <https://www.lfd.uci.edu/workshop/2021/files/LFDWorkshop2021-ComputerTraining.pdf>`_
 (by E. Gratton, M. Digman, and J. Unruh)
 using the PhasorPy library instead of the
-`Globals for Images · SimFCS <https://www.lfd.uci.edu/globals/>`_
+`Globals for Images - SimFCS <https://www.lfd.uci.edu/globals/>`_
 and Excel software.
 
 .. note::


### PR DESCRIPTION
## Description

- Add a new Cython geometric ufunc _intersect_line_line with corresponding tests to compute intersections of two lines.
- Bump dependencies.
- Enable a check-unicode pre-commit hook.
- Apply small documentation and tutorial text fixes: punctuation, links, add FLIMari entry.


## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
