### PR TITLE
Upgrade ruff and fix lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         args: [--max-line-length=79]
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.9.5
+    rev: v3.9.6
     hooks:
       - id: prettier
         args: [--end-of-line=auto]
@@ -103,7 +103,7 @@ repos:
   # when running with --fix place ruff lint hook
   # before ruff-format, black, isort, etc
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.22
+    rev: v0.16.0
     hooks:
       - id: ruff-check
   #     args: [--fix --show-fixes]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Sphinx build configuration file.
 
 https://www.sphinx-doc.org/en/master/usage/configuration.html
@@ -231,8 +235,8 @@ def linkcode_resolve(domain: str, info: dict[str, str]) -> str | None:
         except AttributeError:
             return None
 
-    if inspect.isfunction(obj):
-        obj = inspect.unwrap(obj)
+    if inspect.isfunction(obj):  # type: ignore[unreachable]
+        obj = inspect.unwrap(obj)  # type: ignore[unreachable]
     try:
         fn = inspect.getsourcefile(obj)
     except TypeError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,9 +262,9 @@ typing-modules = ["_typing"]
 "__init__.py" = ["F401", "F403"]
 "conftest.py" = ["ARG001"]
 "setup.py" = ["T201"]
-"tests/*" = ["INP001", "PT011", "SLF001", "TC001"]
+"tests/*" = ["INP001", "PT011", "SLF001", "TC001", "PLR0917"]
 "tools/*" = ["ANN", "INP001", "T201"]
-"tutorials/*" = ["ANN", "D", "E402", "INP001", "T201", "S101", "ERA001"]
+"tutorials/*" = ["ANN", "D", "E402", "INP001", "T201", "S101", "ERA001", "PLR0917"]
 "docs/conf.py" = ["A001", "ANN204", "D102", "E402", "INP001", "RUF012"]
 
 [tool.ruff.format]
