### PR TITLE
Bump tooling and update configs

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: pypa/cibuildwheel@v3.4.1
+      - uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_ARCHS_LINUX: auto
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_ARCHS_LINUX: auto
-          CIBW_ARCHS_WINDOWS: auto
+          CIBW_ARCHS_WINDOWS: native
           CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_BUILD_VERBOSITY: 2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest, windows-11-arm]
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v6
@@ -30,8 +30,8 @@ jobs:
       - uses: pypa/cibuildwheel@v4.1.0
         env:
           CIBW_ARCHS_LINUX: auto
+          CIBW_ARCHS_WINDOWS: auto
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_ARCHS_WINDOWS: AMD64 ARM64
           CIBW_BUILD_VERBOSITY: 2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
   # when running with --fix place ruff lint hook
   # before ruff-format, black, isort, etc
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.16
+    rev: v0.15.17
     hooks:
       - id: ruff-check
   #     args: [--fix --show-fixes]
@@ -116,7 +116,7 @@ repos:
   #     additional_dependencies: [flake8-typing-imports, flake8-docstrings]
 
   # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.20.2
+  #   rev: v2.1.0
   #   hooks:
   #   - id: mypy
   #     files: src

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,9 +148,6 @@ sphinx_gallery_conf = {
     # 'backreferences_dir': None,
 }
 
-# TODO: remove MathJax 3 link once scroll bar issue is resolved
-mathjax_path = 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js'
-
 
 class TutorialOrder:
     """Order tutorials in gallery subsections."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -409,13 +409,14 @@ skip = [
     "cp311*",
     "cp313*",
     "cp314-*",
+    "cp315*",
     "*musllinux*",
     "*i686*",
     "*ppc64le*",
     "*s390x*",
 ]
 test-command = "pytest {project}/tests"
-test-skip = ["cp314t*"]
+test-skip = ["cp314t*", "cp315t*"]
 test-requires = [
     # sync with [dependency-groups.optional]
     "czifile>=2026.4.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -403,7 +403,6 @@ norecursedirs = [
 
 [tool.cibuildwheel]
 skip = [
-    "cp38*",
     "cp39*",
     "cp310*",
     "cp311*",

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -818,7 +818,7 @@ def phasor_component_concentration(
         m = \frac{I}{I_\text{ref} + I}
 
     where :math:`I` is the pixel mean intensity and
-    :math:`I_\text{ref} = 2 \cdot \text{reference_mean}` is twice the
+    :math:`I_\text{ref} = 2 \cdot \text{reference\_mean}` is twice the
     fluorescence-only mean intensity of the calibration solution.
 
     The component-0 concentration is then:

--- a/tools/build_manylinux.cmd
+++ b/tools/build_manylinux.cmd
@@ -3,7 +3,7 @@
 setlocal
 set PATH=C:\Windows;C:\Windows\System32;C:\Program Files\Docker\Docker\resources\bin
 set CIBW_ARCHS_LINUX=auto
-set CIBW_SKIP=cp38* cp39* cp310* cp311* cp313* cp314-* *musllinux*
+set CIBW_SKIP=cp39* cp310* cp311* cp313* cp314-* *musllinux*
 set CIBW_TEST_SKIP=cp314t*
 set CIBW_TEST_COMMAND=pytest {project}/tests
 set CIBW_BUILD_VERBOSITY=3

--- a/tools/build_manylinux.sh
+++ b/tools/build_manylinux.sh
@@ -1,7 +1,7 @@
 # Build PhasorPy manylinux ABI3 wheels on Linux or macOS using Docker
 
 export CIBW_ARCHS_LINUX=auto
-export CIBW_SKIP="cp38* cp39* cp310* cp311* cp313* cp314-* *musllinux*"
+export CIBW_SKIP="cp39* cp310* cp311* cp313* cp314-* *musllinux*"
 export CIBW_TEST_SKIP=cp314t*
 export CIBW_TEST_COMMAND="pytest {project}/tests"
 export CIBW_BUILD_VERBOSITY=3


### PR DESCRIPTION
## Description

Upgrade CI and tooling: cibuildwheel -> v4.1.0 and ruff pre-commit rev -> v0.15.17. Adjust pyproject to include cp315 in skip patterns and test-skip. Remove an obsolete MathJax path from docs config. Tweak a docstring escape for reference_mean to avoid Markdown/LaTeX rendering issues.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT License](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
