### PR TITLE
Add signal_filter_median function

### DIFF
--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -153,18 +153,22 @@ def phasor_filter_median(
         repeat = 0
 
     mean = numpy.asarray(mean)
-    if use_scipy or repeat == 0:  # or using nD numpy filter
+    if use_scipy or repeat == 0:
         real = numpy.asarray(real)
-    elif isinstance(real, numpy.ndarray) and real.dtype == numpy.float32:
-        real = real.copy()
-    else:
-        real = numpy.asarray(real, dtype=numpy.float64, copy=True)
-    if use_scipy or repeat == 0:  # or using nD numpy filter
         imag = numpy.asarray(imag)
-    elif isinstance(imag, numpy.ndarray) and imag.dtype == numpy.float32:
-        imag = imag.copy()
     else:
-        imag = numpy.asarray(imag, dtype=numpy.float64, copy=True)
+        real_dtype = (
+            numpy.float32
+            if isinstance(real, numpy.ndarray) and real.dtype == numpy.float32
+            else numpy.float64
+        )
+        imag_dtype = (
+            numpy.float32
+            if isinstance(imag, numpy.ndarray) and imag.dtype == numpy.float32
+            else numpy.float64
+        )
+        real = numpy.asarray(real, dtype=real_dtype, copy=True)
+        imag = numpy.asarray(imag, dtype=imag_dtype, copy=True)
 
     if mean.shape != real.shape[-mean.ndim if mean.ndim else 1 :]:
         msg = f'{mean.shape=} != {real.shape=}'
@@ -207,7 +211,7 @@ def phasor_filter_median(
             size if i in axes else 1 for i in range(real.ndim)
         )
         pad_width = [
-            (s // 2, s // 2) if s > 1 else (0, 0) for s in kernel_shape
+            ((s - 1) // 2, s // 2) if s > 1 else (0, 0) for s in kernel_shape
         ]
         axis = tuple(range(-real.ndim, 0))
 
@@ -768,21 +772,23 @@ def signal_filter_median(
         # no need to filter
         repeat = 0
 
-    if use_scipy or repeat == 0:  # or using nD numpy filter
-        signal = numpy.asarray(signal)
-    elif isinstance(signal, numpy.ndarray) and signal.dtype == numpy.float32:
-        signal = signal.copy()
-    else:
-        signal = numpy.asarray(signal, dtype=numpy.float64, copy=True)
-
+    # cheap conversion to obtain ndim for axis parsing; no copy/cast yet
+    signal = numpy.asarray(signal)
     _, axes = parse_skip_axis(skip_axis, signal.ndim)
 
-    if len(axes) == 0:
-        # no axes to filter
+    if len(axes) == 0 or repeat == 0:
+        # no axes to filter or no need to call filter
         return signal
-    if repeat == 0:
-        # no need to call filter
-        return signal
+
+    if use_scipy:
+        pass  # scipy creates its own output; no in-place write needed
+    elif len(axes) == 2:
+        # 2D Cython path writes in-place; ensure writable float copy
+        dtype = (
+            numpy.float32 if signal.dtype == numpy.float32 else numpy.float64
+        )
+        signal = numpy.asarray(signal, dtype=dtype, copy=True)
+    # else: numpy nD path builds new arrays at each step
 
     if use_scipy:
         # use scipy NaN-unaware fallback
@@ -803,7 +809,7 @@ def signal_filter_median(
             size if i in axes else 1 for i in range(signal.ndim)
         )
         pad_width = [
-            (s // 2, s // 2) if s > 1 else (0, 0) for s in kernel_shape
+            ((s - 1) // 2, s // 2) if s > 1 else (0, 0) for s in kernel_shape
         ]
         median_axis = tuple(range(-signal.ndim, 0))
 

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -14,7 +14,7 @@ The ``phasorpy.filter`` module provides functions to filter:
   - :py:func:`signal_filter_ncpca`
     (noise-corrected principal component analysis)
   - :py:func:`signal_filter_svd` (spectral vector denoise)
-  - :py:func:`signal_filter_median` (not implemented yet)
+  - :py:func:`signal_filter_median`
 
 """
 
@@ -25,7 +25,7 @@ __all__ = [
     'phasor_filter_median',
     'phasor_filter_pawflim',
     'phasor_threshold',
-    # 'signal_filter_median',
+    'signal_filter_median',
     'signal_filter_ncpca',
     'signal_filter_svd',
 ]
@@ -673,6 +673,169 @@ def phasor_threshold(
         mean = numpy.asarray(numpy.asarray(mean)[0])
 
     return mean, real, imag
+
+
+def signal_filter_median(
+    signal: ArrayLike,
+    /,
+    *,
+    repeat: int = 1,
+    size: int = 3,
+    skip_axis: int | Sequence[int] | None = -1,
+    use_scipy: bool = False,
+    num_threads: int | None = None,
+    **kwargs: Any,
+) -> NDArray[Any]:
+    """Return median-filtered signal.
+
+    By default, apply a NaN-aware median filter over all axes except the last
+    once, with a kernel size of 3.
+
+    Parameters
+    ----------
+    signal : array_like
+        Signal to be filtered.
+    repeat : int, optional, default: 1
+        Number of times to apply median filter.
+    size : int, optional, default: 3
+        Size of median filter kernel.
+    skip_axis : int or sequence of int or None, optional, default: -1
+        Axes in `signal` to exclude from filtering.
+        By default, the last axis is excluded.
+        If None, all axes are filtered.
+    use_scipy : bool, optional, default: False
+        Use :py:func:`scipy.ndimage.median_filter`.
+        This function has undefined behavior if the input array contains
+        NaN values, but is faster when filtering more than two dimensions.
+        See `issue #87 <https://github.com/phasorpy/phasorpy/issues/87>`_.
+    num_threads : int, optional
+        Number of OpenMP threads to use for parallelization.
+        Applies to filtering in two dimensions when not using scipy.
+        By default, multithreading is disabled.
+        If zero, up to half of logical CPUs are used.
+        OpenMP may not be available on all platforms.
+    **kwargs
+        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`.
+
+    Returns
+    -------
+    ndarray
+        Filtered signal.
+
+    Raises
+    ------
+    ValueError
+        If `repeat` is less than 0.
+        If `size` is less than 1.
+    IndexError
+        If any `skip_axis` value is out of bounds.
+
+    Notes
+    -----
+    Signal-space filtering does not commute with the phasor transform.
+    For heterogeneous data, the spatial median of neighboring signals
+    does not produce a physically meaningful signal, causing the phasor
+    coordinates to be displaced from the true distribution.
+    Use :py:func:`phasorpy.filter.phasor_filter_median` instead.
+
+    Examples
+    --------
+    Apply three times a median filter with a kernel size of three,
+    skipping the first axis:
+
+    >>> signal_filter_median(
+    ...     [
+    ...         [[0.0, 1.0, 0.0], [0.0, math.nan, 0.0]],
+    ...         [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+    ...     ],
+    ...     size=3,
+    ...     repeat=3,
+    ...     skip_axis=0,
+    ... )
+    array([[[0, 0, 0],
+            [0, nan, 0]],
+           [[1, 1, 1],
+            [1, 1, 1]]])
+
+    """
+    if repeat < 0:
+        msg = f'{repeat=} < 0'
+        raise ValueError(msg)
+    if size < 1:
+        msg = f'{size=} < 1'
+        raise ValueError(msg)
+    if size == 1:
+        # no need to filter
+        repeat = 0
+
+    if use_scipy or repeat == 0:  # or using nD numpy filter
+        signal = numpy.asarray(signal)
+    elif isinstance(signal, numpy.ndarray) and signal.dtype == numpy.float32:
+        signal = signal.copy()
+    else:
+        signal = numpy.asarray(signal, dtype=numpy.float64, copy=True)
+
+    _, axes = parse_skip_axis(skip_axis, signal.ndim)
+
+    if len(axes) == 0:
+        # no axes to filter
+        return signal
+    if repeat == 0:
+        # no need to call filter
+        return signal
+
+    if use_scipy:
+        # use scipy NaN-unaware fallback
+        from scipy.ndimage import median_filter
+
+        kwargs.pop('axes', None)
+
+        for _ in range(repeat):
+            signal = median_filter(signal, size=size, axes=axes, **kwargs)
+
+        return numpy.asarray(signal)
+
+    if len(axes) != 2:
+        # n-dimensional median filter using numpy
+        from numpy.lib.stride_tricks import sliding_window_view
+
+        kernel_shape = tuple(
+            size if i in axes else 1 for i in range(signal.ndim)
+        )
+        pad_width = [
+            (s // 2, s // 2) if s > 1 else (0, 0) for s in kernel_shape
+        ]
+        median_axis = tuple(range(-signal.ndim, 0))
+
+        nan_mask = numpy.isnan(signal)
+        for _ in range(repeat):
+            signal = numpy.pad(signal, pad_width, mode='edge')
+            signal = sliding_window_view(signal, kernel_shape)
+            signal = numpy.nanmedian(signal, axis=median_axis)
+            signal = numpy.where(nan_mask, numpy.nan, signal)
+
+        return signal
+
+    # two-dimensional median filter using optimized Cython implementation
+    num_threads = number_threads(num_threads)
+
+    buffer = numpy.empty(
+        tuple(signal.shape[ax] for ax in axes), dtype=signal.dtype
+    )
+
+    for index in numpy.ndindex(
+        *[signal.shape[ax] for ax in range(signal.ndim) if ax not in axes]
+    ):
+        index_list: list[int | slice] = list(index)
+        for ax in axes:
+            index_list = [*index_list[:ax], slice(None), *index_list[ax:]]
+        full_index = tuple(index_list)
+
+        _median_filter_2d(
+            signal[full_index], buffer, size, repeat, num_threads
+        )
+
+    return signal
 
 
 def signal_filter_svd(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -12,6 +12,7 @@ from phasorpy.filter import (
     phasor_filter_median,
     phasor_filter_pawflim,
     phasor_threshold,
+    signal_filter_median,
     signal_filter_ncpca,
     signal_filter_svd,
 )
@@ -342,6 +343,93 @@ def test_phasor_filter_median_errors():
     # size < 1
     with pytest.raises(ValueError):
         phasor_filter_median([[0]], [[0]], [[0]], size=0)
+
+
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+def test_signal_filter_median(dtype):
+    """Test signal_filter_median function."""
+    signal = numpy.array(
+        [
+            [[0.0, 10.0, 0.0], [1.0, 2.0, 3.0], [10.0, 5.0, 1.0]],
+            [[5.0, 6.0, 2.0], [10.0, 4.0, 8.0], [0.0, 7.0, 8.0]],
+        ],
+        dtype=dtype,
+    )
+
+    filtered = signal_filter_median(
+        signal, skip_axis=0, size=3, repeat=1, num_threads=1
+    )
+    expected = numpy.array(
+        [
+            [[1.0, 1.0, 2.0], [2.0, 2.0, 2.0], [5.0, 3.0, 2.0]],
+            [[5.0, 5.0, 4.0], [5.0, 6.0, 7.0], [4.0, 7.0, 8.0]],
+        ],
+        dtype=dtype,
+    )
+    assert_allclose(filtered, expected)
+    assert filtered.dtype == dtype
+
+    # sequence of skip_axis should produce same result as scalar
+    filtered_seq = signal_filter_median(
+        signal, skip_axis=[0], size=3, repeat=1, num_threads=1
+    )
+    assert_allclose(filtered_seq, expected)
+
+
+def test_signal_filter_median_scipy_equivalence():
+    """Test signal_filter_median against scipy with finite input."""
+    from scipy.ndimage import median_filter
+
+    signal = numpy.arange(2 * 3 * 4).reshape((2, 3, 4)).astype(numpy.float64)
+
+    expected = median_filter(signal, size=3, axes=(0, 2))
+    filtered = signal_filter_median(signal, skip_axis=1, size=3)
+    assert_allclose(filtered, expected)
+
+
+def test_signal_filter_median_nan():
+    """Test signal_filter_median function NaN handling."""
+    signal = numpy.array(
+        [
+            [[1.0, nan, 5.0], [2.0, 3.0, 4.0], [9.0, 8.0, 7.0]],
+            [[5.0, 6.0, 7.0], [8.0, 9.0, 1.0], [2.0, 3.0, 4.0]],
+        ]
+    )
+
+    filtered = signal_filter_median(signal, skip_axis=0, size=3)
+    assert numpy.isnan(filtered[0, 0, 1])
+    assert not numpy.isnan(filtered[0, 1, 1])
+
+
+def test_signal_filter_median_noop():
+    """Test signal_filter_median no-op modes."""
+    signal = numpy.arange(8).reshape((2, 4))
+
+    assert_array_equal(signal_filter_median(signal, repeat=0), signal)
+    assert_array_equal(signal_filter_median(signal, size=1), signal)
+
+
+def test_signal_filter_median_skip_axis_none():
+    """Test signal_filter_median with skip_axis=None filters all axes."""
+    signal = numpy.array(
+        [[1.0, 0.0, 1.0], [0.0, numpy.nan, 0.0], [1.0, 0.0, 1.0]]
+    )
+
+    filtered = signal_filter_median(signal, skip_axis=None, size=3)
+    assert filtered.shape == signal.shape
+    assert numpy.isnan(filtered[1, 1])
+
+
+def test_signal_filter_median_errors():
+    """Test signal_filter_median function errors."""
+    with pytest.raises(ValueError):
+        signal_filter_median([[0]], repeat=-1)
+
+    with pytest.raises(ValueError):
+        signal_filter_median([[0]], size=0)
+
+    with pytest.raises(IndexError):
+        signal_filter_median([[0]], skip_axis=2)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -382,7 +382,7 @@ def test_signal_filter_median_scipy_equivalence():
 
     signal = numpy.arange(2 * 3 * 4).reshape((2, 3, 4)).astype(numpy.float64)
 
-    expected = median_filter(signal, size=3, axes=(0, 2))
+    expected = median_filter(signal, size=3, axes=(0, 2), mode='nearest')
     filtered = signal_filter_median(signal, skip_axis=1, size=3)
     assert_allclose(filtered, expected)
 
@@ -418,6 +418,36 @@ def test_signal_filter_median_skip_axis_none():
     filtered = signal_filter_median(signal, skip_axis=None, size=3)
     assert filtered.shape == signal.shape
     assert numpy.isnan(filtered[1, 1])
+
+
+def test_signal_filter_median_scipy():
+    """Test signal_filter_median with use_scipy=True."""
+    from scipy.ndimage import median_filter
+
+    signal = numpy.arange(2 * 3 * 4).reshape((2, 3, 4)).astype(numpy.float64)
+
+    expected = median_filter(signal, size=3, axes=(0, 2))
+    filtered = signal_filter_median(
+        signal, skip_axis=1, size=3, use_scipy=True
+    )
+    assert_allclose(filtered, expected)
+
+
+def test_signal_filter_median_ndim():
+    """Test signal_filter_median numpy nD filter when len(axes) != 2."""
+    from scipy.ndimage import median_filter
+
+    signal = numpy.arange(3 * 4 * 5).reshape((3, 4, 5)).astype(numpy.float64)
+
+    # 3 filtered axes (len(axes) == 3, numpy nD path)
+    expected = median_filter(signal, size=3)
+    filtered = signal_filter_median(signal, skip_axis=None, size=3)
+    assert_allclose(filtered, expected)
+
+    # 1 filtered axis (len(axes) == 1, numpy nD path)
+    expected = median_filter(signal, size=3, axes=(2,))
+    filtered = signal_filter_median(signal, skip_axis=[0, 1], size=3)
+    assert_allclose(filtered, expected)
 
 
 def test_signal_filter_median_errors():

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -93,7 +93,7 @@ def test_lifetime_to_signal(harmonic, expected, zero_expected):
     assert time.shape == (16,)
     assert_allclose(signal[1, index], expected, atol=1e-3)
 
-    # two distinct lifetimes: checks each row matches the single-lifetime result
+    # two distinct lifetimes: check each row matches the single-lifetime result
     signal, zero, time = lifetime_to_signal(
         40.0, [4.2, 0.9], zero_phase=None, samples=16, harmonic=harmonic
     )

--- a/tutorials/api/phasorpy_filter.py
+++ b/tutorials/api/phasorpy_filter.py
@@ -18,6 +18,7 @@ from phasorpy.filter import (
     phasor_filter_median,
     phasor_filter_pawflim,
     phasor_threshold,
+    signal_filter_median,
 )
 from phasorpy.io import signal_from_imspector_tiff
 from phasorpy.lifetime import phasor_calibrate
@@ -42,18 +43,10 @@ assert reference_signal.attrs['frequency'] == frequency
 
 mean, real, imag = phasor_from_signal(signal, axis=0)
 
-reference_mean, reference_real, reference_imag = phasor_from_signal(
-    reference_signal, axis=0
-)
+reference = phasor_from_signal(reference_signal, axis=0)
 
 real, imag = phasor_calibrate(
-    real,
-    imag,
-    reference_mean,
-    reference_real,
-    reference_imag,
-    frequency=frequency,
-    lifetime=4.2,
+    real, imag, *reference, frequency=frequency, lifetime=4.2
 )
 
 # %%
@@ -130,6 +123,36 @@ plot_image(
 )
 
 # %%
+# For comparison, the function :py:func:`phasorpy.filter.signal_filter_median`
+# applies a median filter to the signal before phasor transformation:
+
+signal_filtered = signal_filter_median(signal, skip_axis=0, repeat=1, size=3)
+
+mean, real, imag = phasor_from_signal(signal_filtered, axis=0)
+
+real, imag = phasor_calibrate(
+    real, imag, *reference, frequency=frequency, lifetime=4.2
+)
+
+mean_filtered, real_filtered, imag_filtered = phasor_threshold(
+    mean, real, imag, mean_min=1
+)
+
+plot_phasor(
+    real_filtered,
+    imag_filtered,
+    frequency=frequency,
+    title='Phasor coordinates of median-filtered signal',
+)
+
+# %%
+# Note that the resulting phasor coordinates are displaced from the true
+# distribution. Signal-space filtering does not commute with the phasor
+# transform: for heterogeneous samples, the spatial median of neighboring
+# signals does not produce a physically meaningful signal.
+# Use :py:func:`phasorpy.filter.phasor_filter_median` instead.
+
+# %%
 # pawFLIM wavelet filter
 # ----------------------
 #
@@ -145,16 +168,12 @@ harmonic = [1, 2]
 
 mean, real, imag = phasor_from_signal(signal, axis=0, harmonic=harmonic)
 
-reference_mean, reference_real, reference_imag = phasor_from_signal(
-    reference_signal, axis=0, harmonic=harmonic
-)
+reference = phasor_from_signal(reference_signal, axis=0, harmonic=harmonic)
 
 real, imag = phasor_calibrate(
     real,
     imag,
-    reference_mean,
-    reference_real,
-    reference_imag,
+    *reference,
     frequency=frequency,
     lifetime=4.2,
     harmonic=harmonic,


### PR DESCRIPTION
## Description

This PR adds the `signal_filter_median` function, which applies a NaN-aware median filter to a signal. It is provided as a general-purpose utility rather than for use in phasor analysis workflows, since signal-space filtering does not commute with the phasor transform and can displace phasor coordinates from the true distribution.

The `phasorpy_filter` tutorial now demonstrates this displacement: filtering a signal before the phasor transform produces phasor coordinates shifted from the correct values, and recommends using `phasor_filter_median` instead.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