@@ -272,6 +272,9 @@ quote-style = "single"
 
 [tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
+
+[tool.ruff.lint.flake8-copyright]
+notice-rgx = "(#\\s*Copyright\\s*\\(c\\)\\s*PhasorPy\\s*Contributors)"
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
@@ -345,6 +348,8 @@ warn_unreachable = true
 module = [
     "_conftest",
     "phasorpy._phasorpy",
+    "setuptools.*",
+    "sphinx_gallery.*",
     "pooch.*",
     "scipy.*",
     "mkl_fft.*",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPy package Setuptools script."""
 
 # project metadata are defined in pyproject.toml

--- a/src/phasorpy/__init__.py
+++ b/src/phasorpy/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPy package."""
 
 from __future__ import annotations

--- a/src/phasorpy/__main__.py
+++ b/src/phasorpy/__main__.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPy package command-line interface."""
 
 import sys

--- a/src/phasorpy/_phasorpy.pyx
+++ b/src/phasorpy/_phasorpy.pyx
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 # distutils: language = c
 # cython: boundscheck = False
 # cython: wraparound = False

--- a/src/phasorpy/_typing.py
+++ b/src/phasorpy/_typing.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Type annotations.
 
 This module should only be imported when type-checking, for example::

--- a/src/phasorpy/_utils.py
+++ b/src/phasorpy/_utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Private auxiliary and convenience functions.
 
 .. note::

--- a/src/phasorpy/cli.py
+++ b/src/phasorpy/cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPy package command-line interface.
 
 Invoke the command-line application with::

--- a/src/phasorpy/cluster.py
+++ b/src/phasorpy/cluster.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Cluster phasor coordinates.
 
 The ``phasorpy.cluster`` module provides functions to:

--- a/src/phasorpy/color.py
+++ b/src/phasorpy/color.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Color palettes and color manipulation utilities.
 
 The ``phasorpy.color`` module provides color palettes and functions to

--- a/src/phasorpy/component.py
+++ b/src/phasorpy/component.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Analyze components in phasor coordinates.
 
 The ``phasorpy.component`` module provides functions to:
@@ -703,7 +707,7 @@ def phasor_component_concentration(
 ) -> tuple[NDArray[Any], NDArray[Any]]: ...
 
 
-def phasor_component_concentration(
+def phasor_component_concentration(  # noqa: PLR0917
     mean: ArrayLike,
     real: ArrayLike,
     imag: ArrayLike,

--- a/src/phasorpy/conftest.py
+++ b/src/phasorpy/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Pytest configuration."""
 
 from __future__ import annotations

--- a/src/phasorpy/cursor.py
+++ b/src/phasorpy/cursor.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Select regions of interest (cursors) from phasor coordinates.
 
 The ``phasorpy.cursor`` module provides functions to:
@@ -277,7 +281,7 @@ def mask_from_elliptic_cursor(
     return mask.astype(numpy.bool_)  # type: ignore[no-any-return]
 
 
-def mask_from_polar_cursor(
+def mask_from_polar_cursor(  # noqa: PLR0917
     real: ArrayLike,
     imag: ArrayLike,
     phase_min: ArrayLike,

--- a/src/phasorpy/datasets.py
+++ b/src/phasorpy/datasets.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Manage sample data files for testing and tutorials.
 
 The ``phasorpy.datasets`` module provides a :py:func:`fetch` function to

--- a/src/phasorpy/experimental.py
+++ b/src/phasorpy/experimental.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Experimental functions.
 
 The ``phasorpy.experimental`` module provides functions related to phasor

--- a/src/phasorpy/filter.py
+++ b/src/phasorpy/filter.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Filter signals and phasor coordinates.
 
 The ``phasorpy.filter`` module provides functions to filter:
@@ -1517,7 +1521,7 @@ def signal_filter_ncpca(
     return signal
 
 
-def _gaussian_filter(
+def _gaussian_filter(  # noqa: PLR0917
     data: NDArray[Any],
     kernel: NDArray[Any],
     axes: tuple[int, ...],

--- a/src/phasorpy/io/__init__.py
+++ b/src/phasorpy/io/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read and write time-resolved and hyperspectral image file formats.
 
 The ``phasorpy.io`` module provides functions to:

--- a/src/phasorpy/io/_flimlabs.py
+++ b/src/phasorpy/io/_flimlabs.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read FLIM LABS file formats."""
 
 from __future__ import annotations

--- a/src/phasorpy/io/_leica.py
+++ b/src/phasorpy/io/_leica.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read Leica image file formats."""
 
 from __future__ import annotations

--- a/src/phasorpy/io/_ometiff.py
+++ b/src/phasorpy/io/_ometiff.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read and write OME-TIFF file formats."""
 
 from __future__ import annotations

--- a/src/phasorpy/io/_other.py
+++ b/src/phasorpy/io/_other.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read other file formats."""
 
 from __future__ import annotations

--- a/src/phasorpy/io/_simfcs.py
+++ b/src/phasorpy/io/_simfcs.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Read and write SimFCS file formats."""
 
 from __future__ import annotations

--- a/src/phasorpy/lifetime.py
+++ b/src/phasorpy/lifetime.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Process phasor coordinates of luminescence lifetimes.
 
 The ``phasorpy.lifetime`` module provides functions to:
@@ -635,9 +639,9 @@ def phasor_calibrate(
     reference_real: ArrayLike,
     reference_imag: ArrayLike,
     /,
+    *,
     frequency: ArrayLike,
     lifetime: ArrayLike,
-    *,
     harmonic: int | Sequence[int] | Literal['all'] | str | None = None,
     skip_axis: int | Sequence[int] | None = None,
     fraction: ArrayLike | None = None,

--- a/src/phasorpy/phasor.py
+++ b/src/phasorpy/phasor.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Process phasor coordinates.
 
 The ``phasorpy.phasor`` module provides fundamental functions to:
@@ -788,13 +792,14 @@ def phasor_normalize(
     return mean, real, imag
 
 
-def phasor_combine(
+def phasor_combine(  # noqa: PLR0917
     int0: ArrayLike,
     real0: ArrayLike,
     imag0: ArrayLike,
     int1: ArrayLike,
     real1: ArrayLike,
     imag1: ArrayLike,
+    /,
     fraction0: ArrayLike,
     fraction1: ArrayLike | None = None,
     **kwargs: Any,

--- a/src/phasorpy/plot/__init__.py
+++ b/src/phasorpy/plot/__init__.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Plot phasor coordinates and related data.
 
 The ``phasorpy.plot`` module provides functions and classes to visualize

--- a/src/phasorpy/plot/_functions.py
+++ b/src/phasorpy/plot/_functions.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Higher-level plot functions."""
 
 from __future__ import annotations

--- a/src/phasorpy/plot/_lifetime_plots.py
+++ b/src/phasorpy/plot/_lifetime_plots.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """LifetimePlots class."""
 
 from __future__ import annotations

--- a/src/phasorpy/plot/_phasorplot.py
+++ b/src/phasorpy/plot/_phasorplot.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPlot class."""
 
 from __future__ import annotations
@@ -1085,6 +1089,7 @@ class PhasorPlot:
 
     def polar_grid(
         self,
+        *,
         radii: int | Sequence[float] | None = None,
         angles: int | Sequence[float] | None = None,
         samples: int | None = None,

--- a/src/phasorpy/plot/_phasorplot_fret.py
+++ b/src/phasorpy/plot/_phasorplot_fret.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """PhasorPlotFret class."""
 
 from __future__ import annotations

--- a/src/phasorpy/plot/_spectral_plots.py
+++ b/src/phasorpy/plot/_spectral_plots.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """SpectralPlots class."""
 
 from __future__ import annotations
@@ -518,7 +522,7 @@ class SpectralPlots:
                 slider.on_changed(self._on_changed)
                 self._vib_frequency_sliders.append(slider)
 
-    def _calculate(
+    def _calculate(  # noqa: PLR0917
         self,
         wl_min: float,
         wl_max: float,

--- a/src/phasorpy/utils.py
+++ b/src/phasorpy/utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Utility functions.
 
 The ``phasorpy.utils`` module provides auxiliary and convenience functions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Pytest configuration."""
 
 import os

--- a/tests/io/_conftest.py
+++ b/tests/io/_conftest.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test configuration for phasorpy.io module."""
 
 from __future__ import annotations

--- a/tests/io/test_flimlabs.py
+++ b/tests/io/test_flimlabs.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test FLIM LABS file reader functions."""
 
 from __future__ import annotations

--- a/tests/io/test_leica.py
+++ b/tests/io/test_leica.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test Leica image file reader functions."""
 
 import math

--- a/tests/io/test_ometiff.py
+++ b/tests/io/test_ometiff.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test OME-TIFF file reader and writer functions."""
 
 import numpy

--- a/tests/io/test_other.py
+++ b/tests/io/test_other.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test other file reader functions."""
 
 import builtins

--- a/tests/io/test_simfcs.py
+++ b/tests/io/test_simfcs.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test SimFCS file reader functions."""
 
 import os

--- a/tests/plot/test_functions.py
+++ b/tests/plot/test_functions.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test higher-level plot functions."""
 
 import math

--- a/tests/plot/test_lifetime_plots.py
+++ b/tests/plot/test_lifetime_plots.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test LifetimePlots class."""
 
 import pytest

--- a/tests/plot/test_phasorplot.py
+++ b/tests/plot/test_phasorplot.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test PhasorPlot class."""
 
 import io

--- a/tests/plot/test_phasorplot_fret.py
+++ b/tests/plot/test_phasorplot_fret.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test PhasorPlotFret class."""
 
 from matplotlib import pyplot

--- a/tests/plot/test_spectral_plots.py
+++ b/tests/plot/test_spectral_plots.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test SpectralPlots class."""
 
 import numpy

--- a/tests/test__phasorpy.py
+++ b/tests/test__phasorpy.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy._phasorpy module."""
 
 import math

--- a/tests/test__typing.py
+++ b/tests/test__typing.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy._typing module."""
 
 

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy._utils module."""
 
 import numpy

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy command-line interface."""
 
 import os

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.cluster module."""
 
 import numpy

--- a/tests/test_color.py
+++ b/tests/test_color.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.color module."""
 
 import numpy

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.component module."""
 
 from math import nan

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.cursor module."""
 
 import numpy

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.datasets module."""
 
 import os

--- a/tests/test_experimental.py
+++ b/tests/test_experimental.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.experimental module."""
 
 import numpy

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.filter module."""
 
 import os

--- a/tests/test_lifetime.py
+++ b/tests/test_lifetime.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.lifetime module."""
 
 import copy

--- a/tests/test_nan.py
+++ b/tests/test_nan.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test handling NaN coordinates."""
 
 import warnings
@@ -133,7 +137,13 @@ def test_phasor_calibrate_nan(*, nan_safe: bool) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter('error')
         phasor = phasor_calibrate(
-            *VALUES_WITH_NAN[1:], 1.0, 0.0, 1.0, 80, 4.2, nan_safe=nan_safe
+            *VALUES_WITH_NAN[1:],
+            1.0,
+            0.0,
+            1.0,
+            frequency=80.0,
+            lifetime=4.2,
+            nan_safe=nan_safe,
         )
     assert_allclose(
         phasor, [[0.28506, nan, 0.05701], [0.10181, nan, 0.02036]], atol=1e-3

--- a/tests/test_phasor.py
+++ b/tests/test_phasor.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.phasor module."""
 
 import copy

--- a/tests/test_phasorpy.py
+++ b/tests/test_phasorpy.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy module."""
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Test the phasorpy.utils module."""
 
 import os

--- a/tools/sha256.py
+++ b/tools/sha256.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """Print SHA256 hashes of files to be used in phasorpy.datasets.
 
 ::

--- a/tutorials/api/phasorpy_component.py
+++ b/tutorials/api/phasorpy_component.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Multi-component analysis
 ========================

--- a/tutorials/api/phasorpy_cursor.py
+++ b/tutorials/api/phasorpy_cursor.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Cursors
 =======

--- a/tutorials/api/phasorpy_filter.py
+++ b/tutorials/api/phasorpy_filter.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Filter phasor coordinates
 =========================

--- a/tutorials/api/phasorpy_fret.py
+++ b/tutorials/api/phasorpy_fret.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Förster resonance energy transfer
 =================================

--- a/tutorials/api/phasorpy_io.py
+++ b/tutorials/api/phasorpy_io.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 File input/output
 =================
@@ -440,8 +444,8 @@ real, imag = phasor_calibrate(
     real,
     imag,
     *phasor_from_signal(reference_signal),
-    frequency,
-    reference_lifetime,
+    frequency=frequency,
+    lifetime=reference_lifetime,
 )
 
 plot_phasor(
@@ -500,8 +504,8 @@ real, imag = phasor_calibrate(
     reference_mean,
     reference_real,
     reference_imag,
-    frequency,
-    reference_lifetime,
+    frequency=frequency,
+    lifetime=reference_lifetime,
     harmonic=harmonic,
 )
 

--- a/tutorials/api/phasorpy_lifetime_to_signal.py
+++ b/tutorials/api/phasorpy_lifetime_to_signal.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Signal synthesis from lifetimes
 ===============================
@@ -71,8 +75,8 @@ def verify_signal(reference_signal, fractions=None):
         phasor_calibrate(
             *phasor_from_signal(signal)[1:],
             *phasor_from_signal(reference_signal),
-            frequency,
-            reference_lifetime,
+            frequency=frequency,
+            lifetime=reference_lifetime,
         ),
         phasor_from_lifetime(frequency, lifetimes, fractions),
         atol=1e-3,

--- a/tutorials/api/phasorpy_multi_harmonic.py
+++ b/tutorials/api/phasorpy_multi_harmonic.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Multi-harmonic phasor coordinates
 =================================

--- a/tutorials/api/phasorpy_pca.py
+++ b/tutorials/api/phasorpy_pca.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Principal component analysis
 ============================

--- a/tutorials/api/phasorpy_phasor_from_lifetime.py
+++ b/tutorials/api/phasorpy_phasor_from_lifetime.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Phasor coordinates from lifetimes
 =================================

--- a/tutorials/api/phasorpy_phasorplot.py
+++ b/tutorials/api/phasorpy_phasorplot.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Phasor plot
 ===========

--- a/tutorials/applications/phasorpy_component_fit.py
+++ b/tutorials/applications/phasorpy_component_fit.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Spectral unmixing
 =================

--- a/tutorials/applications/phasorpy_fret_efficiency.py
+++ b/tutorials/applications/phasorpy_fret_efficiency.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 FRET efficiency image
 =====================

--- a/tutorials/applications/phasorpy_multidimensional.py
+++ b/tutorials/applications/phasorpy_multidimensional.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Multidimensional phasor approach
 ================================

--- a/tutorials/applications/phasorpy_nadh_concentration.py
+++ b/tutorials/applications/phasorpy_nadh_concentration.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Absolute NADH concentration
 ============================

--- a/tutorials/applications/phasorpy_nadh_fraction.py
+++ b/tutorials/applications/phasorpy_nadh_fraction.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Bound NADH fraction
 ===================

--- a/tutorials/misc/phasorpy_apps.py
+++ b/tutorials/misc/phasorpy_apps.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Interactive applications
 ========================

--- a/tutorials/misc/phasorpy_logo.py
+++ b/tutorials/misc/phasorpy_logo.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 PhasorPy logo
 =============

--- a/tutorials/misc/phasorpy_phasor_from_signal.py
+++ b/tutorials/misc/phasorpy_phasor_from_signal.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Benchmark phasor_from_signal
 ============================

--- a/tutorials/phasorpy_introduction.py
+++ b/tutorials/phasorpy_introduction.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 Introduction to PhasorPy
 ========================

--- a/tutorials/phasorpy_lfd_workshop.py
+++ b/tutorials/phasorpy_lfd_workshop.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 """
 LFD Workshop FLIM tutorial
 ==========================

--- a/tutorials/phasorpy_lifetime_geometry.py
+++ b/tutorials/phasorpy_lifetime_geometry.py
@@ -1,3 +1,7 @@
+# Copyright (c) PhasorPy Contributors
+# SPDX-License-Identifier: MIT
+# See LICENSE.txt file in the project root for details.
+
 r"""
 Geometric interpretation of lifetimes
 =====================================


### PR DESCRIPTION
## Description

This PR upgrades to [ruff v0.16.0](https://astral.sh/blog/ruff-v0.16.0) (which enables many more rules) and fixes two kind of errors:

**1. [missing-copyright-notice](https://docs.astral.sh/ruff/rules/missing-copyright-notice/)**

Fixed by adding the following header to all source files (code, tests, tutorials, setup.py, etc):
```
# Copyright (c) PhasorPy Contributors
# SPDX-License-Identifier: MIT
# See LICENSE.txt file in the project root for details.
```

**2. [too-many-positional-arguments](https://docs.astral.sh/ruff/rules/too-many-positional-arguments/)**

Fixed by either exempting (tests, tutorials, private functions, `phasor_combine`, `phasor_component_concentration`, and `mask_from_polar_cursor`) or changing the function signature (`phasor_calibrate` and `PhasorPlot.polar_grid`).

Most notably, the `frequency` and `lifetime` parameters of `phasor_calibrate` are now keyword-only, a breaking change.

## Checklist

- [ ] The pull request title and description are concise.
- [ ] Related issues are linked in the description.
- [ ] New dependencies are explained.
- [ ] The source code is understood by the contributor and can be explained.
- [ ] If AI was used, the tools, usage, and AI-generated code/text are disclosed.
- [ ] The source code and documentation can be distributed under the [MIT License](https://www.phasorpy.org/docs/stable/license/).
- [ ] The source code adheres to [code standards](https://www.phasorpy.org/docs/stable/contributing/#code-standards).
- [ ] New classes, functions, and features are thoroughly [tested](https://www.phasorpy.org/docs/stable/contributing/#tests).
- [ ] New user-facing classes, functions, and features are [documented](https://www.phasorpy.org/docs/stable/contributing/#documentation).
- [ ] New features are covered in tutorials.
- [ ] No files other than source code, documentation, and project settings are added to the repository.
