### PR TITLE
Replace pyplot stateful API with OOP equivalents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ all = [
 run = [
     # runtime dependencies; sync with [project.dependencies]
     "numpy>=2.1.0",
-    "matplotlib>=3.9.0",
+    "matplotlib>=3.10.0",
     "pandas>=2.3.0",
     "scikit-learn>=1.5.0",
     "scipy>=1.14.0",
@@ -95,7 +95,7 @@ optional = [
 minimal = [
     # minimal runtime versions for testing against oldest supported versions
     "numpy==2.1.0; python_version == \"3.12\"",
-    "matplotlib==3.9.4; python_version == \"3.12\"",
+    "matplotlib==3.10.3; python_version == \"3.12\"",
     "pandas==2.3.2; python_version == \"3.12\"",
     "scikit-learn==1.5.0; python_version == \"3.12\"",
     "scipy==1.14.1; python_version == \"3.12\"",

--- a/src/phasorpy/plot/_functions.py
+++ b/src/phasorpy/plot/_functions.py
@@ -166,7 +166,7 @@ def plot_phasor_image(
     show : bool, optional, default: True
         Show figure.
     **kwargs
-        Optional arguments passed to :func:`matplotlib.pyplot.imshow`.
+        Optional arguments passed to :py:meth:`matplotlib.axes.Axes.imshow`.
 
     Raises
     ------
@@ -336,7 +336,7 @@ def plot_signal_image(
     show : bool, optional, default: True
         Show figure.
     **kwargs
-        Optional arguments passed to :func:`matplotlib.pyplot.imshow`.
+        Optional arguments passed to :py:meth:`matplotlib.axes.Axes.imshow`.
 
     Raises
     ------
@@ -442,7 +442,7 @@ def plot_image(
     show : bool, optional, default: True
         Show figure.
     **kwargs
-        Optional arguments passed to :func:`matplotlib.pyplot.imshow`.
+        Optional arguments passed to :py:meth:`matplotlib.axes.Axes.imshow`.
 
     Raises
     ------
@@ -588,12 +588,12 @@ def plot_polar_frequency(
     show : bool, optional, default: True
         Show figure.
     **kwargs
-        Optional arguments passed to :py:func:`matplotlib.pyplot.plot`.
+        Optional arguments passed to :py:meth:`matplotlib.axes.Axes.plot`.
 
     """
     # TODO: make this customizable: labels, colors, ...
     if ax is None:
-        ax = pyplot.subplots()[1]
+        ax = pyplot.figure().subplots()
     if title is None:
         title = 'Multi-frequency plot'
     if title:
@@ -648,10 +648,11 @@ def plot_histograms(
     show : bool, optional, default: True
         Show figure.
     **kwargs
-        Optional arguments passed to :func:`matplotlib.pyplot.hist`.
+        Optional arguments passed to :py:meth:`matplotlib.axes.Axes.hist`.
 
     """
-    ax = pyplot.subplots()[1]
+    fig = pyplot.figure()
+    ax = fig.subplots()
     if kwargs.get('alpha') is None:
         ax.hist(
             [numpy.asarray(d).flatten() for d in data], label=labels, **kwargs
@@ -669,7 +670,7 @@ def plot_histograms(
         ax.set_ylabel(ylabel)
     if labels is not None:
         ax.legend()
-    pyplot.tight_layout()
+    fig.tight_layout()
     if show:
         pyplot.show()
 
@@ -690,7 +691,7 @@ def _imshow(
 ) -> AxesImage:
     """Plot image array.
 
-    Convenience wrapper around :py:func:`matplotlib.pyplot.imshow`.
+    Convenience wrapper around :py:meth:`matplotlib.axes.Axes.imshow`.
 
     """
     update_kwargs(kwargs, interpolation='none')

--- a/src/phasorpy/plot/_lifetime_plots.py
+++ b/src/phasorpy/plot/_lifetime_plots.py
@@ -154,9 +154,8 @@ class LifetimePlots:
 
         # create plots
         update_kwargs(kwargs, figsize=(10.24, 7.68))
-        fig, ((time_plot, phasor_plot), (phase_plot, ax4)) = pyplot.subplots(
-            2, 2, **kwargs
-        )
+        fig = pyplot.figure(**kwargs)
+        (time_plot, phasor_plot), (phase_plot, ax4) = fig.subplots(2, 2)
 
         if interactive:
             fcm = fig.canvas.manager

--- a/src/phasorpy/plot/_phasorplot.py
+++ b/src/phasorpy/plot/_phasorplot.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from .._typing import IO, Any, ArrayLike, Literal, NDArray
 
 import numpy
-from matplotlib import pyplot
+from matplotlib import pyplot, rcParams
 from matplotlib.font_manager import FontProperties
 from matplotlib.lines import Line2D
 from matplotlib.patches import (
@@ -83,6 +83,7 @@ class PhasorPlot:
         or :py:meth:`PhasorPlot.semicircle`.
     **kwargs
         Additional properties to set on `ax`.
+        ``figsize`` is passed to :py:func:`matplotlib.pyplot.figure`.
 
     See Also
     --------
@@ -122,7 +123,10 @@ class PhasorPlot:
     ) -> None:
         # initialize empty phasor plot
         figsize = kwargs.pop('figsize', None)
-        self._ax = pyplot.subplots(figsize=figsize)[1] if ax is None else ax
+        if ax is None:
+            self._ax = pyplot.figure(figsize=figsize).subplots()
+        else:
+            self._ax = ax
         self._ax.format_coord = (  # type: ignore[method-assign]
             self._on_format_coord
         )
@@ -195,11 +199,7 @@ class PhasorPlot:
     @property
     def fig(self) -> Figure | None:
         """Matplotlib :py:class:`matplotlib.figure.Figure`."""
-        try:
-            # matplotlib >= 3.10.0
-            return self._ax.get_figure(root=True)
-        except TypeError:
-            return self._ax.get_figure()  # type: ignore[return-value]
+        return self._ax.get_figure(root=True)
 
     @property
     def dataunit_to_point(self) -> float:
@@ -244,10 +244,13 @@ class PhasorPlot:
         file : str, path-like, or binary file-like
             Path or Python file-like object to write the current figure to.
         **kwargs
-            Optional arguments passed to :py:func:`matplotlib.pyplot.savefig`.
+            Optional arguments passed to
+            :py:meth:`matplotlib.figure.Figure.savefig`.
 
         """
-        pyplot.savefig(file, **kwargs)
+        fig = self.fig
+        assert fig is not None
+        fig.savefig(file, **kwargs)  # type: ignore[arg-type]
 
     def plot(
         self,
@@ -1408,7 +1411,7 @@ class CircleTicks(AbstractPathEffect):
             self._origin = float(origin[0]), float(origin[1])
 
         if size is None:
-            self._size = pyplot.rcParams['xtick.major.size']
+            self._size = rcParams['xtick.major.size']
         else:
             self._size = size
         if labels is None or len(labels) == 0:

--- a/tutorials/api/phasorpy_component.py
+++ b/tutorials/api/phasorpy_component.py
@@ -271,13 +271,13 @@ for i in range(fractions.size):
         color='red',
         alpha=0.5,
     )
-    hist_artists = pyplot.plot(
+    hist_artists = hist.plot(
         fractions[: i + 1], counts[0][: i + 1], linestyle='-', color='tab:blue'
     )
     plots.append(plot_lines + hist_artists)
 
 _ = matplotlib.animation.ArtistAnimation(fig, plots, interval=100, blit=True)
-pyplot.tight_layout()
+fig.tight_layout()
 pyplot.show()
 
 # sphinx_gallery_start_ignore

--- a/tutorials/misc/phasorpy_logo.py
+++ b/tutorials/misc/phasorpy_logo.py
@@ -20,8 +20,6 @@ cropped to a circle.
 # %%
 # Import required modules, functions, and classes:
 
-from matplotlib import pyplot
-
 from phasorpy.lifetime import lifetime_to_signal, phasor_from_lifetime
 from phasorpy.phasor import phasor_from_signal, phasor_to_signal
 from phasorpy.plot import PhasorPlot
@@ -60,10 +58,11 @@ arrow_color = None  # set to a color to draw arrow
 background_color = None  # set to a color to fill circle
 linewidth = 25
 
-fig, ax = pyplot.subplots(figsize=(6.4, 6.4))
-ax.set_axis_off()
+plot = PhasorPlot(
+    figsize=(6.4, 6.4), xlim=(-0.04, 1.04), ylim=(-0.55, 0.55), title=None
+)
 
-plot = PhasorPlot(ax=ax, xlim=(-0.04, 1.04), ylim=(-0.55, 0.55), title=None)
+plot.ax.set_axis_off()
 
 plot.semicircle(
     frequency=frequency,
@@ -77,7 +76,7 @@ plot.semicircle(
 plot.cursor(*phasor, radius=0.08, linewidth=linewidth, color=cursor_color)
 
 # draw time-domain signal in inset
-cax = ax.inset_axes((0.015, 0.325, 0.97, 0.45))
+cax = plot.ax.inset_axes((0.015, 0.325, 0.97, 0.45))
 cax.set_ylim(0.02, 1.1)
 cax.set_axis_off()
 cax.plot(
@@ -90,7 +89,7 @@ cax.plot(
 )
 
 # draw harmonic in second inset
-cax = ax.inset_axes((0.125, 0.113, 0.75, 0.25))
+cax = plot.ax.inset_axes((0.125, 0.113, 0.75, 0.25))
 cax.set_ylim(-0.11, 1.14)
 cax.set_axis_off()
 cax.plot(
@@ -132,12 +131,12 @@ if background_color is not None:
         zorder=0,
     )
 
-pyplot.tight_layout(pad=0.0, w_pad=0.0, h_pad=0.0)
+plot.fig.tight_layout(pad=0.0, w_pad=0.0, h_pad=0.0)
 
 # save the figure to an SVG file:
 plot.save('phasorpy_logo.svg', dpi=160, transparent=True, bbox_inches='tight')
 plot.show()
 
 # sphinx_gallery_start_ignore
-# mypy: disable-error-code="unreachable"
+# mypy: disable-error-code="unreachable, union-attr"
 # sphinx_gallery_end_ignore


### PR DESCRIPTION
## Description

Replace pyplot stateful API with OOP equivalents. Bump matplotlib to >=3.10.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
