### PR TITLE
Add phasor_filter_gaussian and signal_filter_gaussian functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -423,7 +423,6 @@ test-requires = [
     "ptufile",
     "sdtfile",
     "pawflim",
-    "imagecodecs==2026.3.6; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     # sync with [dependency-groups.test]
     "coverage",
     "cython",  # for Cython.Coverage plugin
@@ -432,6 +431,10 @@ test-requires = [
     "pytest-doctestplus",
     "pytest-runner",
 ]
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_x86_64"
+test-requires = ["imagecodecs==2026.3.6"]
 
 [tool.cibuildwheel.test-environment]
 PHASORPY_DATA_ON_GITHUB = "1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ all = [
     "ptufile>=2024.9.14",
     "sdtfile>=2024.5.24",
     "pawflim>=1.0.4",
+    "imagecodecs==2026.3.6; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     # "mkl-fft>=2.1.1",
 ]
 
@@ -91,6 +92,7 @@ optional = [
     "ptufile>=2024.9.14",
     "sdtfile>=2024.5.24",
     "pawflim>=1.0.4",
+    "imagecodecs==2026.3.6; sys_platform == 'darwin' and platform_machine == 'x86_64'",
 ]
 minimal = [
     # minimal runtime versions for testing against oldest supported versions
@@ -421,6 +423,7 @@ test-requires = [
     "ptufile",
     "sdtfile",
     "pawflim",
+    "imagecodecs==2026.3.6; sys_platform == 'darwin' and platform_machine == 'x86_64'",
     # sync with [dependency-groups.test]
     "coverage",
     "cython",  # for Cython.Coverage plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,6 +434,7 @@ test-requires = [
 
 [[tool.cibuildwheel.overrides]]
 select = "*-macosx_x86_64"
+inherit.test-requires = "append"
 test-requires = ["imagecodecs==2026.3.6"]
 
 [tool.cibuildwheel.test-environment]

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -1466,4 +1466,4 @@ def _gaussian_filter(
         with numpy.errstate(divide='ignore', invalid='ignore'):
             data = numpy.divide(filled, weights)
         data = numpy.where(nan_mask, numpy.nan, data)
-    return data.astype(dtype)
+    return data.astype(dtype, copy=False)

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -4,27 +4,29 @@ The ``phasorpy.filter`` module provides functions to filter:
 
 - phasor coordinates:
 
-  - :py:func:`phasor_filter_gaussian` (not implemented yet)
+  - :py:func:`phasor_threshold`
+  - :py:func:`phasor_filter_gaussian`
   - :py:func:`phasor_filter_median`
   - :py:func:`phasor_filter_pawflim`
-  - :py:func:`phasor_threshold`
 
 - signals:
 
+  - :py:func:`signal_filter_gaussian`
+  - :py:func:`signal_filter_median`
   - :py:func:`signal_filter_ncpca`
     (noise-corrected principal component analysis)
   - :py:func:`signal_filter_svd` (spectral vector denoise)
-  - :py:func:`signal_filter_median`
 
 """
 
 from __future__ import annotations
 
 __all__ = [
-    # 'signal_filter_gaussian',
+    'phasor_filter_gaussian',
     'phasor_filter_median',
     'phasor_filter_pawflim',
     'phasor_threshold',
+    'signal_filter_gaussian',
     'signal_filter_median',
     'signal_filter_ncpca',
     'signal_filter_svd',
@@ -68,8 +70,10 @@ def phasor_filter_median(
     """Return median-filtered phasor coordinates.
 
     By default, apply a NaN-aware median filter independently to the real
-    and imaginary components of phasor coordinates once, with a kernel size
-    of 3 multiplied by the number of dimensions of the input arrays.
+    and imaginary components of phasor coordinates once, with a kernel of
+    size 3 in each filtered dimension.
+    NaN values in the input are preserved in the output and are excluded from
+    the median of their neighbors.
     Return the intensity unchanged.
 
     Parameters
@@ -106,9 +110,9 @@ def phasor_filter_median(
     mean : ndarray
         Unchanged intensity of phasor coordinates.
     real : ndarray
-        Filtered real component of phasor coordinates.
+        Median-filtered real component of phasor coordinates.
     imag : ndarray
-        Filtered imaginary component of phasor coordinates.
+        Median-filtered imaginary component of phasor coordinates.
 
     Raises
     ------
@@ -116,6 +120,11 @@ def phasor_filter_median(
         If the array shapes of `mean`, `real`, and `imag` do not match.
         If `repeat` is less than 0.
         If `size` is less than 1.
+
+    See Also
+    --------
+    phasorpy.filter.signal_filter_median
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
 
     Examples
     --------
@@ -252,6 +261,140 @@ def phasor_filter_median(
     return mean, real, imag
 
 
+def phasor_filter_gaussian(
+    mean: ArrayLike,
+    real: ArrayLike,
+    imag: ArrayLike,
+    /,
+    *,
+    repeat: int = 1,
+    size: int = 3,
+    sigma: float | None = None,
+    mode: str = 'nearest',
+    skip_axis: int | Sequence[int] | None = None,
+) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
+    r"""Return Gaussian-filtered phasor coordinates.
+
+    By default, apply a NaN-aware Gaussian filter independently to the real
+    and imaginary components of phasor coordinates once, with a kernel of
+    size 3 in each filtered dimension.
+    NaN values in the input are preserved in the output and are excluded from
+    the weighted average of their neighbors.
+    Return the intensity unchanged.
+
+    Parameters
+    ----------
+    mean : array_like
+        Intensity of phasor coordinates.
+    real : array_like
+        Real component of phasor coordinates to be filtered.
+    imag : array_like
+        Imaginary component of phasor coordinates to be filtered.
+    repeat : int, optional, default: 1
+        Number of times to apply Gaussian filter.
+    size : int, optional, default: 3
+        Size of the Gaussian kernel. Must be a positive odd integer.
+    sigma : float or None, optional
+        Standard deviation of Gaussian kernel.
+        By default, sigma is computed from `size` using the OpenCV formula
+        :math:`0.3 \cdot ((size - 1) \cdot 0.5 - 1) + 0.8`.
+        By default, all axes except harmonics are included.
+
+    Returns
+    -------
+    mean : ndarray
+        Unchanged intensity of phasor coordinates.
+    real : ndarray
+        Gaussian-filtered real component of phasor coordinates.
+    imag : ndarray
+        Gaussian-filtered imaginary component of phasor coordinates.
+
+    Raises
+    ------
+    ValueError
+        If the array shapes of `mean`, `real`, and `imag` do not match.
+        If `repeat` is less than 0.
+        If `sigma` is not positive.
+        If `size` is less than 1 or even.
+
+    See Also
+    --------
+    phasorpy.filter.signal_filter_gaussian
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
+
+    Examples
+    --------
+    Apply a Gaussian filter with sigma=1:
+
+    >>> mean, real, imag = phasor_filter_gaussian(
+    ...     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+    ...     [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [0.2, 0.2, 0.2]],
+    ...     [[0.3, 0.3, 0.3], [0.6, math.nan, 0.6], [0.4, 0.4, 0.4]],
+    ...     sigma=1,
+    ... )
+    >>> mean
+    array([[1, 2, 3],
+           [4, 5, 6],
+           [7, 8, 9]])
+    >>> real
+    array([[0..., 0..., 0...],
+           [0..., 0..., 0...],
+           [0..., 0..., 0...]])
+    >>> imag
+    array([[0..., 0..., 0...],
+           [0..., nan, 0...],
+           [0..., 0..., 0...]])
+
+    """
+    from scipy.signal.windows import gaussian
+
+    if repeat < 0:
+        msg = f'{repeat=} < 0'
+        raise ValueError(msg)
+    if size < 1:
+        msg = f'{size=} < 1'
+        raise ValueError(msg)
+    if size % 2 == 0:
+        msg = f'{size=} is not odd'
+        raise ValueError(msg)
+    if sigma is None:
+        sigma = 0.3 * ((size - 1) * 0.5 - 1) + 0.8
+    elif sigma <= 0:
+        msg = f'{sigma=} <= 0'
+        raise ValueError(msg)
+    radius = size // 2
+
+    mean = numpy.asarray(mean)
+    dtype = (
+        numpy.float32
+        if isinstance(real, numpy.ndarray) and real.dtype == numpy.float32
+        else numpy.float64
+    )
+    real = numpy.asarray(real, dtype=dtype)
+    imag = numpy.asarray(imag, dtype=dtype)
+
+    if mean.shape != real.shape[-mean.ndim if mean.ndim else 1 :]:
+        msg = f'{mean.shape=} != {real.shape=}'
+        raise ValueError(msg)
+    if real.shape != imag.shape:
+        msg = f'{real.shape=} != {imag.shape=}'
+        raise ValueError(msg)
+
+    prepend_axis = mean.ndim + 1 == real.ndim
+    _, axes = parse_skip_axis(skip_axis, mean.ndim, prepend=prepend_axis)
+
+    if repeat == 0 or radius == 0:
+        return mean, real, imag
+
+    kernel = gaussian(size, std=sigma)
+
+    return (
+        mean,
+        _gaussian_filter(real, kernel, axes, repeat, mode, dtype),
+        _gaussian_filter(imag, kernel, axes, repeat, mode, dtype),
+    )
+
+
 def phasor_filter_pawflim(
     mean: ArrayLike,
     real: ArrayLike,
@@ -268,6 +411,7 @@ def phasor_filter_pawflim(
     This function must only be used with calibrated, unprocessed phasor
     coordinates obtained from FLIM data. The coordinates must not be filtered,
     thresholded, or otherwise pre-processed.
+    Return the intensity unchanged.
 
     The pawFLIM wavelet filter is described in [1]_.
 
@@ -318,6 +462,10 @@ def phasor_filter_pawflim(
         match the first axis of `real` and `imag`.
         If not all harmonics in `harmonic` have a corresponding half
         or double harmonic.
+
+    See Also
+    --------
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
 
     References
     ----------
@@ -541,6 +689,10 @@ def phasor_threshold(
     imag : ndarray
         Thresholded imaginary component of phasor coordinates.
 
+    See Also
+    --------
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
+
     Examples
     --------
     Set phasor coordinates to NaN if mean intensity is smaller than 1.1:
@@ -693,7 +845,9 @@ def signal_filter_median(
     """Return median-filtered signal.
 
     By default, apply a NaN-aware median filter over all axes except the last
-    once, with a kernel size of 3.
+    once, with a kernel of size 3 in each filtered dimension.
+    NaN values in the input are preserved in the output and are excluded from
+    the median of their neighbors.
 
     Parameters
     ----------
@@ -724,7 +878,7 @@ def signal_filter_median(
     Returns
     -------
     ndarray
-        Filtered signal.
+        Median-filtered signal.
 
     Raises
     ------
@@ -733,6 +887,11 @@ def signal_filter_median(
         If `size` is less than 1.
     IndexError
         If any `skip_axis` value is out of bounds.
+
+    See Also
+    --------
+    phasorpy.filter.phasor_filter_median
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
 
     Notes
     -----
@@ -844,6 +1003,107 @@ def signal_filter_median(
     return signal
 
 
+def signal_filter_gaussian(
+    signal: ArrayLike,
+    /,
+    *,
+    repeat: int = 1,
+    size: int = 3,
+    sigma: float | None = None,
+    mode: str = 'nearest',
+    skip_axis: int | Sequence[int] | None = -1,
+) -> NDArray[Any]:
+    r"""Return Gaussian-filtered signal.
+
+    By default, apply a NaN-aware Gaussian filter over all axes except the
+    last once, with a kernel of size 3 in each filtered dimension.
+    NaN values in the input are preserved in the output and are excluded from
+    the weighted average of their neighbors.
+
+    Parameters
+    ----------
+    signal : array_like
+        Signal to be filtered.
+    repeat : int, optional, default: 1
+        Number of times to apply Gaussian filter.
+    size : int, optional, default: 3
+        Size of the Gaussian kernel. Must be a positive odd integer.
+    sigma : float or None, optional
+        Standard deviation of Gaussian kernel.
+        By default, sigma is computed from `size` using the OpenCV formula
+        :math:`0.3 \cdot ((size - 1) \cdot 0.5 - 1) + 0.8`.
+    skip_axis : int or sequence of int or None, optional, default: -1
+        Axes in `signal` to exclude from filtering.
+        By default, the last axis is excluded.
+        If None, all axes are filtered.
+
+    Returns
+    -------
+    ndarray
+        Gaussian-filtered signal.
+
+    Raises
+    ------
+    ValueError
+        If `repeat` is less than 0.
+        If `sigma` is not positive.
+        If `size` is less than 1 or even.
+    IndexError
+        If any `skip_axis` value is out of bounds.
+
+    See Also
+    --------
+    phasorpy.filter.phasor_filter_gaussian
+    :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
+
+    Examples
+    --------
+    Apply a Gaussian filter, skipping the first axis:
+
+    >>> signal_filter_gaussian(
+    ...     [
+    ...         [[0.0, 1.0, 0.0], [0.0, math.nan, 0.0]],
+    ...         [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+    ...     ],
+    ...     size=3,
+    ...     skip_axis=0,
+    ... )
+    array([[[0..., 0..., 0...],
+            [0..., nan, 0...]],
+           [[1..., 1..., 1...],
+            [1..., 1..., 1...]]])
+
+    """
+    from scipy.signal.windows import gaussian
+
+    if repeat < 0:
+        msg = f'{repeat=} < 0'
+        raise ValueError(msg)
+    if size < 1:
+        msg = f'{size=} < 1'
+        raise ValueError(msg)
+    if size % 2 == 0:
+        msg = f'{size=} is not odd'
+        raise ValueError(msg)
+    if sigma is None:
+        sigma = 0.3 * ((size - 1) * 0.5 - 1) + 0.8
+    elif sigma <= 0:
+        msg = f'{sigma=} <= 0'
+        raise ValueError(msg)
+    radius = size // 2
+
+    signal = numpy.asarray(signal)
+    dtype = numpy.float32 if signal.dtype == numpy.float32 else numpy.float64
+    _, axes = parse_skip_axis(skip_axis, signal.ndim)
+
+    if len(axes) == 0 or repeat == 0 or radius == 0:
+        return signal
+
+    signal = numpy.asarray(signal, dtype=dtype)
+    kernel = gaussian(size, std=sigma)
+    return _gaussian_filter(signal, kernel, axes, repeat, mode, dtype)
+
+
 def signal_filter_svd(
     signal: ArrayLike,
     /,
@@ -894,6 +1154,7 @@ def signal_filter_svd(
     vmin : float, optional
         Signal intensity along `axis` below which spectra are excluded from
         denoising.
+        If None or negative, ``0.0`` is used.
     dtype : dtype_like, optional
         Data type of output arrays. Either `float32` or `float64`.
         The default is `float64` unless the `signal` is `float32`.
@@ -1159,3 +1420,27 @@ def signal_filter_ncpca(
         signal = numpy.moveaxis(signal, -1, axis)
 
     return signal
+
+
+def _gaussian_filter(
+    data: NDArray[Any],
+    kernel: NDArray[Any],
+    axes: tuple[int, ...],
+    repeat: int,
+    mode: str,
+    dtype: Any,
+) -> NDArray[Any]:
+    """Return NaN-aware Gaussian-filtered array along specified axes."""
+    from scipy.ndimage import convolve1d
+
+    nan_mask = numpy.isnan(data)
+    for _ in range(repeat):
+        filled = numpy.where(nan_mask, 0.0, data)
+        weights = numpy.where(nan_mask, 0.0, 1.0)
+        for ax in axes:
+            filled = convolve1d(filled, kernel, axis=ax, mode=mode)
+            weights = convolve1d(weights, kernel, axis=ax, mode=mode)
+        with numpy.errstate(divide='ignore', invalid='ignore'):
+            data = numpy.divide(filled, weights)
+        data = numpy.where(nan_mask, numpy.nan, data)
+    return data.astype(dtype)

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -88,9 +88,10 @@ def phasor_filter_median(
         Number of times to apply median filter.
     size : int, optional, default: 3
         Size of median filter kernel.
-    skip_axis : int or sequence of int, optional
+    skip_axis : int or sequence of int or None, optional, default: None
         Axes in `mean` to exclude from filtering.
         By default, all axes except harmonics are included.
+        If None, all axes are filtered.
     use_scipy : bool, optional, default: False
         Use :py:func:`scipy.ndimage.median_filter`.
         This function has undefined behavior if the input arrays contain
@@ -103,7 +104,8 @@ def phasor_filter_median(
         If zero, up to half of logical CPUs are used.
         OpenMP may not be available on all platforms.
     **kwargs
-        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`.
+        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`
+        when `use_scipy` is True.
 
     Returns
     -------
@@ -120,6 +122,8 @@ def phasor_filter_median(
         If the array shapes of `mean`, `real`, and `imag` do not match.
         If `repeat` is less than 0.
         If `size` is less than 1.
+    IndexError
+        If any `skip_axis` value is out of bounds.
 
     See Also
     --------
@@ -298,7 +302,15 @@ def phasor_filter_gaussian(
         Standard deviation of Gaussian kernel.
         By default, sigma is computed from `size` using the OpenCV formula
         :math:`0.3 \cdot ((size - 1) \cdot 0.5 - 1) + 0.8`.
-        By default, all axes except harmonics are included.
+    mode : str, optional, default: 'nearest'
+        Border mode passed to :func:`scipy.ndimage.convolve1d`.
+        Determines how the input is extended beyond its boundaries.
+        Options include `'nearest'`, `'reflect'`, `'mirror'`, `'wrap'`,
+        and `'constant'`.
+    skip_axis : int or sequence of int or None, optional, default: None
+        Axes in `mean` to exclude from filtering.
+        By default, all axes of `mean` are filtered.
+        The harmonics axis, if present, is always excluded.
 
     Returns
     -------
@@ -316,6 +328,8 @@ def phasor_filter_gaussian(
         If `repeat` is less than 0.
         If `sigma` is not positive.
         If `size` is less than 1 or even.
+    IndexError
+        If any `skip_axis` value is out of bounds.
 
     See Also
     --------
@@ -438,9 +452,10 @@ def phasor_filter_pawflim(
         By default, the first axis of `real` and `imag` contains lower
         harmonics starting at one and increasing by one.
         All harmonics must have a corresponding half or double harmonic.
-    skip_axis : int or sequence of int, optional
+    skip_axis : int or sequence of int or None, optional, default: None
         Axes in `mean` to exclude from filtering.
         By default, all axes except harmonics are included.
+        If None, all axes are filtered.
 
     Returns
     -------
@@ -462,6 +477,8 @@ def phasor_filter_pawflim(
         match the first axis of `real` and `imag`.
         If not all harmonics in `harmonic` have a corresponding half
         or double harmonic.
+    IndexError
+        If any `skip_axis` value is out of bounds.
 
     See Also
     --------
@@ -873,7 +890,8 @@ def signal_filter_median(
         If zero, up to half of logical CPUs are used.
         OpenMP may not be available on all platforms.
     **kwargs
-        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`.
+        Optional arguments passed to :py:func:`scipy.ndimage.median_filter`
+        when `use_scipy` is True.
 
     Returns
     -------
@@ -1032,6 +1050,11 @@ def signal_filter_gaussian(
         Standard deviation of Gaussian kernel.
         By default, sigma is computed from `size` using the OpenCV formula
         :math:`0.3 \cdot ((size - 1) \cdot 0.5 - 1) + 0.8`.
+    mode : str, optional, default: 'nearest'
+        Border mode passed to :func:`scipy.ndimage.convolve1d`.
+        Determines how the input is extended beyond its boundaries.
+        Options include `'nearest'`, `'reflect'`, `'mirror'`, `'wrap'`,
+        and `'constant'`.
     skip_axis : int or sequence of int or None, optional, default: -1
         Axes in `signal` to exclude from filtering.
         By default, the last axis is excluded.

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -9,9 +9,11 @@ from numpy.testing import assert_allclose, assert_array_equal
 
 from phasorpy.datasets import fetch
 from phasorpy.filter import (
+    phasor_filter_gaussian,
     phasor_filter_median,
     phasor_filter_pawflim,
     phasor_threshold,
+    signal_filter_gaussian,
     signal_filter_median,
     signal_filter_ncpca,
     signal_filter_svd,
@@ -22,6 +24,134 @@ from phasorpy.phasor import phasor_from_polar, phasor_from_signal
 SKIP_FETCH = bool(os.environ.get('SKIP_FETCH', ''))
 
 rng = numpy.random.default_rng(42)
+
+
+@pytest.mark.parametrize(
+    ('sigma', 'repeat', 'skip_axis'),
+    [
+        (1.0, 1, None),
+        (2.0, 1, None),
+        (1.0, 2, None),
+        (1.0, 0, None),
+        (1.0, 1, 0),  # 3-D with skip_axis
+    ],
+)
+def test_phasor_filter_gaussian(sigma, repeat, skip_axis):
+    """Test phasor_filter_gaussian function."""
+    if skip_axis is None:
+        real = rng.uniform(0.1, 0.9, (5, 5))
+        imag = rng.uniform(0.1, 0.9, (5, 5))
+        mean = numpy.ones((5, 5))
+    else:
+        real = rng.uniform(0.1, 0.9, (3, 5, 5))
+        imag = rng.uniform(0.1, 0.9, (3, 5, 5))
+        mean = numpy.ones((3, 5, 5))
+
+    mean_out, real_out, imag_out = phasor_filter_gaussian(
+        mean,
+        real,
+        imag,
+        sigma=sigma,
+        repeat=repeat,
+        skip_axis=skip_axis,
+    )
+    # mean is unchanged
+    assert_array_equal(mean_out, mean)
+    assert real_out.shape == real.shape
+    assert imag_out.shape == imag.shape
+    # no NaN introduced on finite input
+    assert not numpy.any(numpy.isnan(real_out))
+    assert not numpy.any(numpy.isnan(imag_out))
+
+
+def test_phasor_filter_gaussian_nan():
+    """Test that NaN values in phasor_filter_gaussian are preserved."""
+    real = numpy.array(
+        [[0.2, 0.3, 0.2], [0.4, numpy.nan, 0.4], [0.2, 0.3, 0.2]]
+    )
+    imag = numpy.array(
+        [[0.5, 0.6, 0.5], [0.7, 0.8, 0.7], [numpy.nan, 0.6, 0.5]]
+    )
+    mean = numpy.ones((3, 3))
+
+    _, real_out, imag_out = phasor_filter_gaussian(mean, real, imag, sigma=1.0)
+    # NaN positions are preserved
+    assert numpy.isnan(real_out[1, 1])
+    assert numpy.isnan(imag_out[2, 0])
+    # non-NaN positions are finite
+    assert numpy.isfinite(real_out[0, 0])
+    assert numpy.isfinite(imag_out[0, 0])
+
+
+def test_phasor_filter_gaussian_scipy_equivalence():
+    """phasor_filter_gaussian matches scipy.ndimage.convolve1d with NaNmask."""
+    from scipy.ndimage import convolve1d
+
+    real = rng.uniform(0.1, 0.9, (7, 7))
+    imag = rng.uniform(0.1, 0.9, (7, 7))
+    mean = numpy.ones((7, 7))
+    from scipy.signal.windows import gaussian as scipy_gaussian
+
+    size = 3
+    sigma = 0.3 * ((size - 1) * 0.5 - 1) + 0.8  # OpenCV formula, default
+    kernel = scipy_gaussian(size, std=sigma)
+
+    _, real_out, imag_out = phasor_filter_gaussian(mean, real, imag)
+
+    for arr, out in [(real, real_out), (imag, imag_out)]:
+        filled = arr.copy()
+        weights = numpy.ones_like(arr)
+        for ax in range(arr.ndim):
+            filled = convolve1d(filled, kernel, axis=ax, mode='nearest')
+            weights = convolve1d(weights, kernel, axis=ax, mode='nearest')
+        expected = filled / weights
+        assert_allclose(out, expected, atol=1e-12)
+
+
+def test_phasor_filter_gaussian_float32():
+    """Test phasor_filter_gaussian preserves float32 dtype."""
+    real = rng.uniform(0.1, 0.9, (5, 5)).astype(numpy.float32)
+    imag = rng.uniform(0.1, 0.9, (5, 5)).astype(numpy.float32)
+    mean = numpy.ones((5, 5), dtype=numpy.float32)
+
+    _, real_out, imag_out = phasor_filter_gaussian(mean, real, imag, sigma=1.0)
+    assert real_out.dtype == numpy.float32
+    assert imag_out.dtype == numpy.float32
+
+
+def test_phasor_filter_gaussian_noop():
+    """Test phasor_filter_gaussian no-op modes."""
+    real = rng.uniform(0.1, 0.9, (5, 5))
+    imag = rng.uniform(0.1, 0.9, (5, 5))
+    mean = numpy.ones((5, 5))
+
+    _, real_out, imag_out = phasor_filter_gaussian(
+        mean, real, imag, sigma=1.0, repeat=0
+    )
+    assert_array_equal(real_out, real)
+    assert_array_equal(imag_out, imag)
+
+
+def test_phasor_filter_gaussian_errors():
+    """Test phasor_filter_gaussian function errors."""
+    # shape mismatch mean vs real
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([[0]], [0], [0])
+    # shape mismatch real vs imag
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([0], [0], [[0]])
+    # repeat < 0
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([[0]], [[0]], [[0]], repeat=-1)
+    # sigma <= 0
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([[0]], [[0]], [[0]], sigma=0.0)
+    # size < 1
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([[0]], [[0]], [[0]], size=0)
+    # size is even
+    with pytest.raises(ValueError):
+        phasor_filter_gaussian([[0]], [[0]], [[0]], size=2)
 
 
 @pytest.mark.parametrize(
@@ -460,6 +590,77 @@ def test_signal_filter_median_errors():
 
     with pytest.raises(IndexError):
         signal_filter_median([[0]], skip_axis=2)
+
+
+@pytest.mark.parametrize('dtype', [numpy.float32, numpy.float64])
+def test_signal_filter_gaussian(dtype):
+    """Test signal_filter_gaussian function."""
+    signal = numpy.array(
+        [
+            [[0.0, 1.0, 0.0], [0.0, 2.0, 0.0]],
+            [[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+        ],
+        dtype=dtype,
+    )
+    filtered = signal_filter_gaussian(signal, skip_axis=0, size=3, repeat=1)
+    assert filtered.shape == signal.shape
+    assert filtered.dtype == dtype
+    # constant slices must remain constant
+    assert_allclose(filtered[1], signal[1], atol=1e-6)
+
+
+def test_signal_filter_gaussian_nan():
+    """Test signal_filter_gaussian NaN handling."""
+    signal = numpy.array(
+        [
+            [[1.0, nan, 5.0], [2.0, 3.0, 4.0]],
+            [[5.0, 6.0, 7.0], [8.0, 9.0, 1.0]],
+        ]
+    )
+    filtered = signal_filter_gaussian(signal, skip_axis=0, size=3)
+    assert numpy.isnan(filtered[0, 0, 1])
+    assert not numpy.isnan(filtered[0, 1, 1])
+
+
+def test_signal_filter_gaussian_equivalence():
+    """Test signal_filter_gaussian matches normalized convolve1d (no NaNs)."""
+    from scipy.ndimage import convolve1d
+    from scipy.signal.windows import gaussian as scipy_gaussian
+
+    signal = numpy.arange(3 * 4 * 5, dtype=numpy.float64).reshape((3, 4, 5))
+    size = 3
+    sigma = 0.3 * ((size - 1) * 0.5 - 1) + 0.8
+    kernel = scipy_gaussian(size, std=sigma)
+    kernel_norm = kernel / kernel.sum()  # _gaussian_filter divides by weights
+
+    filtered = signal_filter_gaussian(signal, skip_axis=1, size=size)
+
+    # apply normalized kernel along axes (0, 2)
+    expected = signal.copy()
+    for ax in (0, 2):
+        expected = convolve1d(expected, kernel_norm, axis=ax, mode='nearest')
+    assert_allclose(filtered, expected, atol=1e-12)
+
+
+def test_signal_filter_gaussian_noop():
+    """Test signal_filter_gaussian no-op modes."""
+    signal = numpy.arange(8, dtype=numpy.float64).reshape((2, 4))
+    assert_array_equal(signal_filter_gaussian(signal, repeat=0), signal)
+    assert_array_equal(signal_filter_gaussian(signal, size=1), signal)
+
+
+def test_signal_filter_gaussian_errors():
+    """Test signal_filter_gaussian error handling."""
+    with pytest.raises(ValueError):
+        signal_filter_gaussian([[0]], repeat=-1)
+    with pytest.raises(ValueError):
+        signal_filter_gaussian([[0]], size=0)
+    with pytest.raises(ValueError):
+        signal_filter_gaussian([[0]], size=2)
+    with pytest.raises(ValueError):
+        signal_filter_gaussian([[0]], sigma=0.0)
+    with pytest.raises(IndexError):
+        signal_filter_gaussian([[0]], skip_axis=2)
 
 
 @pytest.mark.parametrize(

--- a/tutorials/api/phasorpy_filter.py
+++ b/tutorials/api/phasorpy_filter.py
@@ -5,8 +5,8 @@ Filter phasor coordinates
 Functions for filtering phasor coordinates.
 
 Filtering phasor coordinates improves signal quality by reducing noise while
-preserving relevant features. Two of the most common filtering methods are
-median filtering and wavelet filtering.
+preserving relevant features. Common methods include thresholding, median,
+Gaussian, and wavelet-based filtering.
 
 """
 
@@ -15,9 +15,11 @@ median filtering and wavelet filtering.
 
 from phasorpy.datasets import fetch
 from phasorpy.filter import (
+    phasor_filter_gaussian,
     phasor_filter_median,
     phasor_filter_pawflim,
     phasor_threshold,
+    signal_filter_gaussian,
     signal_filter_median,
 )
 from phasorpy.io import signal_from_imspector_tiff
@@ -26,8 +28,8 @@ from phasorpy.phasor import phasor_from_signal
 from phasorpy.plot import plot_image, plot_phasor
 
 # %%
-# Get calibrated phasor coordinates
-# ---------------------------------
+# Calibrated phasor coordinates
+# -----------------------------
 #
 # Read a time-correlated single photon counting (TCSPC) histogram from a file.
 # A homogeneous solution of Fluorescein (4.2 ns) was imaged as a reference:
@@ -39,7 +41,7 @@ reference_signal = signal_from_imspector_tiff(fetch('Fluorescein_Embryo.tif'))
 assert reference_signal.attrs['frequency'] == frequency
 
 # %%
-# Calculate and calibrate phasor coordinates:
+# Calculate, calibrate, and plot the phasor coordinates:
 
 mean, real, imag = phasor_from_signal(signal, axis=0)
 
@@ -49,17 +51,25 @@ real, imag = phasor_calibrate(
     real, imag, *reference, frequency=frequency, lifetime=4.2
 )
 
+plot_phasor(
+    real, imag, frequency=frequency, title='Calibrated phasor coordinates'
+)
+
 # %%
-# Unfiltered
-# ----------
+# Threshold
+# ---------
 #
-# Plot the unfiltered, calibrated phasor coordinates after applying a
-# threshold based on the mean intensity to remove background values:
+# Thresholding with :py:func:`phasorpy.filter.phasor_threshold` sets phasor
+# coordinates to NaN (not a number) wherever the mean intensity, real or
+# imaginary coordinates, phase or modulation fall outside specified bounds.
+# Such coordinates are excluded from plots and calculations. Thresholding is
+# typically performed after noise filtering.
+# Use a minimum mean intensity to remove background:
 
 plot_phasor(
     *phasor_threshold(mean, real, imag, mean_min=1)[1:],
     frequency=frequency,
-    title='Unfiltered phasor coordinates',
+    title='Thresholded phasor coordinates',
 )
 
 # %%
@@ -78,7 +88,7 @@ mean_filtered, real_filtered, imag_filtered = phasor_filter_median(
 )
 
 # %%
-# Thresholds should be applied after filtering:
+# Thresholds should be applied after noise filtering:
 
 mean_filtered, real_filtered, imag_filtered = phasor_threshold(
     mean_filtered, real_filtered, imag_filtered, mean_min=1
@@ -151,6 +161,95 @@ plot_phasor(
 # transform: for heterogeneous samples, the spatial median of neighboring
 # signals does not produce a physically meaningful signal.
 # Use :py:func:`phasorpy.filter.phasor_filter_median` instead.
+
+# %%
+# Gaussian filter
+# ---------------
+#
+# Gaussian filtering replaces each pixel value with a weighted average of its
+# neighbors, where weights follow a Gaussian distribution.
+# Unlike median filtering, it is linear and smooths more gradually.
+# The function :py:func:`phasorpy.filter.phasor_filter_gaussian` applies a
+# Gaussian filter to phasor coordinates. By default, a 3x3 kernel with sigma
+# of about 0.8 is used:
+
+mean, real, imag = phasor_from_signal(signal, axis=0)
+
+real, imag = phasor_calibrate(
+    real, imag, *reference, frequency=frequency, lifetime=4.2
+)
+
+mean_filtered, real_filtered, imag_filtered = phasor_filter_gaussian(
+    mean, real, imag, repeat=3, size=3
+)
+
+mean_filtered, real_filtered, imag_filtered = phasor_threshold(
+    mean_filtered, real_filtered, imag_filtered, mean_min=1
+)
+
+plot_phasor(
+    real_filtered,
+    imag_filtered,
+    frequency=frequency,
+    title='Gaussian-filtered phasor coordinates (3x3 kernel, 3 repetitions)',
+)
+
+# %%
+# Increasing the number of repetitions or the kernel size can further reduce
+# noise, but may also blur relevant features:
+
+mean_filtered, real_filtered, imag_filtered = phasor_threshold(
+    *phasor_filter_gaussian(mean, real, imag, repeat=6, size=5), mean_min=1
+)
+
+plot_phasor(
+    real_filtered,
+    imag_filtered,
+    frequency=frequency,
+    title='Gaussian-filtered phasor coordinates (5x5 kernel, 6 repetitions)',
+)
+
+# %%
+# The smoothing effect of Gaussian filtering is demonstrated by plotting the
+# real components of the filtered and unfiltered phasor coordinates as images:
+
+plot_image(
+    phasor_threshold(mean, real, imag, mean_min=1)[1],
+    real_filtered,
+    vmin=0.4,
+    vmax=0.9,
+    labels=['Unfiltered', 'Gaussian-filtered'],
+    title='Real component of phasor coordinates',
+)
+
+# %%
+# For comparison, the function
+# :py:func:`phasorpy.filter.signal_filter_gaussian` applies a Gaussian filter
+# to the signal before phasor transformation:
+
+signal_filtered = signal_filter_gaussian(signal, skip_axis=0, repeat=3, size=3)
+
+mean, real, imag = phasor_from_signal(signal_filtered, axis=0)
+
+real, imag = phasor_calibrate(
+    real, imag, *reference, frequency=frequency, lifetime=4.2
+)
+
+mean_filtered, real_filtered, imag_filtered = phasor_threshold(
+    mean, real, imag, mean_min=1
+)
+
+plot_phasor(
+    real_filtered,
+    imag_filtered,
+    frequency=frequency,
+    title='Phasor coordinates of Gaussian-filtered signal',
+)
+
+# %%
+# Unlike median filtering, Gaussian filtering is a linear operation, so the
+# phasor coordinates of the Gaussian-filtered signal are close to those
+# obtained by filtering the phasor coordinates directly.
 
 # %%
 # pawFLIM wavelet filter


### PR DESCRIPTION
## Description

This PR adds NaN-aware `phasor_filter_gaussian` and `signal_filter_gaussian` functions and improves the `phasorpy_filter` tutorial.

Also pin `imagecodecs==2026.3.6` on macos-intel. Imagecodecs, a requirement of czifile, no longer supports macos-intel.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT license](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New, user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
