### PR TITLE
Fix lifetime_to_signal function

### DIFF
--- a/src/phasorpy/lifetime.py
+++ b/src/phasorpy/lifetime.py
@@ -573,10 +573,6 @@ def lifetime_to_signal(
         # IRF characterized directly by phase delay and modulation depth
         zero_real = numpy.atleast_1d(zero_modulation * math.cos(zero_phase))
         zero_imag = numpy.atleast_1d(zero_modulation * math.sin(zero_phase))
-        if real.ndim > 1:
-            # make broadcastable with real and imag
-            zero_real = zero_real[:, None]
-            zero_imag = zero_imag[:, None]
         phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))
         zero = phasor_to_signal(
             float(numpy.asarray(mean).mean()),

--- a/src/phasorpy/lifetime.py
+++ b/src/phasorpy/lifetime.py
@@ -377,7 +377,9 @@ def lifetime_to_signal(
         Must be specified if `lifetime` is not a scalar.
     mean : array_like, optional, default: 1
         Average intensity (DC) of signal and instrument response function.
-        Must be scalar for now.
+        May be a scalar or array-like broadcastable to the synthesized
+        signal shape, for example to specify per-signal mean values when
+        synthesizing multiple signals.
     background : array_like, optional, default: 0
         Background signal intensity. Must be smaller than `mean`.
     samples : int, optional, default: 64
@@ -421,7 +423,8 @@ def lifetime_to_signal(
         Signal generated from lifetimes at frequency, convolved with
         instrument response function.
     zero : ndarray
-        Instrument response function.
+        Instrument response function. Always 1D with shape ``(samples,)``.
+        When `mean` is array-valued, `zero` is scaled to the mean of `mean`.
     time : ndarray
         Time for each sample in signal in units of `lifetime`.
 
@@ -576,7 +579,7 @@ def lifetime_to_signal(
             zero_imag = zero_imag[:, None]
         phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))
         zero = phasor_to_signal(
-            1.0,
+            float(numpy.asarray(mean).mean()),
             zero_modulation * math.cos(zero_phase),
             zero_modulation * math.sin(zero_phase),
             samples=samples,
@@ -603,8 +606,7 @@ def lifetime_to_signal(
                 samples=samples,
                 harmonic=harmonic,
             )
-        # scale zero to have the same mean as the signal (consistent with
-        # the single-harmonic case where zero is returned with mean=1.0)
+        # scale zero to have the same mean as the signal
         # use a scalar so zero stays 1D even when mean is array-valued
         zero *= float(numpy.asarray(mean).mean()) / zero_dc
         phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))

--- a/src/phasorpy/lifetime.py
+++ b/src/phasorpy/lifetime.py
@@ -351,7 +351,8 @@ def lifetime_to_signal(
     background: ArrayLike | None = None,
     samples: int = 64,
     harmonic: int | Sequence[int] | Literal['all'] | str | None = None,
-    zero_phase: float | None = None,
+    zero_phase: float | None = 0.0,
+    zero_modulation: float = 1.0,
     zero_stdev: float | None = None,
     preexponential: bool = False,
     unit_conversion: float = 1e-3,
@@ -360,8 +361,9 @@ def lifetime_to_signal(
 
     Return a synthetic signal, instrument response function (IRF), and
     time axis, sampled over one period of the fundamental frequency.
-    The signal is convolved with the IRF, which is approximated by a
-    normal distribution.
+    The signal is convolved with the IRF. In time-domain mode, the IRF is
+    approximated by a normal distribution. In frequency-domain mode, the IRF
+    is characterized by its phase delay and modulation depth.
 
     Parameters
     ----------
@@ -374,7 +376,8 @@ def lifetime_to_signal(
         components. Fractions are normalized to sum to 1.
         Must be specified if `lifetime` is not a scalar.
     mean : array_like, optional, default: 1
-        Average signal intensity (DC). Must be scalar for now.
+        Average intensity (DC) of signal and instrument response function.
+        Must be scalar for now.
     background : array_like, optional, default: 0
         Background signal intensity. Must be smaller than `mean`.
     samples : int, optional, default: 64
@@ -386,15 +389,24 @@ def lifetime_to_signal(
         `samples`.
         Use `'all'` to synthesize an exponential time-domain decay signal,
         or `1` to synthesize a homodyne signal.
-    zero_phase : float, optional
+    zero_phase : float, optional, default: 0
         Position of instrument response function in radians along one period.
-        Must be in the range [0, 2 pi]. The default is the 8th sample.
+        Must be in the range [0, 2 pi].
+        If `None`, the 8th sample is used to place the IRF peak visually away
+        from the period boundary.
+    zero_modulation : float, optional, default: 1.0
+        Modulation depth of the excitation source. Must be in range (0, 1].
+        Scales the AC component of the synthesized signal.
+        Only applicable when `harmonic` is a single integer.
+        Setting this to 0.5 guarantees a non-negative homodyne signal for
+        any lifetime.
     zero_stdev : float, optional
         Standard deviation of instrument response function in radians.
         When converted to sample units, must be at least 1.5 and less than
         one tenth of the number of samples to allow sufficient sampling.
         The default is equivalent to 1.5 samples. Increase `samples` to
         narrow the IRF.
+        Only applicable when `harmonic` is not a single integer.
     preexponential : bool, optional, default: False
         Fractions are pre-exponential amplitudes instead of
         fractional intensities.
@@ -420,14 +432,45 @@ def lifetime_to_signal(
     :ref:`sphx_glr_tutorials_api_phasorpy_lifetime_to_signal.py`
     :ref:`sphx_glr_tutorials_misc_phasorpy_apps.py`
 
+    Raises
+    ------
+    ValueError
+        If `zero_modulation` is not in range (0, 1].
+        If `zero_modulation` is not 1.0 and `harmonic` is not a single integer.
+        If `zero_stdev` is provided and `harmonic` is a single integer.
+
     Notes
     -----
     This implementation is based on an inverse discrete Fourier transform
-    (DFT). Because DFT cannot be used on signals with discontinuities
-    (for example, an exponential decay starting at zero) without producing
-    strong artifacts (ripples), the signal is convolved with a continuous
-    instrument response function (IRF). The minimum width of the IRF is
-    limited due to sampling requirements.
+    (DFT).
+
+    When `harmonic` is a single integer, the synthesized signal is a
+    **frequency-domain** homodyne waveform. The instrument response function
+    is characterized directly by its phase delay (`zero_phase`, :math:`\phi_0`)
+    and modulation depth (`zero_modulation`, :math:`M_0`), matching how
+    frequency-domain FLIM instruments are calibrated. The waveform is
+
+    .. math::
+
+        I_k = \bar{I} \cdot \left(1 + 2 \cdot M_0 \cdot M \cdot \cos\!\left(
+        \frac{2 \pi h k}{K} - \phi_0 - \phi\right)\right)
+
+    where :math:`\bar{I}` is the mean intensity (`mean`), :math:`\phi` and
+    :math:`M` are the phasor phase and modulation of the lifetime,
+    :math:`h` is the harmonic, :math:`k` is the sample index
+    (0 to :math:`K-1`), and :math:`K` is the number of samples.
+    For short lifetimes, :math:`M` approaches 1, which can cause the signal
+    to become negative. Setting :math:`M_0 <= 0.5` guarantees a non-negative
+    signal for any lifetime.
+
+    When `harmonic` is `'all'` or a sequence, a **time-domain** signal is
+    synthesized from multiple harmonics using an inverse DFT and convolved
+    with a Gaussian IRF of width `zero_stdev`. Because DFT cannot be applied
+    to discontinuous signals (such as an exponential decay starting at zero)
+    without producing strong artifacts (ripples), the IRF width must be
+    sufficient to suppress those artifacts, but narrow enough to be sampled
+    accurately. The concept of excitation modulation depth (`zero_modulation`)
+    has no physical meaning in this mode.
 
     Examples
     --------
@@ -435,25 +478,26 @@ def lifetime_to_signal(
     lifetime components of 4.2 and 0.9 ns at 40 MHz:
 
     >>> signal, zero, times = lifetime_to_signal(
-    ...     40, [4.2, 0.9], fraction=[0.8, 0.2], samples=16
+    ...     40, [4.2, 0.9], fraction=[0.8, 0.2], samples=16, zero_phase=None
     ... )
     >>> signal  # doctest: +NUMBER
     array([0.2846, 0.1961, 0.1354, ..., 0.8874, 0.6029, 0.4135])
 
-    Synthesize a homodyne frequency-domain waveform signal for
+    Synthesize a non-negative homodyne frequency-domain waveform signal for
     a single lifetime:
 
     >>> signal, zero, times = lifetime_to_signal(
-    ...     40.0, 4.2, samples=16, harmonic=1
+    ...     40.0, 4.2, samples=16, harmonic=1, zero_modulation=0.5
     ... )
     >>> signal  # doctest: +NUMBER
-    array([0.2047, -0.05602, -0.156, ..., 1.471, 1.031, 0.5865])
+    array([1.473, 1.628, 1.687, ..., 0.7197, 0.9814, 1.246])
 
     """
     if harmonic is None:
         harmonic = 'all'
     all_harmonics = harmonic == 'all'
     harmonic, _ = parse_harmonic(harmonic, samples // 2)
+    single_harmonic = not all_harmonics and len(harmonic) == 1
 
     if samples < 16:
         msg = f'{samples=} < 16'
@@ -474,20 +518,35 @@ def lifetime_to_signal(
     scale = samples / (2.0 * math.pi)
     if zero_phase is None:
         zero_phase = 8.0 / scale
-    phase = zero_phase * scale  # in sample units
-    if zero_stdev is None:
-        zero_stdev = 1.5 / scale
-    stdev = zero_stdev * scale  # in sample units
 
     if zero_phase < 0 or zero_phase > 2.0 * math.pi:
         msg = f'{zero_phase=} is out of range [0, 2 pi]'
         raise ValueError(msg)
-    if stdev < 1.5:
-        msg = f'{zero_stdev=} < {1.5 / scale} cannot be sampled sufficiently'
-        raise ValueError(msg)
-    if stdev >= samples / 10:
-        msg = f'{zero_stdev=} >= pi / 5 not supported'
-        raise ValueError(msg)
+
+    if single_harmonic:
+        if zero_stdev is not None:
+            msg = 'zero_stdev is not applicable for single-harmonic signals'
+            raise ValueError(msg)
+        if zero_modulation <= 0.0 or zero_modulation > 1.0:
+            msg = f'{zero_modulation=} is not in range (0, 1]'
+            raise ValueError(msg)
+    else:
+        if zero_modulation != 1.0:
+            msg = (
+                f'{zero_modulation=} not supported for multi-harmonic signals'
+            )
+            raise ValueError(msg)
+        if zero_stdev is None:
+            zero_stdev = 1.5 / scale
+        stdev = zero_stdev * scale  # in sample units
+        if stdev < 1.5:
+            msg = (
+                f'{zero_stdev=} < {1.5 / scale} cannot be sampled sufficiently'
+            )
+            raise ValueError(msg)
+        if stdev >= samples / 10:
+            msg = f'{zero_stdev=} >= pi / 5 not supported'
+            raise ValueError(msg)
 
     frequencies = numpy.atleast_1d(frequency)
     if frequencies.size > 1 or frequencies[0] <= 0.0:
@@ -507,21 +566,48 @@ def lifetime_to_signal(
     )
     real, imag = numpy.atleast_1d(real, imag)
 
-    zero = numpy.zeros(samples, dtype=numpy.float64)
-    _gaussian_signal(zero, phase, stdev)
-    zero_mean, zero_real, zero_imag = phasor_from_signal(
-        zero, harmonic=harmonic
-    )
-    if real.ndim > 1:
-        # make broadcastable with real and imag
-        zero_real = zero_real[:, None]
-        zero_imag = zero_imag[:, None]
-    if not all_harmonics:
+    if single_harmonic:
+        # IRF characterized directly by phase delay and modulation depth
+        zero_real = numpy.atleast_1d(zero_modulation * math.cos(zero_phase))
+        zero_imag = numpy.atleast_1d(zero_modulation * math.sin(zero_phase))
+        if real.ndim > 1:
+            # make broadcastable with real and imag
+            zero_real = zero_real[:, None]
+            zero_imag = zero_imag[:, None]
+        phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))
         zero = phasor_to_signal(
-            zero_mean, zero_real, zero_imag, samples=samples, harmonic=harmonic
+            1.0,
+            zero_modulation * math.cos(zero_phase),
+            zero_modulation * math.sin(zero_phase),
+            samples=samples,
+            harmonic=harmonic[0],
         )
-
-    phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))
+    else:
+        # IRF as Gaussian (time-domain / multi-harmonic)
+        phase = zero_phase * scale  # in sample units
+        zero = numpy.zeros(samples, dtype=numpy.float64)
+        _gaussian_signal(zero, phase, stdev)
+        zero_dc = float(zero.mean())  # DC mean as scalar, for scaling later
+        zero_mean, zero_real, zero_imag = phasor_from_signal(
+            zero, harmonic=harmonic
+        )
+        if real.ndim > 1:
+            # make broadcastable with real and imag
+            zero_real = zero_real[:, None]
+            zero_imag = zero_imag[:, None]
+        if not all_harmonics:
+            zero = phasor_to_signal(
+                zero_mean,
+                zero_real,
+                zero_imag,
+                samples=samples,
+                harmonic=harmonic,
+            )
+        # scale zero to have the same mean as the signal (consistent with
+        # the single-harmonic case where zero is returned with mean=1.0)
+        # use a scalar so zero stays 1D even when mean is array-valued
+        zero *= float(numpy.asarray(mean).mean()) / zero_dc
+        phasor_multiply(real, imag, zero_real, zero_imag, out=(real, imag))
 
     if len(harmonic) == 1:
         harmonic = harmonic[0]

--- a/src/phasorpy/plot/_lifetime_plots.py
+++ b/src/phasorpy/plot/_lifetime_plots.py
@@ -433,8 +433,11 @@ class LifetimePlots:
         )
         signal_max = signal.max()
         if signal_max > 0.0:
+            # scale IRF peak to match signal peak
             signal /= signal_max
-            irf /= signal_max
+            irf_max = irf.max()
+            if irf_max > 0.0:
+                irf /= irf_max
 
         component_signal = lifetime_to_signal(
             frequency,

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -60,13 +60,13 @@ rng = numpy.random.default_rng(42)
             # time domain
             'all',
             [0.355548, 0.245101, 0.748013, 0.515772],
-            [0.0, 0.212965, 0.109340, 0.0],
+            [0.0, 3.407445, 1.749441, 0.0],
         ),
         (
             # frequency domain
             1,
-            [0.204701, -0.056023, 1.031253, 0.586501],
-            [-0.042591, 0.159591, 0.13681, -0.034591],
+            [0.054033, -0.256084, 1.037174, 0.508165],
+            [-1.0, 2.847759, 2.414214, -0.847759],
         ),
     ],
 )
@@ -75,7 +75,7 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     index = [0, 1, -2, -1]
     # single lifetime
     signal, zero, time = lifetime_to_signal(
-        40.0, 4.2, samples=16, harmonic=harmonic
+        40.0, 4.2, zero_phase=None, samples=16, harmonic=harmonic
     )
     assert signal.shape == (16,)
     assert zero.shape == (16,)
@@ -86,7 +86,7 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
 
     # two lifetimes
     signal, zero, time = lifetime_to_signal(
-        40.0, [4.2, 4.2], samples=16, harmonic=harmonic
+        40.0, [4.2, 4.2], zero_phase=None, samples=16, harmonic=harmonic
     )
     assert signal.shape == (2, 16)
     assert zero.shape == (16,)
@@ -95,7 +95,12 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
 
     # one multi-components
     signal, zero, time = lifetime_to_signal(
-        40.0, [4.2, 4.2], [0.5, 0.5], samples=16, harmonic=harmonic
+        40.0,
+        [4.2, 4.2],
+        [0.5, 0.5],
+        zero_phase=None,
+        samples=16,
+        harmonic=harmonic,
     )
     assert signal.shape == (16,)
     assert zero.shape == (16,)
@@ -107,6 +112,7 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
         40.0,
         [[4.2, 4.2], [4.2, 4.2]],
         [[0.5, 0.5], [0.5, 0.5]],
+        zero_phase=None,
         samples=16,
         harmonic=harmonic,
     )
@@ -115,10 +121,37 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     assert time.shape == (16,)
     assert_allclose(signal[1, index], expected, atol=1e-3)
 
+    # array-valued mean (e.g. fractions): zero must remain 1D (regression test)
+    signal, zero, time = lifetime_to_signal(
+        40.0,
+        [4.2, 0.5],
+        mean=[0.8, 0.2],
+        zero_phase=None,
+        samples=16,
+        harmonic=harmonic,
+    )
+    assert signal.shape == (2, 16)
+    assert zero.shape == (16,)
+
 
 def test_lifetime_to_signal_parameters():
     """Test lifetime_to_signal function parameters."""
     # TODO: test mean, background, zero_phase, zero_stdev parameters
+    # zero_modulation=0.5 guarantees non-negative homodyne signal
+    signal, _, _ = lifetime_to_signal(
+        40.0, 4.2, samples=16, harmonic=1, zero_modulation=0.5
+    )
+    assert signal.min() >= 0.0
+    # zero_modulation scales the AC component proportionally
+    signal1, _, _ = lifetime_to_signal(40.0, 4.2, samples=16, harmonic=1)
+    signal_half, _, _ = lifetime_to_signal(
+        40.0, 4.2, samples=16, harmonic=1, zero_modulation=0.5
+    )
+    assert_allclose(
+        signal_half - signal_half.mean(),
+        (signal1 - signal1.mean()) * 0.5,
+        atol=1e-10,
+    )
 
 
 def test_lifetime_to_signal_error():
@@ -144,6 +177,16 @@ def test_lifetime_to_signal_error():
         lifetime_to_signal(40.0, 4.2, samples=100, zero_stdev=math.pi / 5)
     with pytest.raises(IndexError):
         lifetime_to_signal(40.0, 4.2, harmonic=0)
+    with pytest.raises(ValueError):
+        lifetime_to_signal(40.0, 4.2, harmonic=1, zero_modulation=0.0)
+    with pytest.raises(ValueError):
+        lifetime_to_signal(40.0, 4.2, harmonic=1, zero_modulation=1.1)
+    with pytest.raises(ValueError):
+        lifetime_to_signal(40.0, 4.2, zero_modulation=0.5)  # harmonic='all'
+    with pytest.raises(ValueError):
+        lifetime_to_signal(40.0, 4.2, harmonic=[1, 2], zero_modulation=0.5)
+    with pytest.raises(ValueError):
+        lifetime_to_signal(40.0, 4.2, harmonic=1, zero_stdev=0.1)
 
 
 def test_phasor_semicircle():

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -93,8 +93,7 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     assert time.shape == (16,)
     assert_allclose(signal[1, index], expected, atol=1e-3)
 
-    # two distinct lifetimes: validates zero_real/zero_imag broadcasting
-    # (real.ndim > 1 branch) by checking the rows differ and match individually
+    # two distinct lifetimes: checks each row matches the single-lifetime result
     signal, zero, time = lifetime_to_signal(
         40.0, [4.2, 0.9], zero_phase=None, samples=16, harmonic=harmonic
     )

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -93,6 +93,22 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     assert time.shape == (16,)
     assert_allclose(signal[1, index], expected, atol=1e-3)
 
+    # two distinct lifetimes: validates zero_real/zero_imag broadcasting
+    # (real.ndim > 1 branch) by checking the rows differ and match individually
+    signal, zero, time = lifetime_to_signal(
+        40.0, [4.2, 0.9], zero_phase=None, samples=16, harmonic=harmonic
+    )
+    assert signal.shape == (2, 16)
+    assert zero.shape == (16,)
+    signal_42, _, _ = lifetime_to_signal(
+        40.0, 4.2, zero_phase=None, samples=16, harmonic=harmonic
+    )
+    signal_09, _, _ = lifetime_to_signal(
+        40.0, 0.9, zero_phase=None, samples=16, harmonic=harmonic
+    )
+    assert_allclose(signal[0], signal_42, atol=1e-10)
+    assert_allclose(signal[1], signal_09, atol=1e-10)
+
     # one multi-components
     signal, zero, time = lifetime_to_signal(
         40.0,
@@ -134,6 +150,34 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     assert zero.shape == (16,)
 
 
+def test_lifetime_to_signal_multiharmonic():
+    """Test lifetime_to_signal with a sequence of harmonics."""
+    index = [0, 1, -2, -1]
+    expected = [0.38780, 0.34679, 0.64469, 0.44264]
+    zero_expected = [0.31774, 3.25999, 2.18897, 0.15308]
+
+    # single lifetime with harmonic sequence (not all_harmonics, not single)
+    signal, zero, time = lifetime_to_signal(
+        40.0, 4.2, zero_phase=None, samples=16, harmonic=[1, 2]
+    )
+    assert signal.shape == (16,)
+    assert zero.shape == (16,)
+    assert time.shape == (16,)
+    assert_allclose(signal[index], expected, atol=1e-3)
+    assert_allclose(zero[[0, 9, 10, -1]], zero_expected, atol=1e-3)
+
+    # two lifetimes with harmonic sequence: real.ndim > 1 in else branch
+    signal, zero, time = lifetime_to_signal(
+        40.0, [4.2, 4.2], zero_phase=None, samples=16, harmonic=[1, 2]
+    )
+    assert signal.shape == (2, 16)
+    assert zero.shape == (16,)
+    assert time.shape == (16,)
+    assert_allclose(signal[0, index], expected, atol=1e-3)
+    assert_allclose(signal[1, index], expected, atol=1e-3)
+    assert_allclose(zero[[0, 9, 10, -1]], zero_expected, atol=1e-3)
+
+
 def test_lifetime_to_signal_parameters():
     """Test lifetime_to_signal function parameters."""
     # TODO: test mean, background, zero_phase, zero_stdev parameters
@@ -152,6 +196,14 @@ def test_lifetime_to_signal_parameters():
         (signal1 - signal1.mean()) * 0.5,
         atol=1e-10,
     )
+    # single-harmonic zero mean equals background-subtracted mean,
+    # consistent with the multi-harmonic branch
+    for harmonic in (1, [1, 2], 'all'):
+        mean_val = 3.5
+        _, zero, _ = lifetime_to_signal(
+            40.0, 4.2, mean=mean_val, samples=16, harmonic=harmonic
+        )
+        assert_allclose(zero.mean(), mean_val, atol=1e-6)
 
 
 def test_lifetime_to_signal_error():

--- a/tutorials/api/phasorpy_lifetime_to_signal.py
+++ b/tutorials/api/phasorpy_lifetime_to_signal.py
@@ -38,8 +38,8 @@ settings = {
     'samples': 256,  # number of samples to synthesize
     'mean': 1.0,  # average intensity
     'background': 0.0,  # no signal from background
-    'zero_phase': None,  # location of IRF peak in the phase
-    'zero_stdev': None,  # standard deviation of IRF in radians
+    'zero_phase': None,  # automatic location of IRF peak in the phase
+    'zero_stdev': None,  # standard deviation of time-domain IRF in radians
 }
 
 # %%
@@ -65,7 +65,7 @@ reference_signal, _, _ = lifetime_to_signal(
 )
 
 
-def verify_signal(fractions):
+def verify_signal(reference_signal, fractions=None):
     """Verify calibrated phasor coordinates match expected results."""
     assert numpy.allclose(
         phasor_calibrate(
@@ -80,7 +80,7 @@ def verify_signal(fractions):
     )
 
 
-verify_signal(fractions)
+verify_signal(reference_signal, fractions)
 
 # %%
 # Plot the synthesized signals (multi-exponential, reference, and
@@ -92,9 +92,16 @@ ax.set(
     xlabel='Times [ns]',
     ylabel='Intensity [au]',
 )
+ax.plot(
+    times,
+    # scale IRF peak to match signal peak
+    instrument_response * (signal.max() / instrument_response.max()),
+    linewidth=0.8,
+    color='tab:grey',
+    label='Instrument response',
+)
 ax.plot(times, signal, label='Multi-exponential')
 ax.plot(times, reference_signal, label='Reference')
-ax.plot(times, instrument_response, label='Instrument response')
 ax.legend()
 pyplot.show()
 
@@ -107,7 +114,7 @@ pyplot.show()
 
 signal, _, times = lifetime_to_signal(frequency, lifetimes, **settings)
 
-verify_signal(None)
+verify_signal(reference_signal)
 
 # %%
 # Plot the synthesized signals:
@@ -140,7 +147,7 @@ reference_signal, _, _ = lifetime_to_signal(
     frequency, reference_lifetime, harmonic=1, **settings
 )
 
-verify_signal(fractions)
+verify_signal(reference_signal, fractions)
 
 # %%
 # Plot the synthesized signals:
@@ -154,22 +161,39 @@ ax.set(
     ylabel='Intensity [au]',
     xticks=[0, 90, 180, 270, 360],
 )
+ax.plot(
+    phase,
+    instrument_response,
+    linewidth=0.8,
+    color='tab:grey',
+    label='Instrument response',
+)
 ax.plot(phase, signal, label='Multi-exponential')
 ax.plot(phase, reference_signal, label='Reference')
-ax.plot(phase, instrument_response, label='Instrument response')
 ax.legend()
 pyplot.show()
+
+# %%
+# The homodyne signal can contain negative values since the modulation depth
+# of the excitation source is 1.
 
 # %%
 # Frequency domain, single exponential
 # ------------------------------------
 #
-# To synthesize separate signals for each lifetime component at once,
-# omit the lifetime fractions:
+# To synthesize separate signals for each lifetime component at once, omit the
+# lifetime fractions. Halving the modulation depth of the excitation source
+# (``zero_modulation=0.5``) guarantees a non-negative signal for any lifetime:
 
-signal, _, _ = lifetime_to_signal(frequency, lifetimes, harmonic=1, **settings)
+signal, _, _ = lifetime_to_signal(
+    frequency, lifetimes, harmonic=1, zero_modulation=0.5, **settings
+)
 
-verify_signal(None)
+reference_signal, _, _ = lifetime_to_signal(
+    frequency, reference_lifetime, harmonic=1, zero_modulation=0.5, **settings
+)
+
+verify_signal(reference_signal)
 
 # %%
 # Plot the synthesized signals:


### PR DESCRIPTION
## Description

This PR contains fixes and improvements to the `lifetime_to_signal` function. Several changes are breaking.

Previously, `lifetime_to_signal` used a Gaussian instrument response function even when `harmonic=1` (frequency-domain homodyne mode). This was physically incorrect: frequency-domain FLIM instruments are characterized by a phase delay and modulation depth, not a pulse width. The Gaussian unnecessarily attenuated the AC component and made `zero_stdev` a meaningless proxy for modulation depth in that mode.

Changes:

- **Single-harmonic mode** (`harmonic=1`): IRF is now a pure sinusoid, characterized by `zero_phase` and the new `zero_modulation` parameter. `zero_stdev` raises `ValueError` if supplied.

- **Multi-harmonic mode** (`harmonic='all'` or sequence): behavior unchanged; Gaussian IRF controlled by `zero_phase` and `zero_stdev`. `zero_modulation != 1.0` raises `ValueError`.

- New `zero_modulation` parameter (default `1.0`) scales the AC component of the homodyne signal; setting it to `<= 0.5` guarantees a non-negative signal for any lifetime.

- Change default of `zero_phase` to 0.

- Scale average intensity of instrument response function to `mean` parameter.

- Update docstrings, tutorial, and tests accordingly.

- Scale peak of time-domain IRF to signal max for display (in tutorial and lifetime app).
## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
