### PR TITLE
Add phasor_component_concentration function

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -165,7 +165,7 @@ class TutorialOrder:
         # applications
         'component_fit',
         'fret_efficiency',
-        # 'nadh_concentration',
+        'nadh_concentration',
         'multidimensional',
         # misc
         'logo',

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -861,6 +861,12 @@ def phasor_component_concentration(
     if component_imag.shape != (2,):
         msg = f'{component_imag.shape=} != (2,)'
         raise ValueError(msg)
+    if numpy.isnan(component_real).any() or numpy.isnan(component_imag).any():
+        msg = 'component coordinates must not contain NaN values'
+        raise ValueError(msg)
+    if numpy.isinf(component_real).any() or numpy.isinf(component_imag).any():
+        msg = 'component coordinates must not contain infinite values'
+        raise ValueError(msg)
     c0_real = float(component_real[0])
     c0_imag = float(component_imag[0])
     c1_real = float(component_real[1])
@@ -873,8 +879,8 @@ def phasor_component_concentration(
     if c0_real == c1_real:
         msg = 'component_real values must differ'
         raise ValueError(msg)
-    if reference_mean == 0.0:
-        msg = 'reference_mean must not be zero'
+    if not numpy.isfinite(reference_mean) or reference_mean <= 0.0:
+        msg = f'{reference_mean=} is not finite and positive'
         raise ValueError(msg)
     if reference_concentration <= 0.0:
         msg = f'{reference_concentration=} is not positive'
@@ -895,6 +901,9 @@ def phasor_component_concentration(
         reference_real * 0.5,
         reference_imag * 0.5,
     )
+    if not numpy.isfinite(g_cal) or g_cal == 0.0:
+        msg = f'invalid {g_cal=}'
+        raise ValueError(msg)
     # calibration factor
     k = reference_concentration * (c0_real - g_cal) / g_cal
 

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -23,12 +23,16 @@ The ``phasorpy.component`` module provides functions to:
 - calculate phasor coordinates from fractional intensities of
   components (:py:func:`phasor_from_component`)
 
+- calculate absolute concentrations of two components from phasor
+  coordinates and calibration (:py:func:`phasor_component_concentration`)
+
 """
 
 from __future__ import annotations
 
 __all__ = [
     # phasor_component_blind,
+    'phasor_component_concentration',
     'phasor_component_fit',
     'phasor_component_fraction',
     'phasor_component_graphical',
@@ -37,7 +41,7 @@ __all__ = [
 ]
 
 import numbers
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from ._typing import Any, ArrayLike, DTypeLike, NDArray
@@ -47,6 +51,7 @@ import numpy
 from ._phasorpy import (
     _blend_and,
     _fraction_on_segment,
+    _intersect_line_line,
     _is_inside_circle,
     _is_inside_stadium,
     _mean_value_coordinates,
@@ -638,6 +643,317 @@ def phasor_component_fit(
     _blend_and(mean, fractions, out=fractions)
 
     return numpy.asarray(fractions)
+
+
+@overload
+def phasor_component_concentration(
+    mean: ArrayLike,
+    real: ArrayLike,
+    imag: ArrayLike,
+    component_real: ArrayLike,
+    component_imag: ArrayLike,
+    /,
+    reference_mean: float,
+    reference_real: float,
+    reference_imag: float,
+    reference_concentration: float,
+    *,
+    brightness_ratio: None = ...,
+) -> NDArray[Any]: ...
+
+
+@overload
+def phasor_component_concentration(
+    mean: ArrayLike,
+    real: ArrayLike,
+    imag: ArrayLike,
+    component_real: ArrayLike,
+    component_imag: ArrayLike,
+    /,
+    reference_mean: float,
+    reference_real: float,
+    reference_imag: float,
+    reference_concentration: float,
+    *,
+    brightness_ratio: float,
+) -> tuple[NDArray[Any], NDArray[Any]]: ...
+
+
+def phasor_component_concentration(
+    mean: ArrayLike,
+    real: ArrayLike,
+    imag: ArrayLike,
+    component_real: ArrayLike,
+    component_imag: ArrayLike,
+    /,
+    reference_mean: float,
+    reference_real: float,
+    reference_imag: float,
+    reference_concentration: float,
+    *,
+    brightness_ratio: float | None = None,
+) -> NDArray[Any] | tuple[NDArray[Any], NDArray[Any]]:
+    r"""Return concentrations of two components from phasor coordinates.
+
+    Calculate the absolute concentration of the first component and,
+    optionally, the second component of a two-component system from
+    phasor coordinates, using an intensity calibration based on a solution
+    of known concentration according to [4]_.
+
+    The algorithm uses geometric line-line intersections in phasor space
+    to determine fractional contributions and scale them to absolute
+    concentrations.
+
+    Parameters
+    ----------
+    mean : array_like
+        Mean intensity of phasor coordinates.
+    real : array_like
+        Real component of phasor coordinates.
+    imag : array_like
+        Imaginary component of phasor coordinates.
+    component_real : array_like, shape (2,)
+        Real coordinates of the two components.
+        The first component is the calibrated component, whose pure solution
+        is used as the reference;
+    component_imag : array_like, shape (2,)
+        Imaginary coordinates of the two components.
+    reference_mean : float
+        Mean fluorescence intensity of calibration solution.
+        The calibration solution must contain only the first component at a
+        known concentration.
+    reference_real : float
+        Real coordinate of calibration solution phasor.
+    reference_imag : float
+        Imaginary coordinate of calibration solution phasor.
+    reference_concentration : float
+        Known concentration of calibration solution.
+        Same units as the returned concentrations.
+    brightness_ratio : float, optional
+        Ratio of molecular brightness of second to first component.
+        If provided, the second-component concentration is also returned.
+
+    Returns
+    -------
+    conc_first : ndarray
+        Absolute concentration of first component.
+    conc_second : ndarray
+        Absolute concentration of second component.
+        Only returned when `brightness_ratio` is provided.
+
+    Raises
+    ------
+    ValueError
+        If `component_real` values are equal (degenerate component line).
+        If `component_real` or `component_imag` do not have shape ``(2,)``.
+        If `reference_mean` is zero (cannot normalize).
+        If `reference_concentration` is not positive.
+        If `brightness_ratio` is not positive.
+
+    See Also
+    --------
+    phasorpy.component.phasor_component_fraction
+    :ref:`sphx_glr_tutorials_applications_phasorpy_nadh_concentration.py`
+
+    Notes
+    -----
+    The algorithm is based on the ``concandfrac`` procedure from SimFCS and
+    the method described in [4]_.
+    The implementation has been validated against the published cellular NADH
+    concentration, but no independent theoretical or cross-instrument
+    validation has been performed.
+    Users applying the method to other analytes or instrument platforms
+    are encouraged to verify results against known standards.
+
+    The calibration solution must contain only component 0 (no component 1)
+    at a precisely known concentration (`reference_concentration`).
+    It must be acquired under identical instrument settings as the sample
+    (same laser power, detector gain, acquisition time, and objective),
+    because the algorithm relates pixel mean intensities directly to the
+    calibration mean intensity. The mean intensity of the calibration solution
+    should be comparable to the typical pixel mean intensities of the sample.
+
+    The calibration factor :math:`k` relates the component-0 phasor
+    position to an absolute concentration:
+
+    .. math::
+
+        k = c_\text{ref} \cdot \frac{g_0 - g_\text{cal}}
+            {g_\text{cal}}
+
+    where :math:`g_0` is the real coordinate of the component-0 phasor,
+    :math:`g_\text{cal}` is the intersection of the line from :math:`g_0`
+    through the origin with the line connecting the component-1 phasor
+    scaled by :math:`m=0.5` and the calibration phasor scaled by
+    :math:`m=0.5`, and :math:`c_\text{ref}` is the reference concentration.
+
+    For each pixel, a normalized intensity is computed:
+
+    .. math::
+
+        m = \frac{I}{I_\text{ref} + I}
+
+    where :math:`I` is the pixel mean intensity and
+    :math:`I_\text{ref} = 2 \cdot \text{reference_mean}` is twice the
+    fluorescence-only mean intensity of the calibration solution.
+
+    The component-0 concentration is then:
+
+    .. math::
+
+        c_0 = \left|
+            \frac{g_\text{pix} \cdot k}{g_0 - g_\text{pix}} \right|
+
+    where :math:`g_\text{pix}` is the real coordinate of the intersection of
+    the line from :math:`g_0` through the origin with the line from the
+    intensity-scaled component-1 phasor :math:`g_1 \cdot m` through
+    the measured phasor.
+    Note: The absolute value in the :math:`c_0` formula is required for phasor
+    geometries where :math:`g_\text{pix}` falls outside the interval
+    :math:`[0, g_0]` (as is typical for NADH), but has not been validated
+    for other analytes or geometries.
+
+    When `brightness_ratio` :math:`\varepsilon = \varepsilon_1 / \varepsilon_0`
+    is provided, the component-0 fraction :math:`f_0` at each pixel is
+    determined by the intersection :math:`g_\text{frac}` of the line from
+    the origin through the measured phasor with the component line:
+
+    .. math::
+
+        f_0 = \frac{g_1 - g_\text{frac}}
+            {g_1 - g_0}
+
+    The component-1 concentration and total concentration are then:
+
+    .. math::
+
+        c_1 &= c_0 \cdot
+            \frac{1 - f_0}{f_0 \cdot \varepsilon}
+
+        c_\text{total} &= c_0 + c_1
+
+    References
+    ----------
+    .. [4] Ma N, Digman M A, Malacrida L, and Gratton E.
+       `Measurements of absolute concentrations of NADH in cells using
+       the phasor FLIM method
+       <https://doi.org/10.1364/BOE.7.002441>`_.
+       *Biomed Opt Express*, 7(7): 2441-2452 (2016)
+
+    Examples
+    --------
+    Verify the calibration self-consistency:
+    when ``mean = 2 * reference_mean`` (intensity modulation ``m = 0.5``)
+    and the pixel phasor equals the reference phasor scaled by 0.5, the
+    result equals ``reference_concentration``:
+
+    >>> phasor_component_concentration(
+    ...     1000.0, 0.4, 0.05, [0.6, 0.2], [0.1, 0.4], 500.0, 0.8, 0.1, 100.0
+    ... )
+    array(100)
+
+    """
+    component_real = numpy.asarray(component_real, dtype=float)
+    component_imag = numpy.asarray(component_imag, dtype=float)
+    if component_real.shape != (2,):
+        msg = f'{component_real.shape=} != (2,)'
+        raise ValueError(msg)
+    if component_imag.shape != (2,):
+        msg = f'{component_imag.shape=} != (2,)'
+        raise ValueError(msg)
+    c0_real = float(component_real[0])
+    c0_imag = float(component_imag[0])
+    c1_real = float(component_real[1])
+    c1_imag = float(component_imag[1])
+    reference_real = float(reference_real)
+    reference_imag = float(reference_imag)
+    reference_mean = float(reference_mean)
+    reference_concentration = float(reference_concentration)
+
+    if c0_real == c1_real:
+        msg = 'component_real values must differ'
+        raise ValueError(msg)
+    if reference_mean == 0.0:
+        msg = 'reference_mean must not be zero'
+        raise ValueError(msg)
+    if reference_concentration <= 0.0:
+        msg = f'{reference_concentration=} is not positive'
+        raise ValueError(msg)
+    if brightness_ratio is not None and brightness_ratio <= 0.0:
+        msg = f'{brightness_ratio=} is not positive'
+        raise ValueError(msg)
+
+    # line(c0 -> origin) X line(c1/2 -> cal/2)
+    # the raw reference phasor is scaled by 0.5 (m=0.5 condition)
+    g_cal, _ = _intersect_line_line(
+        c0_real,
+        c0_imag,
+        0.0,
+        0.0,
+        c1_real * 0.5,
+        c1_imag * 0.5,
+        reference_real * 0.5,
+        reference_imag * 0.5,
+    )
+    # calibration factor
+    k = reference_concentration * (c0_real - g_cal) / g_cal
+
+    # TODO: preserve float32
+    mean = numpy.asarray(mean, dtype=numpy.float64)
+    real = numpy.asarray(real, dtype=numpy.float64)
+    imag = numpy.asarray(imag, dtype=numpy.float64)
+
+    # normalized intensity
+    m = mean / ((2.0 * reference_mean) + mean)
+
+    # scale second-component phasor by normalized intensity
+    c1_real_scaled = c1_real * m
+    c1_imag_scaled = c1_imag * m
+
+    # line(c0 -> origin) X line(scaled_c1 -> data)
+    g_pix, _ = _intersect_line_line(
+        c0_real,
+        c0_imag,
+        0.0,
+        0.0,
+        c1_real_scaled,
+        c1_imag_scaled,
+        real,
+        imag,
+    )
+
+    # absolute concentration of first component
+    # abs() matches the SimFCS implementation and is required when g_pix
+    # falls outside [0, c0_real]
+    with numpy.errstate(divide='ignore', invalid='ignore'):
+        conc_first = numpy.asarray(numpy.abs(g_pix * k / (c0_real - g_pix)))
+
+    if brightness_ratio is None:
+        return conc_first
+
+    # first-component fraction from line(origin -> data) X line(c0 -> c1)
+    # this matches the SimFCS implementation; alternatively, the closest point
+    # on the component line to the pixel phasor could be used
+    g_frac, _ = _intersect_line_line(
+        c0_real,
+        c0_imag,
+        c1_real,
+        c1_imag,
+        0.0,
+        0.0,
+        real,
+        imag,
+    )
+    with numpy.errstate(divide='ignore', invalid='ignore'):
+        frac_first = numpy.asarray(
+            1.0 - (g_frac - c0_real) / (c1_real - c0_real)
+        )
+        frac_second = 1.0 - frac_first
+        conc_second = numpy.asarray(
+            conc_first * frac_second / (frac_first * brightness_ratio)
+        )
+
+    return conc_first, conc_second
 
 
 def phasor_component_mvc(

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -545,6 +545,14 @@ MISC = pooch.create(
     base_url='https://github.com/phasorpy/phasorpy-data/raw/main/misc',
     env=ENV,
     registry={
+        'NADH_1mM.r64': (
+            'sha256:'
+            'fea442ae2d90bf41ed6187f1874db99f689e72c90ab74f726a99e7615b7c5128'
+        ),
+        'NADH_cell.r64': (
+            'sha256:'
+            '5e819282076007117cea3c1d4a59688523fcf90b0b038e6d9b98c2a8570cba4a'
+        ),
         'NADHandSHG.ifli': (
             'sha256:'
             'dfa65952850b8a222258776a8a14eb1ab7e70ff5f62b58aa2214797c5921b4a3'

--- a/src/phasorpy/plot/_phasorplot.py
+++ b/src/phasorpy/plot/_phasorplot.py
@@ -121,7 +121,8 @@ class PhasorPlot:
         **kwargs: Any,
     ) -> None:
         # initialize empty phasor plot
-        self._ax = pyplot.subplots()[1] if ax is None else ax
+        figsize = kwargs.pop('figsize', None)
+        self._ax = pyplot.subplots(figsize=figsize)[1] if ax is None else ax
         self._ax.format_coord = (  # type: ignore[method-assign]
             self._on_format_coord
         )

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -7,6 +7,7 @@ import pytest
 from numpy.testing import assert_allclose
 
 from phasorpy.component import (
+    phasor_component_concentration,
     phasor_component_fit,
     phasor_component_fraction,
     phasor_component_graphical,
@@ -672,6 +673,99 @@ def test_phasor_component_fit():
     component_imag[0] = numpy.inf
     with pytest.raises(ValueError):
         phasor_component_fit(mean, real, imag, component_imag, component_imag)
+
+
+def test_phasor_component_concentration():
+    """Test phasor_component_concentration."""
+    free_real = 0.6
+    free_imag = 0.1
+    bound_real = 0.2
+    bound_imag = 0.4
+    ref_real = 0.8
+    ref_imag = 0.1
+    ref_mean = 500.0
+    ref_conc = 100.0
+
+    args = (
+        [free_real, bound_real],
+        [free_imag, bound_imag],
+        ref_mean,
+        ref_real,
+        ref_imag,
+        ref_conc,
+    )
+
+    # recover reference concentration from calibration at m=0.5
+    # pixel = (2*ref_mean, ref_real*0.5, ref_imag*0.5) = (1000, 0.4, 0.05)
+    result = phasor_component_concentration(1000.0, 0.4, 0.05, *args)
+    assert_allclose(result, 100.0)
+
+    # scalar input returns scalar-like array
+    result = phasor_component_concentration(500.0, 0.4, 0.05, *args)
+    assert_allclose(result, 90.0)
+
+    # array input
+    means = numpy.array([1000.0, 500.0, 2000.0])
+    reals = numpy.array([0.4, 0.4, 0.4])
+    imags = numpy.array([0.05, 0.05, 0.05])
+    result = phasor_component_concentration(means, reals, imags, *args)
+    assert isinstance(result, numpy.ndarray)
+    assert result.shape == (3,)
+    assert_allclose(result[0], 100.0)
+
+    # with brightness_ratio: returns (c_free, c_bound) for a pixel on the
+    # free-bound line
+    # pixel at 60% free / 40% bound: (0.6*0.6 + 0.4*0.2, 0.6*0.1 + 0.4*0.4)
+    fb_real = free_real * 0.6 + bound_real * 0.4  # 0.44
+    fb_imag = free_imag * 0.6 + bound_imag * 0.4  # 0.22
+    conc_free, conc_bound = phasor_component_concentration(
+        1000.0, fb_real, fb_imag, *args, brightness_ratio=1.0
+    )
+    assert conc_free >= 0.0
+    assert conc_bound >= 0.0
+    # with brightness_ratio=1: conc_bound/conc_free = f_bound/f_free = 0.4/0.6
+    assert_allclose(conc_bound / conc_free, 0.4 / 0.6, rtol=1e-5)
+
+    # NaN input propagates to NaN output
+    result = phasor_component_concentration(
+        ref_mean, numpy.nan, ref_imag, *args
+    )
+    assert numpy.isnan(result)
+
+
+def test_phasor_component_concentration_errors():
+    """Test phasor_component_concentration raises ValueError for bad inputs."""
+    args = ([0.6, 0.2], [0.1, 0.4], 500.0, 0.8, 0.1, 100.0)
+
+    # component_real.shape != (2,)
+    with pytest.raises(ValueError, match='component_real'):
+        phasor_component_concentration(1.0, 0.4, 0.05, [0.6], *args[1:])
+
+    # component_imag.shape != (2,)
+    with pytest.raises(ValueError, match='component_imag'):
+        phasor_component_concentration(
+            1.0, 0.4, 0.05, args[0], [0.1], *args[2:]
+        )
+
+    # component_real[0] == component_real[1]
+    with pytest.raises(ValueError, match='component_real'):
+        phasor_component_concentration(1.0, 0.4, 0.05, [0.2, 0.2], *args[1:])
+
+    # reference_mean == 0
+    with pytest.raises(ValueError, match='reference_mean'):
+        phasor_component_concentration(
+            1.0, 0.4, 0.05, *args[:2], 0.0, *args[3:]
+        )
+
+    # reference_concentration <= 0
+    with pytest.raises(ValueError, match='reference_concentration'):
+        phasor_component_concentration(1.0, 0.4, 0.05, *args[:5], 0.0)
+
+    # brightness_ratio <= 0
+    with pytest.raises(ValueError, match='brightness_ratio'):
+        phasor_component_concentration(
+            1.0, 0.4, 0.05, *args, brightness_ratio=-1.0
+        )
 
 
 # mypy: allow-untyped-defs, allow-untyped-calls

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -747,6 +747,18 @@ def test_phasor_component_concentration_errors():
             1.0, 0.4, 0.05, args[0], [0.1], *args[2:]
         )
 
+    # component_real contains NaN
+    with pytest.raises(ValueError, match='NaN'):
+        phasor_component_concentration(
+            1.0, 0.4, 0.05, [float('nan'), 0.2], *args[1:]
+        )
+
+    # component_imag contains inf
+    with pytest.raises(ValueError, match='infinite'):
+        phasor_component_concentration(
+            1.0, 0.4, 0.05, args[0], [0.1, float('inf')], *args[2:]
+        )
+
     # component_real[0] == component_real[1]
     with pytest.raises(ValueError, match='component_real'):
         phasor_component_concentration(1.0, 0.4, 0.05, [0.2, 0.2], *args[1:])

--- a/tutorials/applications/phasorpy_nadh_concentration.py
+++ b/tutorials/applications/phasorpy_nadh_concentration.py
@@ -1,0 +1,432 @@
+"""
+NADH absolute concentration
+============================
+
+Determine absolute NADH concentration using intensity-calibrated phasor FLIM.
+
+NADH (nicotinamide adenine dinucleotide) is an endogenous fluorophore
+present in cells in two forms, distinguishable by fluorescence lifetime:
+a short-lived free form (cytoplasmic NADH, lifetime ~0.4 ns) and a long-lived
+enzyme-bound form (lifetime ~3.4 ns).
+
+The :py:func:`phasorpy.component.phasor_component_concentration` function
+determines absolute free (and optionally bound) NADH concentrations per pixel
+from two pieces of information: the phasor coordinate, which encodes the
+free-to-bound ratio, and the mean fluorescence intensity, which is scaled to
+absolute concentration using a calibration solution of known concentration.
+
+This tutorial demonstrates the method based on:
+
+.. _ma-2016:
+
+  Ma N, Digman MA, Malacrida L, and Gratton E.
+  `Measurements of absolute concentrations of NADH in cells using the
+  phasor FLIM method <https://doi.org/10.1364/BOE.7.002441>`_.
+  *Biomed Opt Express*, 7(7): 2441-2452 (2016).
+
+"""
+
+# %%
+# Import required modules, functions, and classes:
+
+import math
+
+from phasorpy.component import phasor_component_concentration
+from phasorpy.datasets import fetch
+from phasorpy.filter import phasor_filter_median, phasor_threshold
+from phasorpy.io import phasor_from_simfcs_referenced
+from phasorpy.lifetime import phasor_from_lifetime
+from phasorpy.phasor import phasor_center
+from phasorpy.plot import PhasorPlot, plot_image
+
+# %%
+# CHO-K1 cell measurements
+# ------------------------
+#
+# Determine the absolute NADH concentration in each pixel of a FLIM dataset
+# of CHO-K1 cells measured at 80 MHz, using a 1 mM NADH solution (acquired
+# with the same instrument settings) as the calibration standard.
+#
+# Read the CHO-K1 cell phasor coordinate images from a SimFCS referenced file.
+# Apply a median filter to reduce noise and threshold to retain only
+# pixels with sufficient signal:
+
+filename = fetch('NADH_cell.r64')
+
+cell_mean, cell_real, cell_imag = phasor_threshold(
+    *phasor_filter_median(
+        *phasor_from_simfcs_referenced(filename)[:3],
+        repeat=4,
+    ),
+    mean_min=0.5,
+)
+
+# %%
+# Read the NADH reference/calibration phasor images.
+# The center of the phasor distribution gives the fluorescence-only mean
+# intensity and the unshifted reference phasor.
+
+filename = fetch('NADH_1mM.r64')
+
+reference_mean, reference_real, reference_imag = (
+    float(v)
+    for v in phasor_center(
+        *phasor_threshold(
+            *phasor_from_simfcs_referenced(filename)[:3],
+            mean_min=1.0,
+        )
+    )
+)
+reference_concentration = 1.0  # 1 mM NADH standard
+
+# %%
+# Calculate the phasor coordinates of free and enzyme-bound NADH at 80 MHz
+# from their known single-exponential fluorescence lifetimes:
+
+frequency = 80.0  # MHz
+free_lifetime = 0.4  # ns, free cytoplasmic NADH
+bound_lifetime = 3.4  # ns, enzyme-bound NADH
+
+free_real, free_imag = (
+    float(v) for v in phasor_from_lifetime(frequency, free_lifetime)
+)
+bound_real, bound_imag = (
+    float(v) for v in phasor_from_lifetime(frequency, bound_lifetime)
+)
+
+# %%
+# Plot the phasor distribution of the cell and the reference phasor
+# coordinates. Pixels cluster along the free-bound NADH line:
+
+phasor_plot = PhasorPlot(
+    frequency=frequency,
+    title='CHO-K1 cell phasor distribution',
+)
+phasor_plot.hist2d(cell_real, cell_imag)
+phasor_plot.line([free_real, bound_real], [free_imag, bound_imag], ls='-')
+for label, (rx, ix, col) in {
+    'Free NADH': (free_real, free_imag, 'tab:olive'),
+    'Bound NADH': (bound_real, bound_imag, 'tab:purple'),
+    '1 mM NADH': (reference_real, reference_imag, 'tab:green'),
+}.items():
+    phasor_plot.plot(
+        rx,
+        ix,
+        color=col,
+        markersize=10,
+        markeredgecolor='black',
+        markeredgewidth=0.5,
+        label=label,
+    )
+phasor_plot.show()
+
+# %%
+# Compute the free, bound, and total NADH concentrations for each cell pixel.
+# The brightness ratio (molecular brightness of bound relative to free NADH)
+# is set to 1.0 to reproduce the results of :ref:`Ma et al <ma-2016>`, who
+# did not apply a brightness correction. This is known to be incorrect:
+# bound NADH has a ~3-5x higher quantum yield than free NADH, so accurate
+# total concentrations require a measured brightness ratio:
+
+conc_free, conc_bound = phasor_component_concentration(
+    cell_mean,
+    cell_real,
+    cell_imag,
+    [free_real, bound_real],
+    [free_imag, bound_imag],
+    reference_mean,
+    reference_real,
+    reference_imag,
+    reference_concentration,
+    brightness_ratio=1.0,
+)
+
+conc_total = conc_free + conc_bound
+
+# %%
+# Display the total NADH concentration image. Pixels below the intensity
+# threshold are NaN.
+# The total NADH concentration can be directly compared to the published
+# results (Fig. 7b of :ref:`Ma et al <ma-2016>`), which show a matching
+# concentration range and spatial distribution:
+
+plot_image(
+    conc_total[:128],  # only show the cell region
+    vmin=0.0,
+    vmax=1.0,
+    title='Total NADH concentration (mM) in CHO-K1 cell',
+)
+
+# %%
+# Algorithm
+# ---------
+#
+# The geometric algorithm for computing the concentrations of two components
+# from phasor coordinates is documented in detail in
+# :py:func:`phasorpy.component.phasor_component_concentration` and works by
+# intersecting lines in phasor space.
+#
+# The phasor diagram below shows all coordinates and lines involved in the
+# algorithm:
+
+# Constants
+frequency = 80.0  # MHz
+free_lifetime = 0.4  # ns, free NADH
+bound_lifetime = 3.4  # ns, bound NADH
+
+ref_real = 0.94  # reference phasor
+ref_imag = 0.22
+ref_mean = 3000.0  # approximate fluorescence-only reference mean
+pix_mean = 4000.0  # example pixel intensity
+bound_frac = 0.30  # example pixel: ~30 % bound fraction
+
+# Phasor coordinates of free and bound NADH from lifetimes
+free_real, free_imag = (
+    float(v) for v in phasor_from_lifetime(frequency, free_lifetime)
+)
+bound_real, bound_imag = (
+    float(v) for v in phasor_from_lifetime(frequency, bound_lifetime)
+)
+
+# Example cell pixel slightly off the free-bound line.
+# Real pixels scatter around the F-B line due to noise and other components.
+# The offset is chosen so that g_pix stays within the diagram.
+pix_real = free_real * (1 - bound_frac) + bound_real * bound_frac + 0.035
+pix_imag = free_imag * (1 - bound_frac) + bound_imag * bound_frac - 0.035
+
+# Bound and reference phasors scaled to m = 0.5
+# (calibration condition I == I_ref)
+b_cal_real = bound_real * 0.5
+b_cal_imag = bound_imag * 0.5
+r_cal_real = ref_real * 0.5
+r_cal_imag = ref_imag * 0.5
+
+# Bound phasor scaled to pixel intensity
+m_pix = pix_mean / (2.0 * ref_mean + pix_mean)
+b_pix_real = bound_real * m_pix
+b_pix_imag = bound_imag * m_pix
+
+
+def intersect(x0, y0, x1, y1, x2, y2, x3, y3):
+    # return intersection of line (x0,y0)-(x1,y1) and (x2,y2)-(x3,y3)
+    det = (x0 - x1) * (y2 - y3) - (y0 - y1) * (x2 - x3)
+    if det == 0:
+        return math.nan, math.nan
+    a = x0 * y1 - y0 * x1
+    b = x2 * y3 - y2 * x3
+    return [
+        (a * (x2 - x3) - (x0 - x1) * b) / det,
+        (a * (y2 - y3) - (y0 - y1) * b) / det,
+    ]
+
+
+def extend(x1, y1, x2, y2, oh=0.075):
+    # return start exact, end extended by oh past the intersection point
+    d = math.hypot(x2 - x1, y2 - y1)
+    ux, uy = (x2 - x1) / d, (y2 - y1) / d
+    return x1, y1, x2 + oh * ux, y2 + oh * uy
+
+
+# g_cal: line(free -> origin) X line(b_cal -> r_cal)
+g_cal, s_cal = intersect(
+    free_real,
+    free_imag,
+    0.0,
+    0.0,
+    b_cal_real,
+    b_cal_imag,
+    r_cal_real,
+    r_cal_imag,
+)
+
+# g_pix: line(free -> origin) X line(b_pix -> pixel)
+g_pix, s_pix = intersect(
+    free_real,
+    free_imag,
+    0.0,
+    0.0,
+    b_pix_real,
+    b_pix_imag,
+    pix_real,
+    pix_imag,
+)
+
+# g_frac: line(free -> bound) X line(origin -> pixel)
+g_frac, s_frac = intersect(
+    free_real,
+    free_imag,
+    bound_real,
+    bound_imag,
+    0.0,
+    0.0,
+    pix_real,
+    pix_imag,
+)
+
+phasor_plot = PhasorPlot(
+    figsize=(12.2, 4.8),
+    frequency=frequency,
+    xlim=(-0.025, 1.46),
+    ylim=(-0.025, 0.55),
+    grid={'lifetime': [0, 1, 2, 4, 8]},
+    title='Phasor geometry of NADH concentration algorithm',
+)
+
+# Origin -> Reference
+phasor_plot.line(
+    [0.0, ref_real],
+    [0.0, ref_imag],
+    color='tab:gray',
+    linestyle=':',
+    alpha=0.7,
+)
+
+# Free -> Bound
+phasor_plot.line(
+    [free_real, bound_real],
+    [free_imag, bound_imag],
+    color='tab:gray',
+    linestyle='-',
+    alpha=0.7,
+)
+
+# Origin -> Bound
+phasor_plot.line(
+    [0.0, bound_real],
+    [0.0, bound_imag],
+    color='tab:gray',
+    linestyle=':',
+    alpha=0.7,
+)
+
+# Origin -> Free
+x0, y0, x1, y1 = extend(0.0, 0.0, g_pix, s_pix)
+phasor_plot.line(
+    [x0, x1],
+    [y0, y1],
+    color='tab:olive',
+    linestyle='-',
+)
+
+# Origin -> g_frac
+x0, y0, x1, y1 = extend(0.0, 0.0, g_frac, s_frac)
+phasor_plot.line(
+    [x0, x1],
+    [y0, y1],
+    color='tab:blue',
+    linestyle='-',
+)
+
+# B_cal -> g_cal
+x0, y0, x1, y1 = extend(b_cal_real, b_cal_imag, g_cal, s_cal)
+phasor_plot.line(
+    [x0, x1],
+    [y0, y1],
+    color='tab:green',
+    linestyle='-',
+)
+
+# B_pix -> g_pix
+x0, y0, x1, y1 = extend(b_pix_real, b_pix_imag, g_pix, s_pix)
+phasor_plot.line(
+    [x0, x1],
+    [y0, y1],
+    color='tab:orange',
+    linestyle='-',
+)
+
+# Phasor coordinates
+for label, (rx, ix, col, mk, (dx, dy)) in {
+    'Pixel': (pix_real, pix_imag, 'tab:blue', 'o', (-0.02, -0.035)),
+    'Free': (free_real, free_imag, 'tab:olive', 'o', (0.02, -0.03)),
+    'Bound': (bound_real, bound_imag, 'tab:purple', 'o', (-0.1, 0.0)),
+    'Reference': (ref_real, ref_imag, 'tab:green', 'o', (0.017, 0.0)),
+    'Origin': (0.0, 0.0, 'tab:gray', 'o', (0.02, -0.015)),
+    '$R_\\mathrm{cal}$': (
+        r_cal_real,
+        r_cal_imag,
+        'tab:green',
+        '^',
+        (0.01, 0.015),
+    ),
+    '$B_\\mathrm{cal}$': (
+        b_cal_real,
+        b_cal_imag,
+        'tab:green',
+        '^',
+        (0.025, 0.01),
+    ),
+    '$B_\\mathrm{pix}$': (
+        b_pix_real,
+        b_pix_imag,
+        'tab:orange',
+        '^',
+        (0.01, -0.03),
+    ),
+    '$g_\\mathrm{cal}$': (g_cal, s_cal, 'tab:green', 'X', (-0.01, -0.04)),
+    '$g_\\mathrm{pix}$': (g_pix, s_pix, 'tab:orange', 'X', (-0.01, -0.04)),
+    '$g_\\mathrm{frac}$': (g_frac, s_frac, 'tab:blue', 'X', (-0.01, 0.03)),
+}.items():
+    phasor_plot.plot(
+        rx,
+        ix,
+        marker=mk,
+        fillstyle='left' if label == 'Pixel' else None,
+        markerfacecolor=col,
+        markerfacecoloralt='tab:orange' if label == 'Pixel' else col,
+        markersize=10,
+        markeredgecolor='black',
+        markeredgewidth=0.5,
+    )
+    phasor_plot.ax.annotate(
+        label,
+        xy=(rx, ix),
+        xytext=(rx + dx, ix + dy),
+        fontsize=10,
+        fontweight='bold',
+        color=col,
+    )
+
+phasor_plot.show()
+
+# %%
+# The steps below correspond to the labelled points in the phasor diagram,
+# using the free phasor :math:`F`, bound phasor :math:`B`,
+# reference phasor :math:`R` (center of the calibration distribution),
+# per-pixel phasor :math:`P`, and the origin :math:`O`:
+#
+# **1. Calibration factor**:
+# Scale bound and reference phasors by fixed intensity modulation
+# :math:`m = 0.5` to obtain :math:`B_\text{cal} = 0.5 \cdot B`
+# and :math:`R_\text{cal} = 0.5 \cdot R`.
+# Find :math:`g_\text{cal}`, the intersection of the :math:`F`-:math:`O` line
+# with the :math:`B_\text{cal}`-:math:`R_\text{cal}` line.
+# The calibration factor is
+# :math:`k = c_\text{ref} \cdot (g_\text{free} - g_\text{cal}) / g_\text{cal}`,
+# where :math:`g_\text{free}` is the real/G component of the free phasor.
+#
+# **2. Per-pixel intensity modulation**:
+# For each pixel with mean intensity :math:`I`, compute
+# :math:`m = I / (2 I_R + I)` where :math:`I_R` is the reference mean.
+# Scale the bound phasor: :math:`B_\text{pix} = m \cdot B`.
+#
+# **3. Free concentration**:
+# Find :math:`g_\text{pix}`, the intersection of the :math:`F`-:math:`O` line
+# with the :math:`B_\text{pix}`-:math:`P` line.
+# Then :math:`c_\text{free} = |g_\text{pix} \cdot k / (g_\text{free}
+# - g_\text{pix})|`.
+#
+# **4. Bound and total concentration** (when brightness ratio is provided):
+# Find :math:`g_\text{frac}`, the intersection of the :math:`F`-:math:`B` line
+# with the :math:`O`-:math:`P` line.
+# :math:`g_\text{frac}` determines the free fraction :math:`f_\text{free}`,
+# from which :math:`c_\text{bound}` and :math:`c_\text{total}` follow.
+#
+# Note that the diagram labels :math:`g_\text{cal}`, :math:`g_\text{pix}`, and
+# :math:`g_\text{frac}` as intersection points, but only the real/G component
+# is used in the calculations.
+
+# sphinx_gallery_start_ignore
+# sphinx_gallery_thumbnail_number = -2
+# mypy: allow-untyped-defs, allow-untyped-calls
+# sphinx_gallery_end_ignore


### PR DESCRIPTION
## Description

This PR adds a ``phasor_component_concentration`` function to the ``component`` module. The function computes the absolute concentration of the free component (and optionally the bound and total concentrations, given a brightness_ratio) from phasor coordinates and an intensity calibration based on a reference solution of known concentration.

The geometric algorithm and a real-world application are demonstrated in the ``phasorpy_nadh_concentration`` tutorial. Two data files from an NADH measurement are registered in ``datasets.py``.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
