### PR TITLE
Add signal_from_tdflim and lifetime_from_tdflim functions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -103,7 +103,7 @@ repos:
   # when running with --fix place ruff lint hook
   # before ruff-format, black, isort, etc
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.18
+    rev: v0.15.19
     hooks:
       - id: ruff-check
   #     args: [--fix --show-fixes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ all = [
     # sync with [dependency-groups.optional]
     "czifile>=2026.4.11",
     "fbdfile>=2025.9.18",
-    "lfdfiles>=2026.4.30",
+    "lfdfiles>=2026.6.24",
     "liffile>=2025.2.10",
     "ptufile>=2024.9.14",
     "sdtfile>=2024.5.24",
@@ -87,7 +87,7 @@ optional = [
     # optional runtime dependencies; sync with [project.optional-dependencies]
     "czifile>=2026.4.11",
     "fbdfile>=2025.9.18",
-    "lfdfiles>=2026.4.30",
+    "lfdfiles>=2026.6.24",
     "liffile>=2025.2.10",
     "ptufile>=2024.9.14",
     "sdtfile>=2024.5.24",
@@ -106,7 +106,7 @@ minimal = [
     # optional
     "czifile==2026.4.11; python_version == \"3.12\"",
     "fbdfile==2025.9.18; python_version == \"3.12\"",
-    "lfdfiles==2026.4.30; python_version == \"3.12\"",
+    "lfdfiles==2026.6.24; python_version == \"3.12\"",
     "liffile==2025.2.10; python_version == \"3.12\"",
     "ptufile==2024.9.14; python_version == \"3.12\"",
     "sdtfile==2024.5.24; python_version == \"3.12\"",

--- a/src/phasorpy/io/__init__.py
+++ b/src/phasorpy/io/__init__.py
@@ -16,6 +16,7 @@ The ``phasorpy.io`` module provides functions to:
   - :py:func:`signal_from_pqbin` - PicoQuant BIN
   - :py:func:`signal_from_sdt` - Becker & Hickl SDT
   - :py:func:`signal_from_fbd` - FLIMbox FBD
+  - :py:func:`signal_from_tdflim` - ISS TDFLIM
   - :py:func:`signal_from_flimlabs_json` - FLIM LABS JSON
   - :py:func:`signal_from_imspector_tiff` - ImSpector FLIM TIFF
   - :py:func:`signal_from_flif` - FlimFast FLIF
@@ -36,6 +37,7 @@ The ``phasorpy.io`` module provides functions to:
   - :py:func:`phasor_from_flimlabs_json` - FLIM LABS JSON
   - :py:func:`phasor_from_simfcs_referenced` - SimFCS REF and R64
   - :py:func:`lifetime_from_lif` - Leica LIF and XLEF
+  - :py:func:`lifetime_from_tdflim` - ISS TDFLIM
 
 - write phasor coordinate images to OME-TIFF and SimFCS file formats:
 
@@ -68,15 +70,15 @@ For advanced or unsupported use cases, consider using these libraries directly.
 
 The signal-reading functions typically have the following signature::
 
-    signal_from_ext(
+    signal_from_format(
         filename: str | os.PathLike,
         /,
         **kwargs
     ) -> xarray.DataArray:
 
-where ``ext`` indicates the file format and ``kwargs`` are optional arguments
-passed to the underlying file reader libraries or used to select which data
-is returned. The returned `xarray.DataArray
+where ``format`` indicates the file format and ``kwargs`` are optional
+arguments passed to the underlying file reader libraries or used to select
+which data is returned. The returned `xarray.DataArray
 <https://docs.xarray.dev/en/stable/user-guide/data-structures.html>`_
 contains an N-dimensional array with labeled coordinates, dimensions, and
 attributes:

--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 __all__ = [
+    'lifetime_from_tdflim',
     'phasor_from_ifli',
     'signal_from_czi',
     'signal_from_flif',
@@ -11,6 +12,7 @@ __all__ = [
     'signal_from_pqbin',
     'signal_from_ptu',
     'signal_from_sdt',
+    'signal_from_tdflim',
 ]
 
 import os
@@ -994,6 +996,184 @@ def signal_from_pqbin(
             0, size_x * pixel_resolution * 1e-6, size_x, endpoint=False
         ),
         H=numpy.linspace(0, size_h * tcspc_resolution, size_h, endpoint=False),
+    )
+
+    from xarray import DataArray
+
+    return DataArray(data, **metadata)
+
+
+def signal_from_tdflim(
+    filename: str | PathLike[Any],
+    /,
+    *,
+    channel: int | None = 0,
+) -> DataArray:
+    """Return TCSPC histogram and metadata from ISS Vista TDFLIM file.
+
+    ISS Vista TDFLIM files are ZIP archives containing acquisition metadata
+    and raw photon histogram data from fluorescence lifetime imaging
+    measurements.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of ISS Vista TDFLIM file to read.
+        The file extension is typically ``.iss-tdflim``.
+    channel : int or None, optional, default: 0
+        Index of channel to return.
+        By default, return the first channel.
+        If None, return all channels.
+
+    Returns
+    -------
+    xarray.DataArray
+        TCSPC histogram with :ref:`axes codes <axes>` `'TCYXH'` and
+        type `uint16` or `uint32`, and selected metadata:
+
+        - ``coords['T']``: time series coordinates, if available.
+        - ``coords['C']``: channel IDs, if available.
+        - ``coords['Y']``: Y spatial coordinates
+        - ``coords['X']``: X spatial coordinates
+        - ``coords['H']``: delay times of histogram bins in ns.
+        - ``attrs['frequency']``: repetition frequency in MHz.
+
+        Length-1 dimensions are squeezed.
+
+    Raises
+    ------
+    lfdfiles.LfdFileError
+        If file is not an ISS Vista TDFLIM file containing TCSPC histogram.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
+
+    Examples
+    --------
+    >>> signal = signal_from_tdflim('vista.iss-tdflim')  # doctest: +SKIP
+    >>> signal.values  # doctest: +SKIP
+    array(...)
+    >>> signal.dtype  # doctest: +SKIP
+    dtype('uint16')
+    >>> signal.dims  # doctest: +SKIP
+    ('Y', 'X', 'H')
+    >>> signal.coords['H'].data  # doctest: +SKIP
+    array([0, ..., ...])
+    >>> signal.attrs['frequency']  # doctest: +SKIP
+    80.0
+
+    """
+    import lfdfiles
+
+    with lfdfiles.VistaTdflim(filename) as tdflim:
+        data = tdflim.asarray()
+        axes = tdflim.axes or 'TCYXH'
+        coords = dict(tdflim.coords)
+        attrs = {'frequency': tdflim.attrs['frequency']}
+
+    if channel is not None:
+        data = data[:, channel]
+        axes = axes[0] + axes[2:]
+
+    shape, dims, _ = squeeze_dims(data.shape, axes, skip='YXH')
+    data = data.reshape(shape)
+    metadata = xarray_metadata(
+        dims,
+        shape,
+        os.path.basename(filename),
+        attrs=attrs,
+        **{k: coords[k] for k in dims if k in coords},
+    )
+
+    from xarray import DataArray
+
+    return DataArray(data, **metadata)
+
+
+def lifetime_from_tdflim(
+    filename: str | PathLike[Any],
+    /,
+    *,
+    channel: int | None = 0,
+) -> DataArray:
+    """Return lifetime and metadata from ISS Vista TDFLIM version 2 file.
+
+    ISS Vista TDFLIM files are ZIP archives containing acquisition metadata
+    and raw photon histogram data from fluorescence lifetime imaging
+    measurements. Version 2 of the file format also contains lifetime images
+    computed from the TCSPC histograms.
+
+    Parameters
+    ----------
+    filename : str or Path
+        Name of ISS Vista TDFLIM file to read.
+        The file extension is typically ``.iss-tdflim``.
+    channel : int or None, optional, default: 0
+        Index of channel to return.
+        By default, return the first channel.
+        If None, return all channels.
+
+    Returns
+    -------
+    xarray.DataArray
+        Lifetime image with :ref:`axes codes <axes>` `'TCYX'` and
+        type `float32`, and selected metadata:
+
+        - ``coords['T']``: time series coordinates, if available.
+        - ``coords['C']``: channel IDs, if available.
+        - ``coords['Y']``: Y spatial coordinates
+        - ``coords['X']``: X spatial coordinates
+        - ``attrs['frequency']``: repetition frequency in MHz.
+
+        Length-1 dimensions are squeezed.
+
+    Raises
+    ------
+    lfdfiles.LfdFileError
+        If file is not an ISS Vista TDFLIM file.
+    ValueError
+        If file does not contain a lifetime image.
+
+    Notes
+    -----
+    The implementation is based on the
+    `lfdfiles <https://github.com/cgohlke/lfdfiles/>`__ library.
+
+    Examples
+    --------
+    >>> lifetime = lifetime_from_tdflim('vista.iss-tdflim')  # doctest: +SKIP
+    >>> lifetime.values  # doctest: +SKIP
+    array(...)
+    >>> lifetime.dtype  # doctest: +SKIP
+    dtype('float32')
+    >>> lifetime.dims  # doctest: +SKIP
+    ('Y', 'X')
+    >>> lifetime.attrs['frequency']  # doctest: +SKIP
+    80.0
+
+    """
+    import lfdfiles
+
+    with lfdfiles.VistaTdflim(filename) as tdflim:
+        data = tdflim.lifetime()
+        axes = (tdflim.axes or 'TCYXH')[:-1]
+        coords = dict(tdflim.coords)
+        attrs = {'frequency': tdflim.attrs['frequency']}
+
+    if channel is not None:
+        data = data[:, channel]
+        axes = axes[0] + axes[2:]
+
+    shape, dims, _ = squeeze_dims(data.shape, axes)
+    data = data.reshape(shape)
+    metadata = xarray_metadata(
+        dims,
+        shape,
+        os.path.basename(filename),
+        attrs=attrs,
+        **{k: coords[k] for k in dims if k in coords},
     )
 
     from xarray import DataArray

--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -163,6 +163,8 @@ def signal_from_sdt(
     ------
     ValueError
         If file is not an SDT file containing TCSPC histogram.
+    IndexError
+        If dataset index is out of bounds.
 
     Notes
     -----
@@ -1044,6 +1046,8 @@ def signal_from_tdflim(
     ------
     lfdfiles.LfdFileError
         If file is not an ISS Vista TDFLIM file containing TCSPC histogram.
+    IndexError
+        If channel index is out of bounds.
 
     Notes
     -----
@@ -1135,6 +1139,8 @@ def lifetime_from_tdflim(
         If file is not an ISS Vista TDFLIM file.
     ValueError
         If file does not contain a lifetime image.
+    IndexError
+        If channel index is out of bounds.
 
     Notes
     -----

--- a/tests/io/test_other.py
+++ b/tests/io/test_other.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 
 from phasorpy.datasets import fetch
 from phasorpy.io import (
+    lifetime_from_tdflim,
     phasor_from_ifli,
     signal_from_czi,
     signal_from_flif,
@@ -18,6 +19,7 @@ from phasorpy.io import (
     signal_from_pqbin,
     signal_from_ptu,
     signal_from_sdt,
+    signal_from_tdflim,
 )
 
 
@@ -224,6 +226,53 @@ def test_phasor_from_ifli():
     filename = fetch('simfcs.r64')
     with pytest.raises(lfdfiles.LfdFileError):
         phasor_from_ifli(filename)
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_signal_from_tdflim():
+    """Test read ISS Vista TDFLIM file."""
+    filename = private_file('version1.iss-tdflim')
+    signal = signal_from_tdflim(filename, channel=None)
+    assert signal.values.sum(dtype=numpy.uint64) == 1098769946
+    assert signal.dtype == numpy.uint16
+    assert signal.shape == (2, 128, 128, 1024)
+    assert signal.dims == ('C', 'Y', 'X', 'H')
+    assert_almost_equal(
+        signal.coords['H'].data[[1, -1]], [0.012215228, 12.496178]
+    )
+    assert pytest.approx(signal.attrs['frequency']) == 79.946319
+
+    signal = signal_from_tdflim(filename)
+    assert signal.values.sum(dtype=numpy.uint64) == 694177148
+    assert signal.shape == (128, 128, 1024)
+    assert signal.dims == ('Y', 'X', 'H')
+
+    with pytest.raises(lfdfiles.LfdFileError):
+        signal_from_tdflim(fetch('flimfast.flif'))
+
+
+@pytest.mark.skipif(SKIP_PRIVATE, reason='file is private')
+def test_lifetime_from_tdflim():
+    """Test read ISS Vista TDFLIM file."""
+    filename = private_file('version2.iss-tdflim')
+    lifetime = lifetime_from_tdflim(filename, channel=None)
+    assert lifetime.values.mean() == pytest.approx(3.0074844)
+    assert lifetime.dtype == numpy.float32
+    assert lifetime.shape == (128, 128)
+    assert lifetime.dims == ('Y', 'X')
+    assert lifetime.attrs['frequency'] == 20.0
+    assert_almost_equal(
+        lifetime.coords['X'].data[[1, -1]], [-3.8046875, 20.8046875]
+    )
+
+    lifetime = lifetime_from_tdflim(filename)
+    assert lifetime.values.mean() == pytest.approx(3.0074844)
+    assert lifetime.dtype == numpy.float32
+    assert lifetime.shape == (128, 128)
+    assert lifetime.dims == ('Y', 'X')
+
+    with pytest.raises(ValueError):
+        lifetime_from_tdflim(private_file('version1.iss-tdflim'))
 
 
 @pytest.mark.skipif(SKIP_FETCH, reason='fetch is disabled')

--- a/tutorials/api/phasorpy_io.py
+++ b/tutorials/api/phasorpy_io.py
@@ -740,6 +740,7 @@ with TemporaryDirectory() as tmpdir:
 #
 # PhasorPy supports reading time-resolved signals from additional file formats:
 # :py:func:`~phasorpy.io.signal_from_pqbin` (PicoQuant BIN),
+# :py:func:`~phasorpy.io.signal_from_tdflim` (ISS TDFLIM),
 # :py:func:`~phasorpy.io.signal_from_imspector_tiff` (ImSpector FLIM TIFF),
 # and :py:func:`~phasorpy.io.signal_from_flif` (FlimFast FLIF).
 #


### PR DESCRIPTION
## Description

Add `signal_from_tdflim` and `lifetime_from_tdflim` functions to read TCSPC histogram and lifetime images from ISS Vista TDFLIM files (`.iss-tdflim`) via the `lfdfiles >= 2026.6.24` library. No public data files are available. Tests are using private files.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code and documentation can be distributed under the [MIT License](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
