### PR TITLE
Fix phasor_filter_gaussian to apply intensity weighting by default

### DIFF
--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -430,11 +430,9 @@ def phasor_filter_gaussian(
         else numpy.float64
     )
     # track whether asarray creates new arrays we own (safe to modify in-place)
-    owned = not (
-        isinstance(real, numpy.ndarray)
-        and real.dtype == dtype
-        and isinstance(imag, numpy.ndarray)
-        and imag.dtype == dtype
+    owned = not any(
+        isinstance(a, numpy.ndarray) and a.dtype == dtype
+        for a in (real, imag)
     )
     mean = numpy.asarray(mean, dtype=dtype)
     real = numpy.asarray(real, dtype=dtype)

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -67,7 +67,7 @@ def phasor_filter_median(
     num_threads: int | None = None,
     **kwargs: Any,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
-    """Return median-filtered phasor coordinates.
+    r"""Return median-filtered phasor coordinates.
 
     By default, apply a NaN-aware median filter independently to the real
     and imaginary components of phasor coordinates once, with a kernel of
@@ -128,7 +128,29 @@ def phasor_filter_median(
     See Also
     --------
     phasorpy.filter.signal_filter_median
+    phasorpy.filter.phasor_filter_gaussian
     :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
+
+    Notes
+    -----
+    The median filter is applied directly to the normalized phasor coordinates
+    (`real` and `imag`), treating each pixel equally regardless of its
+    intensity (`mean`).
+
+    Because the median is a non-linear operation, there is no
+    intensity-weighted equivalent:
+
+    .. math::
+
+        \text{median}(G_i \cdot \bar{I}_i) / \text{median}(\bar{I}_i)
+        \neq \text{intensity-weighted median}(G_i)
+
+    As a result, operations that combine median-filtered phasor coordinates
+    using intensity weighting, such as computing the mean phasor of a region
+    of interest, will give incorrect results.
+
+    For intensity-weighted spatial filtering, use
+    :py:func:`phasor_filter_gaussian` instead.
 
     Examples
     --------
@@ -276,15 +298,19 @@ def phasor_filter_gaussian(
     sigma: float | None = None,
     mode: str = 'nearest',
     skip_axis: int | Sequence[int] | None = None,
+    weighted: bool = True,
+    nan_safe: bool = True,
 ) -> tuple[NDArray[Any], NDArray[Any], NDArray[Any]]:
     r"""Return Gaussian-filtered phasor coordinates.
 
-    By default, apply a NaN-aware Gaussian filter independently to the real
-    and imaginary components of phasor coordinates once, with a kernel of
+    By default, apply a NaN-aware, intensity-weighted Gaussian filter to the
+    real and imaginary components of phasor coordinates once, with a kernel of
     size 3 in each filtered dimension.
+    Each pixel's phasor coordinate is weighted by its intensity (`mean`)
+    before averaging with its neighbors.
     NaN values in the input are preserved in the output and are excluded from
-    the weighted average of their neighbors.
-    Return the intensity unchanged.
+    the average of their neighbors.
+    Return the Gaussian-filtered intensity.
 
     Parameters
     ----------
@@ -297,7 +323,7 @@ def phasor_filter_gaussian(
     repeat : int, optional, default: 1
         Number of times to apply Gaussian filter.
     size : int, optional, default: 3
-        Size of the Gaussian kernel. Must be a positive odd integer.
+        Size of Gaussian kernel. Must be a positive odd integer.
     sigma : float or None, optional
         Standard deviation of Gaussian kernel.
         By default, sigma is computed from `size` using the OpenCV formula
@@ -311,11 +337,20 @@ def phasor_filter_gaussian(
         Axes in `mean` to exclude from filtering.
         By default, all axes of `mean` are filtered.
         The harmonics axis, if present, is always excluded.
+    weighted : bool, optional, default: True
+        Apply intensity weighting when filtering phasor coordinates.
+        If False, real and imaginary components are filtered independently
+        without intensity weighting.
+    nan_safe : bool, optional, default: True
+        Ensure that filter is applied to same elements of input arrays.
+        By default, NaNs are distributed among input arrays before filtering.
+        This may be disabled if the phasor coordinates were previously
+        filtered by :py:func:`phasor_threshold`.
 
     Returns
     -------
     mean : ndarray
-        Unchanged intensity of phasor coordinates.
+        Gaussian-filtered intensity of phasor coordinates.
     real : ndarray
         Gaussian-filtered real component of phasor coordinates.
     imag : ndarray
@@ -336,23 +371,34 @@ def phasor_filter_gaussian(
     phasorpy.filter.signal_filter_gaussian
     :ref:`sphx_glr_tutorials_api_phasorpy_filter.py`
 
+    Notes
+    -----
+    Intensity weighting (``weighted=True``, the default) is the physically
+    correct approach for averaging phasor coordinates.
+    Each phasor coordinate is weighted by its mean intensity before spatial
+    averaging, which is equivalent to applying a Gaussian filter to the signal
+    before computing phasor coordinates (the two operations commute).
+    Setting ``weighted=False`` may be useful to reproduce results from software
+    that does not apply intensity weighting, or as part of a workflow using
+    unnormalized phasor coordinates.
+
     Examples
     --------
     Apply a Gaussian filter with `sigma=1`:
 
     >>> mean, real, imag = phasor_filter_gaussian(
-    ...     [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+    ...     [[1, 1, 1], [1, 1, 1], [1, 1, 1]],
     ...     [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5], [0.2, 0.2, 0.2]],
     ...     [[0.3, 0.3, 0.3], [0.6, math.nan, 0.6], [0.4, 0.4, 0.4]],
     ...     sigma=1,
     ... )
     >>> mean
-    array([[1, 2, 3],
-           [4, 5, 6],
-           [7, 8, 9]])
+    array([[1, 1, 1],
+           [1, nan, 1],
+           [1, 1, 1]])
     >>> real
     array([[0..., 0..., 0...],
-           [0..., 0..., 0...],
+           [0..., nan, 0...],
            [0..., 0..., 0...]])
     >>> imag
     array([[0..., 0..., 0...],
@@ -378,12 +424,19 @@ def phasor_filter_gaussian(
         raise ValueError(msg)
     radius = size // 2
 
-    mean = numpy.asarray(mean)
     dtype = (
         numpy.float32
         if isinstance(real, numpy.ndarray) and real.dtype == numpy.float32
         else numpy.float64
     )
+    # track whether asarray creates new arrays we own (safe to modify in-place)
+    owned = not (
+        isinstance(real, numpy.ndarray)
+        and real.dtype == dtype
+        and isinstance(imag, numpy.ndarray)
+        and imag.dtype == dtype
+    )
+    mean = numpy.asarray(mean, dtype=dtype)
     real = numpy.asarray(real, dtype=dtype)
     imag = numpy.asarray(imag, dtype=dtype)
 
@@ -400,13 +453,35 @@ def phasor_filter_gaussian(
     if repeat == 0 or radius == 0:
         return mean, real, imag
 
+    if nan_safe:
+        mean, real, imag = phasor_threshold(mean, real, imag)
+        owned = True
+
     kernel = gaussian(size, std=sigma)
 
-    return (
-        mean,
-        _gaussian_filter(real, kernel, axes, repeat, mode, dtype),
-        _gaussian_filter(imag, kernel, axes, repeat, mode, dtype),
-    )
+    if prepend_axis:
+        mean = numpy.expand_dims(mean, 0)
+
+    if weighted:
+        if owned:
+            real *= mean
+            imag *= mean
+        else:
+            real = numpy.asarray(real * mean)
+            imag = numpy.asarray(imag * mean)
+
+    mean = _gaussian_filter(mean, kernel, axes, repeat, mode, dtype)
+    real = _gaussian_filter(real, kernel, axes, repeat, mode, dtype)
+    imag = _gaussian_filter(imag, kernel, axes, repeat, mode, dtype)
+
+    if weighted:
+        with numpy.errstate(divide='ignore', invalid='ignore'):
+            real /= mean
+            imag /= mean
+
+    if prepend_axis:
+        return numpy.asarray(mean[0]), real, imag
+    return mean, real, imag
 
 
 def phasor_filter_pawflim(

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -431,8 +431,7 @@ def phasor_filter_gaussian(
     )
     # track whether asarray creates new arrays we own (safe to modify in-place)
     owned = not any(
-        isinstance(a, numpy.ndarray) and a.dtype == dtype
-        for a in (real, imag)
+        isinstance(a, numpy.ndarray) and a.dtype == dtype for a in (real, imag)
     )
     mean = numpy.asarray(mean, dtype=dtype)
     real = numpy.asarray(real, dtype=dtype)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -19,7 +19,11 @@ from phasorpy.filter import (
     signal_filter_svd,
 )
 from phasorpy.io import signal_from_imspector_tiff, signal_from_lsm
-from phasorpy.phasor import phasor_from_polar, phasor_from_signal
+from phasorpy.phasor import (
+    phasor_from_polar,
+    phasor_from_signal,
+    phasor_normalize,
+)
 
 SKIP_FETCH = bool(os.environ.get('SKIP_FETCH', ''))
 
@@ -84,12 +88,33 @@ def test_phasor_filter_gaussian_nan():
 
 
 def test_phasor_filter_gaussian_mean_nan():
-    """Test that NaN in mean is unchanged by phasor_filter_gaussian."""
+    """Test NaN handling in phasor_filter_gaussian."""
+    # NaN in mean: propagates to real/imag outputs (nan_safe=True default)
     mean = numpy.array([[1.0, numpy.nan], [3.0, 4.0]])
     real = numpy.zeros((2, 2))
     imag = numpy.zeros((2, 2))
-    mean_out, _, _ = phasor_filter_gaussian(mean, real, imag, sigma=1.0)
-    assert_array_equal(mean_out, mean)
+    mean_out, real_out, imag_out = phasor_filter_gaussian(
+        mean, real, imag, sigma=1.0
+    )
+    assert numpy.isnan(mean_out[0, 1])
+    assert numpy.isnan(real_out[0, 1])
+    assert numpy.isnan(imag_out[0, 1])
+    assert numpy.isfinite(mean_out[0, 0])
+
+    # NaN in real propagates to mean_out when nan_safe=True,
+    # but not when nan_safe=False
+    mean2 = numpy.array([[1.0, 1.0], [1.0, 1.0]])
+    real2 = numpy.array([[0.0, numpy.nan], [0.3, 0.4]])
+    imag2 = numpy.zeros((2, 2))
+    mean_out2, _, _ = phasor_filter_gaussian(
+        mean2, real2, imag2, sigma=1.0, nan_safe=True
+    )
+    assert numpy.isnan(mean_out2[0, 1])  # NaN propagated from real
+
+    mean_out3, _, _ = phasor_filter_gaussian(
+        mean2, real2, imag2, sigma=1.0, nan_safe=False
+    )
+    assert numpy.isfinite(mean_out3[0, 1])  # NaN not propagated to mean
 
 
 def test_phasor_filter_gaussian_scipy_equivalence():
@@ -117,6 +142,33 @@ def test_phasor_filter_gaussian_scipy_equivalence():
         assert_allclose(out, expected, atol=1e-12)
 
 
+def test_phasor_filter_gaussian_intensity_weighted():
+    """Test that phasor_filter_gaussian applies intensity weighting."""
+    from scipy.ndimage import convolve1d
+    from scipy.signal.windows import gaussian as scipy_gaussian
+
+    real = rng.uniform(0.1, 0.9, (7, 7))
+    imag = rng.uniform(0.1, 0.9, (7, 7))
+    mean = rng.uniform(0.5, 5.0, (7, 7))
+
+    size = 3
+    sigma = 1.0
+    kernel = scipy_gaussian(size, std=sigma)
+
+    _, real_out, imag_out = phasor_filter_gaussian(
+        mean, real, imag, size=size, sigma=sigma
+    )
+
+    for arr, out in [(real, real_out), (imag, imag_out)]:
+        filled_w = arr * mean
+        filled_m = mean.copy()
+        for ax in range(arr.ndim):
+            filled_w = convolve1d(filled_w, kernel, axis=ax, mode='nearest')
+            filled_m = convolve1d(filled_m, kernel, axis=ax, mode='nearest')
+        expected = filled_w / filled_m
+        assert_allclose(out, expected, atol=1e-12)
+
+
 def test_phasor_filter_gaussian_float32():
     """Test phasor_filter_gaussian preserves float32 dtype."""
     real = rng.uniform(0.1, 0.9, (5, 5)).astype(numpy.float32)
@@ -139,6 +191,88 @@ def test_phasor_filter_gaussian_noop():
     )
     assert_array_equal(real_out, real)
     assert_array_equal(imag_out, imag)
+
+
+def test_phasor_filter_gaussian_harmonics():
+    """Test phasor_filter_gaussian with a harmonics axis (prepend_axis)."""
+    # mean has shape (H, W), real/imag have shape (N, H, W)
+    # axis 0 of real/imag is the harmonics axis and must not be filtered
+    mean = rng.uniform(0.5, 5.0, (5, 5))
+    real = rng.uniform(0.1, 0.9, (2, 5, 5))
+    imag = rng.uniform(0.1, 0.9, (2, 5, 5))
+
+    mean_out, real_out, imag_out = phasor_filter_gaussian(
+        mean, real, imag, sigma=1.0
+    )
+    assert mean_out.shape == mean.shape
+    assert real_out.shape == real.shape
+    assert imag_out.shape == imag.shape
+    assert not numpy.any(numpy.isnan(real_out))
+    assert not numpy.any(numpy.isnan(imag_out))
+    # each harmonic must equal the single-harmonic result
+    for h in range(2):
+        _, real_h, imag_h = phasor_filter_gaussian(
+            mean, real[h], imag[h], sigma=1.0
+        )
+        assert_allclose(real_out[h], real_h)
+        assert_allclose(imag_out[h], imag_h)
+
+
+def test_phasor_filter_gaussian_unweighted_equivalence():
+    """Test weighted=False + phasor_normalize matches weighted=True workflow.
+
+    Filtering unnormalized phasor coordinates (from phasor_from_signal with
+    normalize=False) using an unweighted Gaussian and then normalizing with
+    phasor_normalize is mathematically equivalent to filtering normalized
+    phasor coordinates with intensity weighting (the default).
+    """
+    rng_local = numpy.random.default_rng(123)
+    samples = 32
+    signal = rng_local.uniform(0.5, 2.0, (5, 5, samples))
+
+    # Workflow 1: normalized phasor + intensity-weighted filter (default)
+    mean1, real1, imag1 = phasor_from_signal(signal, normalize=True)
+    mean1, real1, imag1 = phasor_filter_gaussian(
+        mean1, real1, imag1, sigma=1.0, nan_safe=False
+    )
+
+    # Workflow 2: unnormalized phasor + unweighted filter + normalize
+    mean2, real2, imag2 = phasor_from_signal(signal, normalize=False)
+    mean2, real2, imag2 = phasor_filter_gaussian(
+        mean2, real2, imag2, sigma=1.0, weighted=False, nan_safe=False
+    )
+    mean2, real2, imag2 = phasor_normalize(
+        mean2, real2, imag2, samples=samples
+    )
+
+    assert_allclose(mean1, mean2, atol=1e-10)
+    assert_allclose(real1, real2, atol=1e-10)
+    assert_allclose(imag1, imag2, atol=1e-10)
+
+
+def test_phasor_filter_gaussian_signal_prefilter_equivalence():
+    """Test pre- and post-gaussian filtering produce identical results."""
+    # Because the Gaussian filter is linear and commutes with the phasor
+    # transform, filtering the signal before computing phasor coordinates is
+    # mathematically equivalent to computing phasor coordinates first and then
+    # applying the intensity-weighted Gaussian filter (weighted=True,
+    # the default).
+    rng_local = numpy.random.default_rng(456)
+    signal = rng_local.uniform(0.5, 2.0, (5, 5, 32))
+
+    # filter signal first, then compute phasor coordinates
+    signal_filtered = signal_filter_gaussian(signal, skip_axis=-1, sigma=1.0)
+    mean1, real1, imag1 = phasor_from_signal(signal_filtered)
+
+    # compute phasor coordinates first, then intensity-weighted filter
+    mean2, real2, imag2 = phasor_from_signal(signal)
+    mean2, real2, imag2 = phasor_filter_gaussian(
+        mean2, real2, imag2, sigma=1.0, nan_safe=False
+    )
+
+    assert_allclose(mean1, mean2, atol=1e-6)
+    assert_allclose(real1, real2, atol=1e-6)
+    assert_allclose(imag1, imag2, atol=1e-6)
 
 
 def test_phasor_filter_gaussian_errors():
@@ -475,6 +609,28 @@ def test_phasor_filter_median_mean_nan():
     imag = numpy.zeros((2, 2))
     mean_out, _, _ = phasor_filter_median(mean, real, imag)
     assert_array_equal(mean_out, mean)
+
+
+def test_phasor_filter_median_harmonics():
+    """Test phasor_filter_median with a harmonics axis (prepend_axis)."""
+    # mean has shape (H, W), real/imag have shape (N, H, W)
+    # axis 0 of real/imag is the harmonics axis and must not be filtered
+    mean = numpy.full((5, 5), 1.0)
+    real = rng.uniform(0.1, 0.9, (2, 5, 5))
+    imag = rng.uniform(0.1, 0.9, (2, 5, 5))
+
+    mean_out, real_out, imag_out = phasor_filter_median(mean, real, imag)
+    assert mean_out.shape == mean.shape
+    assert_array_equal(mean_out, mean)
+    assert real_out.shape == real.shape
+    assert imag_out.shape == imag.shape
+    assert not numpy.any(numpy.isnan(real_out))
+    assert not numpy.any(numpy.isnan(imag_out))
+    # each harmonic must equal the single-harmonic result
+    for h in range(2):
+        _, real_h, imag_h = phasor_filter_median(mean, real[h], imag[h])
+        assert_allclose(real_out[h], real_h)
+        assert_allclose(imag_out[h], imag_h)
 
 
 def test_phasor_filter_median_errors():
@@ -1505,6 +1661,23 @@ def test_phasor_threshold_harmonic():
     assert_allclose(mean1, mean_)
     assert_allclose(real1, real_)
     assert_allclose(imag1, imag_)
+
+
+def test_phasor_threshold_returns_copies():
+    """Test phasor_threshold always returns new arrays, never views."""
+    mean = numpy.ones((3, 3))
+    real = numpy.full((3, 3), 0.5)
+    imag = numpy.full((3, 3), 0.3)
+
+    for kwargs in (
+        {},  # NaN-propagation only
+        {'mean_min': 0.5},  # mean threshold
+        {'real_min': 0.1, 'imag_max': 0.9},  # coordinate thresholds
+    ):
+        m2, r2, i2 = phasor_threshold(mean, real, imag, **kwargs)
+        assert not numpy.shares_memory(mean, m2)
+        assert not numpy.shares_memory(real, r2)
+        assert not numpy.shares_memory(imag, i2)
 
 
 @pytest.mark.parametrize('dtype', [None, 'float32'])

--- a/tutorials/api/phasorpy_filter.py
+++ b/tutorials/api/phasorpy_filter.py
@@ -133,6 +133,13 @@ plot_image(
 )
 
 # %%
+# Note that the median filter is a non-linear operation applied directly to
+# the normalized phasor coordinates.
+# As a result, operations that combine median-filtered phasor coordinates
+# using intensity weighting, such as computing the mean phasor of a region
+# of interest, will give incorrect results.
+
+# %%
 # For comparison, the function :py:func:`~phasorpy.filter.signal_filter_median`
 # applies a median filter to the signal before phasor transformation:
 
@@ -169,9 +176,11 @@ plot_phasor(
 # Gaussian filtering replaces each pixel value with a weighted average of its
 # neighbors, where weights follow a Gaussian distribution.
 # Unlike median filtering, it is linear and smooths more gradually.
-# The function :py:func:`~phasorpy.filter.phasor_filter_gaussian` applies a
-# Gaussian filter to phasor coordinates. By default, a 3x3 kernel with sigma
-# of about 0.8 is used:
+# The function :py:func:`~phasorpy.filter.phasor_filter_gaussian` applies an
+# intensity-weighted Gaussian filter to phasor coordinates: each phasor
+# coordinate is weighted by the mean intensity before spatial averaging,
+# which is the physically correct approach for phasor analysis.
+# By default, a 3x3 kernel with sigma of about 0.8 is used:
 
 mean, real, imag = phasor_from_signal(signal, axis=0)
 
@@ -247,9 +256,11 @@ plot_phasor(
 )
 
 # %%
-# Unlike median filtering, Gaussian filtering is a linear operation, so the
-# phasor coordinates of the Gaussian-filtered signal are close to those
-# obtained by filtering the phasor coordinates directly.
+# Unlike median filtering, Gaussian filtering is a linear operation that
+# commutes with the phasor transform.
+# Consequently, the phasor coordinates of the Gaussian-filtered signal are
+# identical to those obtained by intensity-weighted filtering of the phasor
+# coordinates directly.
 
 # %%
 # pawFLIM wavelet filter


### PR DESCRIPTION
## Description

This PR fixes the `phasor_filter_gaussian` function to apply intensity weighting by default. Add a `weighted` parameter (default True) to allow opting out. Intensity-weighted filtering is the physically correct approach and is equivalent to Gaussian filtering the signal before the phasor transform. Add equivalence tests and update tutorial.

Also add a note that operations that combine **median**-filtered phasor coordinates using intensity weighting, such as computing the mean phasor of a region of interest, will give incorrect results.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT License](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
